### PR TITLE
Updating test_Mbucket_with_Nobjects.py with s3-obj-compression fixes and bug-1825302

### DIFF
--- a/rgw/v2/lib/rgw_config_opts.py
+++ b/rgw/v2/lib/rgw_config_opts.py
@@ -16,6 +16,7 @@ class ConfigOpts(object):
     rgw_max_objs_per_shard = 'rgw_max_objs_per_shard'
     rgw_lc_debug_interval = 'rgw_lc_debug_interval'
     rgw_lc_max_worker = 'rgw_lc_max_worker'
+    debug_rgw = 'debug_rgw'
     rgw_crypt_require_ssl = 'rgw_crypt_require_ssl'
     bluestore_block_size = 'bluestore_block_size'
     rgw_gc_max_queue_size = 'rgw_gc_max_queue_size'


### PR DESCRIPTION
Updating test_Mbucket_with_Nobjects.py with below changes:

1. Fixing the s3-object compression in luminous
2. Addressing Bug-1825302 (delete_bucket ops with debug_rgw set to value greater than 10) 

Logs :
1. s3-object compression fixes

luminous ->> http://pastebin.test.redhat.com/911453
nautilus (4.2) 0>> http://pastebin.test.redhat.com/911454

2. Addressing Bug-1825302 (delete_bucket ops with debug_rgw set to value greater than 10) :
RHCS-4.2 logs - http://pastebin.test.redhat.com/911522


Signed-off-by: viduship <vimisra@redhat.com>