### PR TITLE
test_versioning_with_objects.py: reusable.delete_version_object function to delete all versioned objects

### DIFF
--- a/rgw/v2/tests/s3_swift/test_versioning_with_objects.py
+++ b/rgw/v2/tests/s3_swift/test_versioning_with_objects.py
@@ -267,8 +267,7 @@ def test_exec(config):
                                     response = HttpResponseParser(del_obj_version)
                                     if response.status_code == 204:
                                         log.info('version deleted ')
-                                        write_key_io_info.delete_version_info(each_user['access_key'], bucket.name,
-                                                                              s3_object_path, version.version_id)
+                                        reusable.delete_version_object(bucket,version.version_id, s3_object_path, rgw_conn, each_user)
                                     else:
                                         raise TestExecError("version  deletion failed")
                                 else:


### PR DESCRIPTION

To deletes all versioned objects in test_versioning_with_objects.py, changed to use reusable.delete_version_object function

