### PR TITLE
verify default num_shards of 11 on bucket creation

### DIFF
--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -514,8 +514,8 @@ def check_default_num_shards(bucket):
     :param bucket: s3Bucket
     """
     # verify the num_shards. The default bucket-index shards increased to 11. Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1813349
-    ceph_version=utils.get_ceph_version()
-    if ceph_version == 'nautilus':
+    ceph_version_id, ceph_version_name = utils.get_ceph_version()
+    if ceph_version_name == 'nautilus':
         bucket_stats = utils.exec_shell_cmd("radosgw-admin bucket stats --bucket=%s" % bucket)
         bucket_stats_json = json.loads(bucket_stats)
         bkt_num_shards = bucket_stats_json['num_shards']

--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -36,6 +36,7 @@ def create_bucket(bucket_name, rgw, user_info):
         response = HttpResponseParser(created)
         if response.status_code == 200:
             log.info('bucket created')
+            check_default_num_shards(bucket_name)
         else:
             raise TestExecError("bucket creation failed")
     else:

--- a/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
+++ b/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
@@ -124,7 +124,6 @@ def test_exec(config):
                 bucket_name_to_create = utils.gen_bucket_name_from_userid(each_user['user_id'], rand_no=bc)
                 log.info('creating bucket with name: %s' % bucket_name_to_create)
                 bucket = reusable.create_bucket(bucket_name_to_create, rgw_conn, each_user)
-                reusable.check_default_num_shards(bucket_name_to_create)
                 if config.test_ops['create_object'] is True:
                     # uploading data
                     log.info('s3 objects to create: %s' % config.objects_count)

--- a/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
+++ b/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
@@ -124,6 +124,7 @@ def test_exec(config):
                 bucket_name_to_create = utils.gen_bucket_name_from_userid(each_user['user_id'], rand_no=bc)
                 log.info('creating bucket with name: %s' % bucket_name_to_create)
                 bucket = reusable.create_bucket(bucket_name_to_create, rgw_conn, each_user)
+                reusable.check_default_num_shards(bucket_name_to_create)
                 if config.test_ops['create_object'] is True:
                     # uploading data
                     log.info('s3 objects to create: %s' % config.objects_count)

--- a/rgw/v2/utils/utils.py
+++ b/rgw/v2/utils/utils.py
@@ -268,7 +268,7 @@ def get_ceph_version():
     get the current ceph version
     """
     log.info('get ceph version')
-    ceph_version= exec_shell_cmd('sudo ceph version')
-    version_info = ceph_version.split()[4]
-    return (version_info)
+    ceph_version=exec_shell_cmd('sudo ceph version')
+    version_id, version_name = ceph_version.split()[2], ceph_version.split()[4]
+    return version_id, version_name
 

--- a/rgw/v2/utils/utils.py
+++ b/rgw/v2/utils/utils.py
@@ -263,3 +263,12 @@ def get_hostname_ip():
 def cmp(val1, val2):
     return (val1 > val2) - (val1 < val2)
 
+def get_ceph_version():
+    """
+    get the current ceph version
+    """
+    log.info('get ceph version')
+    ceph_version= exec_shell_cmd('sudo ceph version')
+    version_info = ceph_version.split()[4]
+    return (version_info)
+


### PR DESCRIPTION
 From Ceph Nautilus 4.1 onwards the default num_shards is 11 on a newly created bucket.