### PR TITLE
Using an existing RGW user to run the scripts

### DIFF
--- a/rgw/v2/lib/resource_op.py
+++ b/rgw/v2/lib/resource_op.py
@@ -59,7 +59,7 @@ def resource_op(exec_info):
         return False
 
 
-def create_users(no_of_users_to_create, cluster_name='ceph'):
+def create_users(no_of_users_to_create, cluster_name='ceph', users_info_list=None):
     """
         This function is to create n users on the cluster 
 
@@ -72,17 +72,24 @@ def create_users(no_of_users_to_create, cluster_name='ceph'):
     """
     admin_ops = UserMgmt()
     all_users_details = []
-    for i in range(no_of_users_to_create):
-        user_details = admin_ops.create_admin_user(
-            user_id=names.get_first_name().lower() + random.choice(string.ascii_lowercase) + "." + str(
-                random.randint(1, 1000)),
-            displayname=names.get_full_name().lower(),
-            cluster_name=cluster_name)
-        all_users_details.append(user_details)
+    if users_info_list:
+        for each in users_info_list:
+            user_id = each['user_id'],
+            display_name = each['display_name']
+            cluster_name = cluster_name
+            user_details = admin_ops.create_admin_user(each['user_id'], display_name, cluster_name)
+            all_users_details.append(user_details)
+    else:
+        for i in range(no_of_users_to_create):
+            user_details = admin_ops.create_admin_user(
+                user_id=names.get_first_name().lower() + random.choice(string.ascii_lowercase) + "." + str(
+                    random.randint(1, 1000)),
+                displayname=names.get_full_name().lower(),
+                cluster_name=cluster_name)
+            all_users_details.append(user_details)
     return all_users_details
 
-
-def create_tenant_users(no_of_users_to_create, tenant_name, cluster_name='ceph'):
+def create_tenant_users(no_of_users_to_create, tenant_name, cluster_name='ceph', users_info_list=None):
     """
         This function is to create n users with tenant on the cluster 
 
@@ -95,16 +102,25 @@ def create_tenant_users(no_of_users_to_create, tenant_name, cluster_name='ceph')
     """
     admin_ops = UserMgmt()
     all_users_details = []
-    for i in range(no_of_users_to_create):
-        user_details = admin_ops.create_tenant_user(
-            user_id=names.get_first_name().lower() + random.choice(string.ascii_lowercase) + "." + str(
-                random.randint(1, 1000)),
-            displayname=names.get_full_name().lower(),
-            cluster_name=cluster_name,
-            tenant_name=tenant_name)
-        all_users_details.append(user_details)
+    if users_info_list:
+        for each in users_info_list:
+            user_id = each['user_id'],
+            display_name = each['display_name']
+            cluster_name = cluster_name
+            tenant_name = each['tenant']
+            user_details = admin_ops.create_tenant_user(tenant_name, each['user_id'], display_name, cluster_name)
+            all_users_details.append(user_details)
+    else:
+        for i in range(no_of_users_to_create):
+            user_details = admin_ops.create_tenant_user(
+                user_id=names.get_first_name().lower() + random.choice(string.ascii_lowercase) + "." + str(
+                    random.randint(1, 1000)),
+                displayname=names.get_full_name().lower(),
+                cluster_name=cluster_name,
+                tenant_name=tenant_name)
+            all_users_details.append(user_details)
     return all_users_details
-
+		
 
 class Config(object):
     def __init__(self, conf_file=None):
@@ -126,6 +142,8 @@ class Config(object):
         self.max_objects_per_shard = self.doc['config'].get('max_objects_per_shard')
         self.max_objects = None
         self.user_count = self.doc['config'].get('user_count')
+        self.user_create = self.doc['config'].get('user_create')
+        self.user_type = self.doc['config'].get('user_type')
         self.bucket_count = self.doc['config'].get('bucket_count')
         self.objects_count = self.doc['config'].get('objects_count')
         self.use_aws4 = self.doc['config'].get('use_aws4', None)

--- a/rgw/v2/tests/s3_swift/configs/test_Mbuckets.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_Mbuckets.yaml
@@ -2,6 +2,7 @@
 # script: test_Mbuckets_with_Nobjects.py
 config:
  user_count: 1
+ user_create: false
  bucket_count: 10
  objects_count: 0
  objects_size_range:

--- a/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects.yaml
@@ -2,6 +2,7 @@
 # script: test_Mbuckets_with_Nobjects.py
 config:
  user_count: 1
+ user_create: false
  bucket_count: 1
  objects_count: 2
  objects_size_range:

--- a/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_aws4.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_aws4.yaml
@@ -3,6 +3,7 @@
 config:
  use_aws4: true
  user_count: 1
+ user_create: false
  bucket_count: 1
  objects_count: 2
  objects_size_range:

--- a/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_compression.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_compression.yaml
@@ -2,6 +2,7 @@
 # script: test_Mbuckets_with_Nobjects.py
 config:
  user_count: 1
+ user_create: false
  bucket_count: 1
  objects_count: 2
  objects_size_range:

--- a/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_delete.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_delete.yaml
@@ -2,6 +2,7 @@
 # script: test_Mbuckets_with_Nobjects.py
 config:
  user_count: 1
+ user_create: false
  bucket_count: 2
  objects_count: 2
  objects_size_range:

--- a/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_download.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_download.yaml
@@ -2,6 +2,7 @@
 # script: test_Mbuckets_with_Nobjects.py
 config:
  user_count: 1
+ user_create: false
  bucket_count: 1
  objects_count: 2
  objects_size_range:

--- a/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_enc.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_enc.yaml
@@ -2,6 +2,7 @@
 # script: test_Mbuckets_with_Nobjects.py
 config:
  user_count: 1
+ user_create: false
  bucket_count: 1
  objects_count: 2
  objects_size_range:

--- a/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_multipart.yaml
@@ -2,6 +2,7 @@
 # script: test_Mbuckets_with_Nobjects.py
 config:
  user_count: 1
+ user_create: false
  bucket_count: 1
  objects_count: 2
  split_size: 100

--- a/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_sharding.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_sharding.yaml
@@ -2,6 +2,7 @@
 # script: test_Mbuckets_with_Nobjects.py
 config:
  user_count: 1
+ user_create: false
  bucket_count: 1
  objects_count: 1
  objects_size_range:

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_lifecycle_config_disable.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_lifecycle_config_disable.yaml
@@ -3,6 +3,7 @@
 config:
  user_count: 1
  bucket_count: 1
+ user_create: false
  objects_count: 2
  objects_size_range:
   min: 5

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_lifecycle_config_modify.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_lifecycle_config_modify.yaml
@@ -2,6 +2,7 @@
 # script: test_bucket_lifecycle_config_ops.py
 config:
  user_count: 1
+ user_create: false
  bucket_count: 1
  objects_count: 2
  objects_size_range:

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_lifecycle_config_read.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_lifecycle_config_read.yaml
@@ -2,6 +2,7 @@
 # script: test_bucket_lifecycle_config_ops.py
 config:
  user_count: 1
+ user_create: false
  bucket_count: 1
  objects_count: 2
  objects_size_range:

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_lifecycle_config_versioning.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_lifecycle_config_versioning.yaml
@@ -4,6 +4,7 @@ config:
  user_count: 1
  bucket_count: 1
  objects_count: 2
+ user_create: false
  objects_size_range:
   min: 5
   max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_policy_delete.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_policy_delete.yaml
@@ -3,4 +3,5 @@
 # TC 11213
 config:
  bucket_policy_op: delete
+ user_create: false
 

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_policy_modify.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_policy_modify.yaml
@@ -3,4 +3,5 @@
 # TC 11214
 config:
  bucket_policy_op: modify
+ user_create: false
 

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_policy_replace.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_policy_replace.yaml
@@ -3,4 +3,5 @@
 # TC 11215
 config:
  bucket_policy_op: replace
+ user_create: false
 

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_request_payer.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_request_payer.yaml
@@ -1,4 +1,5 @@
 # TC Ids - CEPH-10344, CEPH-10346, CEPH-10351
 config:
  user_count: 1
+ user_create: false
  bucket_count: 10

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_request_payer_download.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_request_payer_download.yaml
@@ -1,6 +1,7 @@
 # TC Ids - CEPH-10347
 config:
  user_count: 1
+ user_create: false
  bucket_count: 10
  objects_count: 10
  objects_size_range:

--- a/rgw/v2/tests/s3_swift/configs/test_byte_range.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_byte_range.yaml
@@ -3,6 +3,7 @@ config:
  user_count: 1
  bucket_count: 1
  objects_count: 1
+ user_create: false
  objects_size_range:
   min: 10
   max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_dynamic_resharding.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dynamic_resharding.yaml
@@ -1,5 +1,6 @@
 config:
  objects_count: 100
+ user_create: false
  objects_size_range:
   min: 15
   max: 20

--- a/rgw/v2/tests/s3_swift/configs/test_dynamic_resharding_with_version.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dynamic_resharding_with_version.yaml
@@ -1,6 +1,7 @@
 # test case id: CEPH-83571740
 config:
  objects_count: 100
+ user_create: false
  objects_size_range:
   min: 15
   max: 20

--- a/rgw/v2/tests/s3_swift/configs/test_gc_list.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_gc_list.yaml
@@ -2,6 +2,7 @@
 # script: test_Mbuckets_with_Nobjects.py
 config:
  user_count: 1
+ user_create: false
  bucket_count: 2
  objects_count: 10
  gc_verification: true

--- a/rgw/v2/tests/s3_swift/configs/test_gc_list_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_gc_list_multipart.yaml
@@ -2,6 +2,7 @@
 # script: test_Mbuckets_with_Nobjects.py
 config:
  user_count: 1
+ user_create: false
  bucket_count: 2
  objects_count: 5
  gc_verification: true

--- a/rgw/v2/tests/s3_swift/configs/test_lc_date.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_date.yaml
@@ -1,6 +1,9 @@
 # script: test_bucket_lifecycle_object_expiration.py
 config:
  objects_count: 1
+ bucket_count: 1
+ user_count: 1
+ user_create: false
  objects_size_range:
   min: 5
   max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_lc_multiple_rule_prefix_current_days.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_multiple_rule_prefix_current_days.yaml
@@ -1,6 +1,8 @@
 # script: test_bucket_lifecycle_object_expiration.py
 config:
  objects_count: 2
+ user_count: 1
+ user_create: false
  objects_size_range:
   min: 5
   max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_lc_rule_delete_marker.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_rule_delete_marker.yaml
@@ -1,6 +1,8 @@
 # test_bucket_lifecycle_object_expiration.py
 config:
  objects_count: 1
+ user_create: false
+ user_count: 1
  objects_size_range:
   min: 5
   max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_lc_rule_prefix_and_tag.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_rule_prefix_and_tag.yaml
@@ -1,6 +1,7 @@
 #test_bucket_lifecycle_object_expiration.py
 config:
  objects_count: 2
+ user_create: false
  objects_size_range:
   min: 5
   max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_lc_rule_prefix_non_current_days.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_rule_prefix_non_current_days.yaml
@@ -1,6 +1,8 @@
 # script: test_bucket_lifecycle_object_expiration.py
 config:
  objects_count: 1
+ user_create: false
+ user_count: 1
  objects_size_range:
   min: 5
   max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_manual_resharding.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_manual_resharding.yaml
@@ -1,5 +1,6 @@
 config:
  objects_count: 10
+ user_create: false
  objects_size_range:
   min: 15
   max: 20

--- a/rgw/v2/tests/s3_swift/configs/test_manual_resharding_with_version.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_manual_resharding_with_version.yaml
@@ -1,6 +1,7 @@
 # test case id: CEPH-83571740
 config:
  objects_count: 10
+ user_create: false
  objects_size_range:
   min: 15
   max: 20

--- a/rgw/v2/tests/s3_swift/configs/test_ssl_beast.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_ssl_beast.yaml
@@ -4,6 +4,7 @@ config:
  user_count: 1
  frontend: beast
  ssl: true
+ user_create: false
 
 
 # supported config options for frontends and SSL

--- a/rgw/v2/tests/s3_swift/configs/test_ssl_civetweb.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_ssl_civetweb.yaml
@@ -4,3 +4,4 @@ config:
  user_count: 1
  frontend: civetweb
  ssl: true
+ user_create: false

--- a/rgw/v2/tests/s3_swift/configs/test_versioning_objects_acls.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_versioning_objects_acls.yaml
@@ -3,6 +3,7 @@
 # CEPH - 9190
 config:
  user_count: 1
+ user_create: false
  bucket_count: 1
  objects_count: 2
  version_count: 2

--- a/rgw/v2/tests/s3_swift/configs/test_versioning_objects_delete.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_versioning_objects_delete.yaml
@@ -2,6 +2,7 @@
 # script: test_versioning_with_objects.py
 config:
  user_count: 1
+ user_create: false
  bucket_count: 1
  objects_count: 2
  version_count: 4

--- a/rgw/v2/tests/s3_swift/configs/test_versioning_objects_delete_from_another_user.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_versioning_objects_delete_from_another_user.yaml
@@ -3,6 +3,7 @@
 # test_case: CEPH-9226
 config:
  user_count: 1
+ user_create: false
  bucket_count: 1
  objects_count: 2
  version_count: 4

--- a/rgw/v2/tests/s3_swift/configs/test_versioning_objects_enable.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_versioning_objects_enable.yaml
@@ -2,6 +2,7 @@
 # script: test_versioning_with_objects.py
 config:
  user_count: 1
+ user_create: false
  bucket_count: 1
  objects_count: 2
  version_count: 4

--- a/rgw/v2/tests/s3_swift/configs/test_versioning_objects_suspend.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_versioning_objects_suspend.yaml
@@ -2,6 +2,7 @@
 # script: test_versioning_with_objects.py
 config:
  user_count: 1
+ user_create: false
  bucket_count: 1
  objects_count: 2
  version_count: 4

--- a/rgw/v2/tests/s3_swift/configs/test_versioning_objects_suspend_from_another_user.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_versioning_objects_suspend_from_another_user.yaml
@@ -1,7 +1,9 @@
+
 # upload type: non multipart
 # script: test_versioning_with_objects.py
 config:
  user_count: 1
+ user_create: false
  bucket_count: 1
  objects_count: 2
  version_count: 4

--- a/rgw/v2/tests/s3_swift/configs/test_versioning_objects_suspend_re-upload.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_versioning_objects_suspend_re-upload.yaml
@@ -3,6 +3,7 @@
 # covers even for CEPH-9223
 config:
  user_count: 1
+ user_create: false
  bucket_count: 1
  objects_count: 2
  version_count: 4

--- a/rgw/v2/tests/s3_swift/configs/test_versioning_suspend.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_versioning_suspend.yaml
@@ -2,6 +2,7 @@
 # script: test_versioning_with_objects.py
 config:
  user_count: 1
+ user_create: false
  bucket_count: 1
  objects_count: 0
  version_count: 0

--- a/rgw/v2/tests/s3_swift/io_info.yaml
+++ b/rgw/v2/tests/s3_swift/io_info.yaml
@@ -1,0 +1,6 @@
+users:
+- access_key: L99CAKIBDiXn9MQrJ0e8
+  bucket: []
+  secret_key: iTY2n51873Y51VOOLSODX6S40n48NnVALJ7E8UR3
+  tenant: tenant0
+  user_id: jenniferi.870

--- a/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
+++ b/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
@@ -62,7 +62,16 @@ def test_exec(config):
     rgw_service = RGWService()
 
     # create user
-    all_users_info = s3lib.create_users(config.user_count)
+    # use an already existing user
+    all_users_info = None
+    if config.user_create is False:
+        log.info('Using an already existing user')
+        with open('user_details') as f:
+            all_users_info = json.load(f)
+            all_users_info = s3lib.create_users(config.user_count, users_info_list=all_users_info)
+    else:
+        log.info('create a new user')
+        all_users_info = s3lib.create_users(config.user_count)
     if config.test_ops.get('encryption_algorithm', None) is not None:
         log.info('encryption enabled, making ceph config changes')
         ceph_conf.set_to_ceph_conf('global', ConfigOpts.rgw_crypt_require_ssl, "false")

--- a/rgw/v2/tests/s3_swift/test_bucket_lifecycle_object_expiration.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_lifecycle_object_expiration.py
@@ -40,13 +40,12 @@ from v2.lib.s3.write_io_info import IOInfoInitialize, BasicIOInfoStructure, Buck
 from v2.tests.s3_swift import reusable
 from v2.lib.s3 import lifecycle as lc
 from v2.lib.s3 import lifecycle_validation as lc_ops
+from v2.lib.s3.write_io_info import AddUserInfo
 import logging
 
 log = logging.getLogger()
 
-
 TEST_DATA_PATH = None
-
 
 def test_exec(config):
     io_info_initialize = IOInfoInitialize()
@@ -71,65 +70,69 @@ def test_exec(config):
         raise TestExecError("RGW service restart failed")
     else:
         log.info('RGW service restarted')
-
-    config.user_count = 1
-    config.bucket_count = 1
     # create user
-    user_info = s3lib.create_users(config.user_count)
-    user_info = user_info[0]
-    auth = Auth(user_info, ssl=config.ssl)
-    rgw_conn = auth.do_auth()
-    rgw_conn2 = auth.do_auth_using_client()
-    log.info('no of buckets to create: %s' % config.bucket_count)
-    bucket_name = utils.gen_bucket_name_from_userid(user_info['user_id'], rand_no=1)
-    obj_list = []
-    obj_tag = 'suffix1=WMV1'
-    bucket = reusable.create_bucket(bucket_name, rgw_conn, user_info)
-    prefix = list(map(lambda x: x,
-                      [rule['Filter'].get('Prefix') or
-                       rule['Filter']['And'].get('Prefix')
-                       for rule in config.lifecycle_conf]))
-    prefix = prefix if prefix else ['dummy1']
-    if config.test_ops['enable_versioning'] is True:
-        reusable.enable_versioning(bucket, rgw_conn, user_info, write_bucket_io_info)
-        if config.test_ops['create_object'] is True:
-            for oc, size in list(config.mapped_sizes.items()):
-                config.obj_size = size
-                key = prefix.pop()
-                prefix.insert(0, key)
-                s3_object_name = key + '.' + bucket.name + '.' + str(oc)
-                obj_list.append(s3_object_name)
-                if config.test_ops['version_count'] > 0:
-                    for vc in range(config.test_ops['version_count']):
-                        log.info('version count for %s is %s' % (s3_object_name, str(vc)))
-                        log.info('modifying data: %s' % s3_object_name)
-                        reusable.upload_object(s3_object_name, bucket, TEST_DATA_PATH, config, user_info,
-                                               append_data=True,
-                                               append_msg='hello object for version: %s\n' % str(vc))
-                else:
-                    log.info('s3 objects to create: %s' % config.objects_count)
-                    reusable.upload_object(s3_object_name, bucket, TEST_DATA_PATH, config, user_info)
+    # To use an already existing user, information of which is present in user_details file
+    user_info = None
+    if config.user_create is False:
+        log.info('Using an already existing user')
+        with open('user_details') as f:
+            user_info = json.load(f)
+            user_info = s3lib.create_users(config.user_count, users_info_list=user_info)
+    else:
+        log.info('creating a new user')
+        user_info = s3lib.create_users(config.user_count)
+    for each_user in user_info:
+        auth = Auth(each_user, ssl=config.ssl)
+        rgw_conn = auth.do_auth()
+        rgw_conn2 = auth.do_auth_using_client()
+        log.info('no of buckets to create: %s' % config.bucket_count)
+        bucket_name = utils.gen_bucket_name_from_userid(each_user['user_id'], rand_no=1)
+        obj_list = []
+        obj_tag = 'suffix1=WMV1'
+        bucket = reusable.create_bucket(bucket_name, rgw_conn, each_user)
+        prefix = list(map(lambda x: x,
+                          [rule['Filter'].get('Prefix') or
+                           rule['Filter']['And'].get('Prefix')
+                           for rule in config.lifecycle_conf]))
+        prefix = prefix if prefix else ['dummy1']
+        if config.test_ops['enable_versioning'] is True:
+            reusable.enable_versioning(bucket, rgw_conn, each_user, write_bucket_io_info)
+            if config.test_ops['create_object'] is True:
+                for oc, size in list(config.mapped_sizes.items()):
+                    config.obj_size = size
+                    key = prefix.pop()
+                    prefix.insert(0, key)
+                    s3_object_name = key + '.' + bucket.name + '.' + str(oc)
+                    obj_list.append(s3_object_name)
+                    if config.test_ops['version_count'] > 0:
+                        for vc in range(config.test_ops['version_count']):
+                            log.info('version count for %s is %s' % (s3_object_name, str(vc)))
+                            log.info('modifying data: %s' % s3_object_name)
+                            reusable.upload_object(s3_object_name, bucket, TEST_DATA_PATH, config, each_user,
+                                                   append_data=True,
+                                                   append_msg='hello object for version: %s\n' % str(vc))
+                    else:
+                        log.info('s3 objects to create: %s' % config.objects_count)
+                        reusable.upload_object(s3_object_name, bucket, TEST_DATA_PATH, config, each_user)
 
-        life_cycle_rule = {"Rules": config.lifecycle_conf}
-        reusable.put_get_bucket_lifecycle_test(bucket, rgw_conn, rgw_conn2, life_cycle_rule, config)
-        lc_ops.validate_prefix_rule(bucket, config)
-        if config.test_ops['delete_marker'] is True:
-            life_cycle_rule_new = {"Rules": config.delete_marker_ops}
-            reusable.put_get_bucket_lifecycle_test(bucket, rgw_conn, rgw_conn2, life_cycle_rule_new, config)
-    if config.test_ops['enable_versioning'] is False:
-        if config.test_ops['create_object'] is True:
-            for oc, size in list(config.mapped_sizes.items()):
-                config.obj_size = size
-                key = prefix.pop()
-                prefix.insert(0, key)
-                s3_object_name = key + '.' + bucket.name + '.' + str(oc)
-                obj_list.append(s3_object_name)
-                reusable.upload_object_with_tagging(s3_object_name, bucket, TEST_DATA_PATH, config, user_info, obj_tag)
-        life_cycle_rule = {"Rules": config.lifecycle_conf}
-        reusable.put_get_bucket_lifecycle_test(bucket, rgw_conn, rgw_conn2, life_cycle_rule, config)
-        lc_ops.validate_and_rule(bucket, config)
-    reusable.remove_user(user_info)
-
+            life_cycle_rule = {"Rules": config.lifecycle_conf}
+            reusable.put_get_bucket_lifecycle_test(bucket, rgw_conn, rgw_conn2, life_cycle_rule, config)
+            lc_ops.validate_prefix_rule(bucket, config)
+            if config.test_ops['delete_marker'] is True:
+                life_cycle_rule_new = {"Rules": config.delete_marker_ops}
+                reusable.put_get_bucket_lifecycle_test(bucket, rgw_conn, rgw_conn2, life_cycle_rule_new, config)
+        if config.test_ops['enable_versioning'] is False:
+            if config.test_ops['create_object'] is True:
+                for oc, size in list(config.mapped_sizes.items()):
+                    config.obj_size = size
+                    key = prefix.pop()
+                    prefix.insert(0, key)
+                    s3_object_name = key + '.' + bucket.name + '.' + str(oc)
+                    obj_list.append(s3_object_name)
+                    reusable.upload_object_with_tagging(s3_object_name, bucket, TEST_DATA_PATH, config, each_user, obj_tag)
+            life_cycle_rule = {"Rules": config.lifecycle_conf}
+            reusable.put_get_bucket_lifecycle_test(bucket, rgw_conn, rgw_conn2, life_cycle_rule, config)
+            lc_ops.validate_and_rule(bucket, config)
 
 if __name__ == '__main__':
 

--- a/rgw/v2/tests/s3_swift/test_bucket_policy_ops.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_policy_ops.py
@@ -11,8 +11,6 @@ Operation:
 - testing
 - modify bucket policy to replace the existing policy - TC 11215
 - add policy to the existing policy - TC 11214
-
-
 """
 import os, sys
 
@@ -57,12 +55,29 @@ def test_exec(config):
 
     # create user
     config.user_count = 1
-    tenant1 = 'MountEverest'
-    tenant2 = 'Himalayas'
-    tenant1_user_info = s3lib.create_tenant_users(tenant_name=tenant1, no_of_users_to_create=config.user_count)
-    tenant1_user1_info = tenant1_user_info[0]
-    tenant2_user_info = s3lib.create_tenant_users(tenant_name=tenant2, no_of_users_to_create=config.user_count)
-    tenant2_user1_info = tenant2_user_info[0]
+    user_info = None
+    # use existing tenanted users with the name tenant0 and tenant1
+    if config.user_create is False:
+        log.info('Using an already existing tenanted user')
+        for each in range(2):
+            with open('tenanted_user_details') as f:
+                user_info = json.load(f)
+                tenant_name = 'tenant' + str(each)
+                user_info = s3lib.create_tenant_users(config.user_count, tenant_name=tenant_name, users_info_list=user_info)
+                if each == 0:
+                    tenant1_user1_info = user_info[0]
+                    tenant1 = 'tenant' + str(each)
+                else:
+                    tenant2_user1_info = user_info[0]
+                    tenant2 = 'tenant' + str(each)
+    else:
+        log.info ('create new tenanted users')
+        tenant1 = 'MountEverest'
+        tenant2 = 'Himalayas'
+        tenant1_user_info = s3lib.create_tenant_users(tenant_name=tenant1, no_of_users_to_create=config.user_count)
+        tenant1_user1_info = tenant1_user_info[0]
+        tenant2_user_info = s3lib.create_tenant_users(tenant_name=tenant2, no_of_users_to_create=config.user_count)
+        tenant2_user1_info = tenant2_user_info[0]
     tenant1_user1_auth = Auth(tenant1_user1_info, ssl=config.ssl)
     tenant2_user1_auth = Auth(tenant2_user1_info, ssl=config.ssl)
     rgw_tenant1_user1 = tenant1_user1_auth.do_auth()

--- a/rgw/v2/tests/s3_swift/test_bucket_request_payer.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_request_payer.py
@@ -21,6 +21,7 @@ from v2.lib.s3.auth import Auth
 import v2.utils.utils as utils
 from v2.utils.log import configure_logging
 import traceback
+import json
 import argparse
 from v2.lib.exceptions import TestExecError, RGWBaseException
 from v2.utils.test_desc import AddTestInfo
@@ -32,9 +33,7 @@ import logging
 
 log = logging.getLogger()
 
-
 TEST_DATA_PATH = None
-
 
 def test_exec(config, requester):
 
@@ -44,7 +43,16 @@ def test_exec(config, requester):
     log.info('requester type: %s' % requester)
 
     # create user
-    all_users_info = s3lib.create_users(config.user_count)
+    # use an already existing user
+    all_users_info = None
+    if config.user_create is False:
+        log.info('Using an already existing user')
+        with open('user_details') as f:
+            all_users_info = json.load(f)
+            all_users_info = s3lib.create_users(config.user_count, users_info_list=all_users_info)
+    else:
+        log.info('create a new user')
+        all_users_info = s3lib.create_users(config.user_count)
     for each_user in all_users_info:
         # authenticate
         auth = Auth(each_user, ssl=config.ssl)

--- a/rgw/v2/tests/s3_swift/test_dynamic_bucket_resharding.py
+++ b/rgw/v2/tests/s3_swift/test_dynamic_bucket_resharding.py
@@ -55,8 +55,19 @@ def test_exec(config):
     rgw_service = RGWService()
 
     log.info('starting IO')
+
     config.user_count = 1
-    user_info = s3lib.create_users(config.user_count)
+    # create user
+    # use an already existing user
+    user_info = None
+    if config.user_create is False:
+        log.info('Using an already existing user')
+        with open('user_details') as f:
+            user_info = json.load(f)
+            user_info = s3lib.create_users(config.user_count, users_info_list=user_info)
+    else:
+        log.info('create a new user')
+        user_info = s3lib.create_users(config.user_count)
     user_info = user_info[0]
     auth = Auth(user_info, ssl=config.ssl)
     rgw_conn = auth.do_auth()

--- a/rgw/v2/tests/s3_swift/test_frontends_with_ssl.py
+++ b/rgw/v2/tests/s3_swift/test_frontends_with_ssl.py
@@ -44,7 +44,17 @@ def test_exec(config):
     basic_io_structure = BasicIOInfoStructure()
     io_info_initialize.initialize(basic_io_structure.initial())
 
-    all_users_info = s3lib.create_users(config.user_count)
+    # create user
+    # use an already existing user
+    all_users_info = None
+    if config.user_create is False:
+        log.info('Using an already existing user')
+        with open('user_details') as f:
+            all_users_info = json.load(f)
+            all_users_info = s3lib.create_users(config.user_count, users_info_list=all_users_info)
+    else:
+        log.info('create a new user')
+        all_users_info = s3lib.create_users(config.user_count)
     for each_user in all_users_info:
         auth = Auth(each_user, ssl=config.ssl)
         rgw_conn = auth.do_auth()

--- a/rgw/v2/tests/s3_swift/test_versioning_with_objects.py
+++ b/rgw/v2/tests/s3_swift/test_versioning_with_objects.py
@@ -34,6 +34,7 @@ from v2.utils.log import configure_logging
 from v2.utils.utils import HttpResponseParser
 from v2.tests.s3_swift import reusable
 import traceback
+import json
 import argparse
 import v2.lib.manage_data as manage_data
 from v2.lib.exceptions import TestExecError, RGWBaseException
@@ -61,7 +62,16 @@ def test_exec(config):
     io_info_initialize.initialize(basic_io_structure.initial())
 
     # create user
-    all_users_info = s3lib.create_users(config.user_count)
+    # use an already existing user
+    all_users_info = None
+    if config.user_create is False:
+        log.info('Using an already existing user')
+        with open('user_details') as f:
+            all_users_info = json.load(f)
+            all_users_info = s3lib.create_users(config.user_count, users_info_list=all_users_info)
+    else:
+        log.info('create a new user')
+        all_users_info = s3lib.create_users(config.user_count)
     extra_user = s3lib.create_users(1)[0]
     extra_user_auth = Auth(extra_user, ssl=config.ssl)
     extra_user_conn = extra_user_auth.do_auth()

--- a/rgw/v2/tests/s3_swift/user_create.py
+++ b/rgw/v2/tests/s3_swift/user_create.py
@@ -1,0 +1,92 @@
+import os, sys
+
+sys.path.append(os.path.abspath(os.path.join(__file__, "../../../..")))
+from v2.lib.resource_op import Config
+import v2.lib.resource_op as s3lib
+from v2.lib.s3.auth import Auth
+import v2.utils.utils as utils
+from v2.utils.log import configure_logging
+from v2.utils.utils import HttpResponseParser, RGWService
+from v2.lib.rgw_config_opts import CephConfOp, ConfigOpts
+import traceback
+import argparse
+import yaml
+import v2.lib.manage_data as manage_data
+from v2.lib.exceptions import TestExecError, RGWBaseException
+from v2.utils.test_desc import AddTestInfo
+from v2.lib.s3.write_io_info import IOInfoInitialize, BasicIOInfoStructure
+import random, time
+import json
+import logging
+
+log = logging.getLogger()
+TEST_DATA_PATH = None
+
+def test_exec(config):
+    test_info = AddTestInfo('create users')
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+    try:
+        test_info.started_info()
+        # create a non-tenanted user
+        if config.user_type == 'non-tenanted':
+            all_users_info = s3lib.create_users(config.user_count, config.cluster_name)
+            with open('user_details', 'w') as fout:
+                json.dump(all_users_info, fout)
+            test_info.success_status('non-tenanted users creation completed')
+        else:
+            log.info('create tenanted users')
+            for i in range(config.user_count):
+                tenant_name = 'tenant' + str(i)
+                all_users_info = s3lib.create_tenant_users(config.user_count, tenant_name, config.cluster_name)
+                with open('tenanted_user_details', 'w') as fout:
+                    json.dump(all_users_info, fout)
+                test_info.success_status('tenanted users creation completed')
+        test_info.success_status('test passed')
+        sys.exit(0)
+    except Exception as e:
+        log.info(e)
+        log.info(traceback.format_exc())
+        test_info.failed_status('user creation failed')
+        sys.exit(1)
+    except (RGWBaseException, Exception) as e:
+        log.info(e)
+        log.info(traceback.format_exc())
+        test_info.failed_status('user creation failed')
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    test_info = AddTestInfo('user create test')
+    test_info.started_info()
+    project_dir = os.path.abspath(os.path.join(__file__, "../../.."))
+    test_data_dir = 'test_data'
+    TEST_DATA_PATH = (os.path.join(project_dir, test_data_dir))
+    log.info('TEST_DATA_PATH: %s' % TEST_DATA_PATH)
+    if not os.path.exists(TEST_DATA_PATH):
+            log.info('test data dir not exists, creating.. ')
+            os.makedirs(TEST_DATA_PATH)
+    parser = argparse.ArgumentParser(description='RGW S3 Automation')
+    parser.add_argument('-c', dest="config",
+                            help='RGW Test yaml configuration')
+    parser.add_argument('-log_level', dest='log_level',
+                            help='Set Log Level [DEBUG, INFO, WARNING, ERROR, CRITICAL]',
+                            default='info')
+    args = parser.parse_args()
+    yaml_file = args.config
+    log_f_name = os.path.basename(os.path.splitext(yaml_file)[0])
+    configure_logging(f_name=log_f_name,
+                          set_level=args.log_level.upper())
+    config = Config(yaml_file)
+    config.read()
+#        if config.mapped_sizes is None:
+#           config.mapped_sizes = utils.make_mapped_sizes(config)
+    with open(yaml_file, 'r') as f:
+            doc = yaml.load(f)
+            config.cluster_name = doc['config']['cluster_name']
+            config.user_count = doc['config']['user_count']
+            log.info('user_count:%s\n' % (config.user_count))
+    test_exec(config)
+
+


### PR DESCRIPTION
Signed off : viduship  <vimishra@redhat.com>

The flow is to have users (tenanted and non-tenanted) created via the user_create.py file, save user details in a file, and
use the details when running the below ceph-qe-scripts.

Below are the python scripts for which this is enabled:
1) test_Mbuckets_with_Nobjects.py
2) test_bucket_lifecycle_config_ops.py
3) test_bucket_lifecycle_object_expiration.py
4) test_bucket_policy_ops.py
5) test_bucket_request_payer.py
6) test_byte_range.py
7) test_dynamic_bucket_resharding.py
8) test_frontends_with_ssl.py
9) test_versioning_with_objects.py

