### PR TITLE
to check for any ceph daemon crashes

### DIFF
--- a/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
+++ b/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
@@ -247,7 +247,7 @@ def test_exec(config):
     # check for any crashes during the execution
     crash_info=reusable.check_for_crash()
     if crash_info:
-        raise TestExecError("Crash found")
+        raise TestExecError("ceph daemon crash found!")
 
 if __name__ == '__main__':
 

--- a/rgw/v2/tests/s3_swift/test_bucket_lifecycle_config_ops.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_lifecycle_config_ops.py
@@ -250,7 +250,10 @@ def test_exec(config):
                             raise TestExecError("bucket lifecycle config retrieval failed after disabled")
                     else:
                         raise TestExecError("bucket lifecycle config retrieval failed after disabled")
-
+    # check for any crashes during the execution
+    crash_info=reusable.check_for_crash()
+    if crash_info:
+        raise TestExecError("ceph daemon crash found!")
 
 if __name__ == '__main__':
 

--- a/rgw/v2/tests/s3_swift/test_bucket_lifecycle_object_expiration.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_lifecycle_object_expiration.py
@@ -129,7 +129,10 @@ def test_exec(config):
         reusable.put_get_bucket_lifecycle_test(bucket, rgw_conn, rgw_conn2, life_cycle_rule, config)
         lc_ops.validate_and_rule(bucket, config)
     reusable.remove_user(user_info)
-
+    # check for any crashes during the execution
+    crash_info=reusable.check_for_crash()
+    if crash_info:
+        raise TestExecError("ceph daemon crash found!")
 
 if __name__ == '__main__':
 

--- a/rgw/v2/tests/s3_swift/test_bucket_listing.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_listing.py
@@ -202,7 +202,7 @@ def test_exec(config):
     # check for any crashes during the execution
     crash_info=reusable.check_for_crash()
     if crash_info:
-        raise TestExecError("Crash found")
+        raise TestExecError("ceph daemon crash found!")
     reusable.remove_user(each_user)
     
 

--- a/rgw/v2/tests/s3_swift/test_bucket_policy_ops.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_policy_ops.py
@@ -195,7 +195,10 @@ def test_exec(config):
             else:
                 raise TestExecError("bucket policy did not get deleted")
         # log.info('get_policy after deletion: %s' % get_policy)
-
+    # check for any crashes during the execution
+    crash_info=reusable.check_for_crash()
+    if crash_info:
+        raise TestExecError("ceph daemon crash found!")
 
 if __name__ == '__main__':
 

--- a/rgw/v2/tests/s3_swift/test_bucket_request_payer.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_request_payer.py
@@ -84,7 +84,10 @@ def test_exec(config, requester):
                     config.obj_size = size
                     s3_object_name = utils.gen_s3_object_name(bucket.name, oc)
                     reusable.upload_object(s3_object_name, bucket, TEST_DATA_PATH, config, each_user)
-
+    # check for any crashes during the execution
+    crash_info=reusable.check_for_crash()
+    if crash_info:
+        raise TestExecError("ceph daemon crash found!")
 
 if __name__ == '__main__':
 

--- a/rgw/v2/tests/s3_swift/test_dynamic_bucket_resharding.py
+++ b/rgw/v2/tests/s3_swift/test_dynamic_bucket_resharding.py
@@ -147,7 +147,10 @@ def test_exec(config):
         else:
             reusable.delete_objects(bucket)
         reusable.delete_bucket(bucket)
-
+    # check for any crashes during the execution
+    crash_info=reusable.check_for_crash()
+    if crash_info:
+        raise TestExecError("ceph daemon crash found!")
 
 if __name__ == '__main__':
 

--- a/rgw/v2/tests/s3_swift/test_multitenant_user_access.py
+++ b/rgw/v2/tests/s3_swift/test_multitenant_user_access.py
@@ -113,7 +113,10 @@ def test_exec(config):
     if t1_u1_b1_o1_download is None:
         raise TestExecError('object downloaded\n'
                             'downloaded tenant2->user1->bucket1->object1, this should not happen')
-
+    # check for any crashes during the execution
+    crash_info=reusable.check_for_crash()
+    if crash_info:
+        raise TestExecError("ceph daemon crash found!")
 
 if __name__ == '__main__':
 

--- a/rgw/v2/tests/s3_swift/test_swift_basic_ops.py
+++ b/rgw/v2/tests/s3_swift/test_swift_basic_ops.py
@@ -33,6 +33,7 @@ from v2.lib.exceptions import TestExecError, RGWBaseException
 from v2.utils.test_desc import AddTestInfo
 from v2.lib.s3.write_io_info import IOInfoInitialize, BasicIOInfoStructure
 from v2.lib.swift.auth import Auth
+from v2.tests.s3_swift import reusable
 import v2.lib.manage_data as manage_data
 from v2.lib.admin import UserMgmt
 import logging
@@ -108,7 +109,10 @@ def test_exec(config):
         # delete container
         log.info('deleting swift container')
         rgw.delete_container(container_name)
-
+    # check for any crashes during the execution
+    crash_info=reusable.check_for_crash()
+    if crash_info:
+        raise TestExecError("ceph daemon crash found!")
 
 if __name__ == '__main__':
 

--- a/rgw/v2/tests/s3_swift/test_tenant_user_secret_key.py
+++ b/rgw/v2/tests/s3_swift/test_tenant_user_secret_key.py
@@ -24,6 +24,7 @@ from v2.utils.test_desc import AddTestInfo
 from v2.lib.s3.write_io_info import IOInfoInitialize, BasicIOInfoStructure
 from v2.lib.swift.auth import Auth
 import v2.lib.manage_data as manage_data
+from v2.tests.s3_swift import reusable
 
 TEST_DATA_PATH = None
 import logging
@@ -94,7 +95,10 @@ def test_exec(config):
                 rgw.put_object(container_name, swift_object_name,
                                contents=fp.read(),
                                content_type='text/plain')
-
+    # check for any crashes during the execution
+    crash_info=reusable.check_for_crash()
+    if crash_info:
+        raise TestExecError("ceph daemon crash found!")
 
 if __name__ == '__main__':
 

--- a/rgw/v2/tests/s3_swift/test_user_bucket_rename.py
+++ b/rgw/v2/tests/s3_swift/test_user_bucket_rename.py
@@ -117,7 +117,10 @@ def test_exec(config):
             raise TestExecError("RGW Bucket unlink error")
         log.info('output :%s' % out5)
         reusable.link_chown_to_nontenanted(non_ten_users[0]['user_id'], ten_buckets[ten_users[0]['user_id']], tenant1)
-
+    # check for any crashes during the execution
+    crash_info=reusable.check_for_crash()
+    if crash_info:
+        raise TestExecError("ceph daemon crash found!")
 
 if __name__ == '__main__':
 

--- a/rgw/v2/tests/s3_swift/test_versioning_copy_objects.py
+++ b/rgw/v2/tests/s3_swift/test_versioning_copy_objects.py
@@ -124,7 +124,10 @@ def test_exec(config):
         for version in versions:
             log.info(
                 'key_name: %s --> version_id: %s' % (version.object_key, version.version_id))
-
+    # check for any crashes during the execution
+    crash_info=reusable.check_for_crash()
+    if crash_info:
+        raise TestExecError("ceph daemon crash found!")
 
 if __name__ == '__main__':
 

--- a/rgw/v2/tests/s3_swift/test_versioning_with_objects.py
+++ b/rgw/v2/tests/s3_swift/test_versioning_with_objects.py
@@ -411,7 +411,10 @@ def test_exec(config):
                         utils.exec_shell_cmd('sudo rm -rf %s' % s3_object_path)
             if config.test_ops.get('delete_bucket') is True:
                 reusable.delete_bucket(bucket)
-
+    # check for any crashes during the execution
+    crash_info=reusable.check_for_crash()
+    if crash_info:
+        raise TestExecError("ceph daemon crash found!")
 
 if __name__ == '__main__':
 

--- a/rgw/v2/tests/s3_swift/user_op_using_rest.py
+++ b/rgw/v2/tests/s3_swift/user_op_using_rest.py
@@ -32,6 +32,7 @@ from v2.lib.s3.write_io_info import IOInfoInitialize, BasicIOInfoStructure
 from v2.lib.swift.auth import Auth
 from v2.lib.admin import UserMgmt
 from rgwadmin import RGWAdmin
+from v2.tests.s3_swift import reusable
 import logging
 
 log = logging.getLogger()
@@ -135,7 +136,10 @@ def test_exec(config):
             test_info.failed_status('test failed')
             sys.exit(1)
         log.info("Verification for Delete operation completed")
-
+    # check for any crashes during the execution
+    crash_info=reusable.check_for_crash()
+    if crash_info:
+        raise TestExecError("ceph daemon crash found!")
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
 check added to find any ceph daemon crashes to the following scripts.

- test_Mbuckets_with_Nobjects.py
- test_bucket_lifecycle_config_ops.py
- test_bucket_lifecycle_object_expiration.py
- test_bucket_listing.py
- test_bucket_policy_ops.py
- test_bucket_request_payer.py
- test_dynamic_bucket_resharding.py
- test_multitenant_user_access.py
- test_swift_basic_ops.py
- test_tenant_user_secret_key.py
- test_user_bucket_rename.py
- test_versioning_copy_objects.py
- test_versioning_with_objects.py
- user_op_using_rest.py