### PR TITLE
lifecycle config changes and other minor fixes

### DIFF
--- a/rgw/v2/lib/resource_op.py
+++ b/rgw/v2/lib/resource_op.py
@@ -102,7 +102,7 @@ class Config(object):
         self.sharding_type = self.doc['config'].get('sharding_type')
         self.split_size = self.doc['config'].get('split_size', 5)
         self.test_ops = self.doc['config'].get('test_ops')
-        self.lifecycle_ops = self.doc['config'].get('lifecycle_ops')
+        self.lifecycle_conf = self.doc['config'].get('lifecycle_conf')
         self.delete_marker_ops = self.doc['config'].get('delete_marker_ops')
         self.mapped_sizes = self.doc['config'].get('mapped_sizes')
         self.bucket_policy_op = self.doc['config'].get('bucket_policy_op')

--- a/rgw/v2/tests/s3_swift/configs/test_lc_date.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_date.yaml
@@ -1,7 +1,5 @@
 # script: test_bucket_lifecycle_object_expiration.py
 config:
- user_count: 1
- bucket_count: 1
  objects_count: 1
  objects_size_range:
   min: 5
@@ -11,7 +9,7 @@ config:
       create_object: true
       version_count: 3
       delete_marker: false
- lifecycle_ops:
+ lifecycle_conf:
       - ID: LC_Rule_1
         Filter:
           Prefix: key1

--- a/rgw/v2/tests/s3_swift/configs/test_lc_multiple_rule_prefix_current_days.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_multiple_rule_prefix_current_days.yaml
@@ -1,7 +1,5 @@
 # script: test_bucket_lifecycle_object_expiration.py
 config:
- user_count: 1
- bucket_count: 1
  objects_count: 2
  objects_size_range:
   min: 5
@@ -11,7 +9,7 @@ config:
       create_object: true
       version_count: 3
       delete_marker: false
- lifecycle_ops:
+ lifecycle_conf:
       - ID: LC_Rule_1
         Filter:
           Prefix: key1

--- a/rgw/v2/tests/s3_swift/configs/test_lc_rule_delete_marker.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_rule_delete_marker.yaml
@@ -1,7 +1,5 @@
 # test_bucket_lifecycle_object_expiration.py
 config:
- user_count: 1
- bucket_count: 1
  objects_count: 1
  objects_size_range:
   min: 5
@@ -11,7 +9,7 @@ config:
       create_object: true
       version_count: 2
       delete_marker: true
- lifecycle_ops:
+ lifecycle_conf:
       - ID: LC_Rule_1
         Filter:
           Prefix: key2

--- a/rgw/v2/tests/s3_swift/configs/test_lc_rule_prefix_and_tag.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_rule_prefix_and_tag.yaml
@@ -1,7 +1,5 @@
 #test_bucket_lifecycle_object_expiration.py
 config:
- user_count: 1
- bucket_count: 1
  objects_count: 2
  objects_size_range:
   min: 5
@@ -11,7 +9,7 @@ config:
       create_object: true
       delete_marker: false
       version_count: 0
- lifecycle_ops:
+ lifecycle_conf:
     - ID: rule1
       Filter:
         And:

--- a/rgw/v2/tests/s3_swift/configs/test_lc_rule_prefix_non_current_days.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_rule_prefix_non_current_days.yaml
@@ -1,7 +1,5 @@
 # script: test_bucket_lifecycle_object_expiration.py
 config:
- user_count: 1
- bucket_count: 1
  objects_count: 1
  objects_size_range:
   min: 5
@@ -11,7 +9,7 @@ config:
       create_object: true
       version_count: 3
       delete_marker: false
- lifecycle_ops:
+ lifecycle_conf:
       - ID: LC_Rule_2
         Filter:
           Prefix: key1

--- a/rgw/v2/tests/s3_swift/resuables.py
+++ b/rgw/v2/tests/s3_swift/resuables.py
@@ -306,11 +306,10 @@ def link_chown_to_nontenanted(new_uid, bucket, tenant):
     return
 
 
-def delete_bucket_object(bucket):
+def delete_objects(bucket):
     """
-    deletes all objects in bucket and bucket too
-    :param bucket: s3Bucket object
-
+    deletes the objects in a given bucket
+    :param bucket: S3Bucket object
     """
     log.info('listing all objects in bucket: %s' % bucket.name)
     objects = s3lib.resource_op({'obj': bucket,
@@ -338,6 +337,14 @@ def delete_bucket_object(bucket):
             raise TestExecError("objects deletion failed")
     else:
         raise TestExecError("objects deletion failed")
+
+
+def delete_bucket(bucket):
+    """
+    deletes a given bucket
+    :param bucket: s3Bucket object
+    """
+
     log.info('deleting bucket: %s' % bucket.name)
     # bucket_deleted_status = s3_ops.resource_op(bucket, 'delete')
     bucket_deleted_status = s3lib.resource_op({'obj': bucket,

--- a/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
+++ b/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
@@ -197,7 +197,8 @@ def test_exec(config):
                         cmd = 'radosgw-admin bucket stats --bucket=%s' % bucket.name
                         out = utils.exec_shell_cmd(cmd)
                     if config.test_ops['delete_bucket_object'] is True:
-                        resuables.delete_bucket_object(bucket)
+                        resuables.delete_objects(bucket)
+                        resuables.delete_bucket(bucket)
         # disable compression after test
         if config.test_ops['compression']['enable'] is True:
             log.info('disable compression')

--- a/rgw/v2/tests/s3_swift/test_bucket_lifecycle_object_expiration.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_lifecycle_object_expiration.py
@@ -71,7 +71,9 @@ def test_exec(config):
         raise TestExecError("RGW service restart failed")
     else:
         log.info('RGW service restarted')
-    
+
+    config.user_count = 1
+    config.bucket_count = 1
     # create user
     user_info = s3lib.create_users(config.user_count)
     user_info = user_info[0]
@@ -86,7 +88,7 @@ def test_exec(config):
     prefix = list(map(lambda x: x,
                       [rule['Filter'].get('Prefix') or
                        rule['Filter']['And'].get('Prefix')
-                       for rule in config.lifecycle_ops]))
+                       for rule in config.lifecycle_conf]))
     prefix = prefix if prefix else ['dummy1']
     if config.test_ops['enable_versioning'] is True:
         resuables.enable_versioning(bucket, rgw_conn, user_info, write_bucket_io_info)
@@ -108,7 +110,7 @@ def test_exec(config):
                     log.info('s3 objects to create: %s' % config.objects_count)
                     resuables.upload_object(s3_object_name, bucket, TEST_DATA_PATH, config, user_info)
 
-        life_cycle_rule = {"Rules": config.lifecycle_ops}
+        life_cycle_rule = {"Rules": config.lifecycle_conf}
         resuables.put_get_bucket_lifecycle_test(bucket, rgw_conn, rgw_conn2, life_cycle_rule)
         lc_ops.validate_prefix_rule(bucket, config)
         if config.test_ops['delete_marker'] is True:
@@ -123,7 +125,7 @@ def test_exec(config):
                 s3_object_name = key + '.' + bucket.name + '.' + str(oc)
                 obj_list.append(s3_object_name)
                 resuables.upload_object_with_tagging(s3_object_name, bucket, TEST_DATA_PATH, config, user_info, obj_tag)
-        life_cycle_rule = {"Rules": config.lifecycle_ops}
+        life_cycle_rule = {"Rules": config.lifecycle_conf}
         resuables.put_get_bucket_lifecycle_test(bucket, rgw_conn, rgw_conn2, life_cycle_rule)
         lc_ops.validate_and_rule(bucket, config) 
     resuables.remove_user(user_info)

--- a/rgw/v2/tests/s3_swift/test_versioning_with_objects.py
+++ b/rgw/v2/tests/s3_swift/test_versioning_with_objects.py
@@ -32,6 +32,7 @@ from v2.lib.s3.auth import Auth
 import v2.utils.utils as utils
 from v2.utils.log import configure_logging
 from v2.utils.utils import HttpResponseParser
+from v2.tests.s3_swift import resuables
 import traceback
 import argparse
 import v2.lib.manage_data as manage_data
@@ -409,6 +410,8 @@ def test_exec(config):
                     log.info('s3_object_uploaded_md5: %s' % non_version_data_info['md5'])
                     if config.local_file_delete is True:
                         utils.exec_shell_cmd('sudo rm -rf %s' % s3_object_path)
+            if config.test_ops.get('delete_bucket') is True:
+                resuables.delete_bucket(bucket)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
lifecycle config changes: 

- changed the config parameter from lifecycle_ops to lifecycle_conf
- split delete_bucket_object function to delete_object and delete_bucket
- delete bucket option added versioning tests
   