### PR TITLE
rgw/v2/tests/s3_swift: Adding multisite test configs

### DIFF
--- a/rgw/v2/lib/resource_op.py
+++ b/rgw/v2/lib/resource_op.py
@@ -166,6 +166,7 @@ class Config(object):
         self.max_objects_per_shard = self.doc['config'].get('max_objects_per_shard')
         self.max_objects = None
         self.user_count = self.doc['config'].get('user_count')
+	self.user_remove = self.doc['config'].get('user_remove', True)
         self.bucket_count = self.doc['config'].get('bucket_count')
         self.objects_count = self.doc['config'].get('objects_count')
         self.pseudo_dir_count = self.doc['config'].get('pseudo_dir_count')

--- a/rgw/v2/tests/s3_swift/mutisiste_configs/test_LargeObjGet_GC.yaml
+++ b/rgw/v2/tests/s3_swift/mutisiste_configs/test_LargeObjGet_GC.yaml
@@ -1,0 +1,20 @@
+# BZ id : 1892644#c52
+# script: test_LargeObjGet_1892644.py
+config:
+ user_count: 1
+ bucket_count: 1
+ objects_count: 1
+ gc_verification: true
+ local_file_delete: false
+ split_size: 5
+ objects_size_range:
+  min: 1G
+  max: 2G
+ test_ops:
+      create_bucket: true
+      create_object: true
+      upload_type: normal
+      delete_bucket_object: true
+
+
+

--- a/rgw/v2/tests/s3_swift/mutisiste_configs/test_Mbuckets.yaml
+++ b/rgw/v2/tests/s3_swift/mutisiste_configs/test_Mbuckets.yaml
@@ -1,0 +1,22 @@
+# upload type: non multipart
+# script: test_Mbuckets_with_Nobjects.py
+config:
+ user_count: 1
+ bucket_count: 10
+ objects_count: 0
+ objects_size_range:
+  min: 0
+  max: 0
+ test_ops:
+      create_bucket: true
+      create_object: false
+      download_object: false
+      delete_bucket_object: false
+      sharding:
+        enable: false
+        max_shards: 0
+      compression:
+        enable: false
+        type: zlib
+
+

--- a/rgw/v2/tests/s3_swift/mutisiste_configs/test_Mbuckets_with_Nobjects.yaml
+++ b/rgw/v2/tests/s3_swift/mutisiste_configs/test_Mbuckets_with_Nobjects.yaml
@@ -1,0 +1,20 @@
+# upload type: non multipart
+# script: test_Mbuckets_with_Nobjects.py
+config:
+ user_count: 1
+ bucket_count: 1
+ objects_count: 2
+ objects_size_range:
+  min: 5M
+  max: 15M
+ test_ops:
+      create_bucket: true
+      create_object: true
+      download_object: false
+      delete_bucket_object: false
+      sharding:
+        enable: false
+        max_shards: 0
+      compression:
+        enable: false
+        type: zlib

--- a/rgw/v2/tests/s3_swift/mutisiste_configs/test_Mbuckets_with_Nobjects_aws4.yaml
+++ b/rgw/v2/tests/s3_swift/mutisiste_configs/test_Mbuckets_with_Nobjects_aws4.yaml
@@ -1,0 +1,21 @@
+# upload type: non multipart
+# script: test_Mbuckets_with_Nobjects.py
+config:
+ use_aws4: true
+ user_count: 1
+ bucket_count: 1
+ objects_count: 2
+ objects_size_range:
+  min: 5
+  max: 15
+ test_ops:
+      create_bucket: true
+      create_object: true
+      download_object: false
+      delete_bucket_object: false
+      sharding:
+        enable: false
+        max_shards: 0
+      compression:
+        enable: false
+        type: zlib

--- a/rgw/v2/tests/s3_swift/mutisiste_configs/test_Mbuckets_with_Nobjects_compression.yaml
+++ b/rgw/v2/tests/s3_swift/mutisiste_configs/test_Mbuckets_with_Nobjects_compression.yaml
@@ -1,0 +1,20 @@
+# upload type: non multipart
+# script: test_Mbuckets_with_Nobjects.py
+config:
+ user_count: 1
+ bucket_count: 1
+ objects_count: 2
+ objects_size_range:
+  min: 5
+  max: 15
+ test_ops:
+      create_bucket: true
+      create_object: true
+      download_object: false
+      delete_bucket_object: false
+      sharding:
+        enable: false
+        max_shards: 0
+      compression:
+        enable: true
+        type: zlib

--- a/rgw/v2/tests/s3_swift/mutisiste_configs/test_Mbuckets_with_Nobjects_delete.yaml
+++ b/rgw/v2/tests/s3_swift/mutisiste_configs/test_Mbuckets_with_Nobjects_delete.yaml
@@ -1,0 +1,20 @@
+# upload type: non multipart
+# script: test_Mbuckets_with_Nobjects.py
+config:
+ user_count: 1
+ bucket_count: 2
+ objects_count: 2
+ objects_size_range:
+  min: 5
+  max: 15
+ test_ops:
+      create_bucket: true
+      create_object: true
+      download_object: false
+      delete_bucket_object: true
+      sharding:
+        enable: false
+        max_shards: 0
+      compression:
+        enable: false
+        type: zlib

--- a/rgw/v2/tests/s3_swift/mutisiste_configs/test_Mbuckets_with_Nobjects_download.yaml
+++ b/rgw/v2/tests/s3_swift/mutisiste_configs/test_Mbuckets_with_Nobjects_download.yaml
@@ -1,0 +1,20 @@
+# upload type: non multipart
+# script: test_Mbuckets_with_Nobjects.py
+config:
+ user_count: 1
+ bucket_count: 1
+ objects_count: 2
+ objects_size_range:
+  min: 5
+  max: 15
+ test_ops:
+      create_bucket: true
+      create_object: true
+      download_object: true
+      delete_bucket_object: false
+      sharding:
+        enable: false
+        max_shards: 0
+      compression:
+        enable: false
+        type: zlib

--- a/rgw/v2/tests/s3_swift/mutisiste_configs/test_Mbuckets_with_Nobjects_enc.yaml
+++ b/rgw/v2/tests/s3_swift/mutisiste_configs/test_Mbuckets_with_Nobjects_enc.yaml
@@ -1,0 +1,21 @@
+# upload type: non multipart
+# script: test_Mbuckets_with_Nobjects.py
+config:
+ user_count: 1
+ bucket_count: 1
+ objects_count: 2
+ objects_size_range:
+  min: 5
+  max: 15
+ test_ops:
+      create_bucket: true
+      create_object: true
+      encryption_algorithm: AES256
+      download_object: true
+      delete_bucket_object: false
+      sharding:
+        enable: false
+        max_shards: 0
+      compression:
+        enable: false
+        type: zlib

--- a/rgw/v2/tests/s3_swift/mutisiste_configs/test_Mbuckets_with_Nobjects_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/mutisiste_configs/test_Mbuckets_with_Nobjects_multipart.yaml
@@ -1,0 +1,22 @@
+# upload type: non multipart
+# script: test_Mbuckets_with_Nobjects.py
+config:
+ user_count: 1
+ bucket_count: 1
+ objects_count: 2
+ split_size: 100
+ objects_size_range:
+  min: 300
+  max: 500
+ test_ops:
+      create_bucket: true
+      create_object: true
+      upload_type: multipart
+      download_object: true
+      delete_bucket_object: false
+      sharding:
+        enable: false
+        max_shards: 0
+      compression:
+        enable: false
+        type: zlib

--- a/rgw/v2/tests/s3_swift/mutisiste_configs/test_Mbuckets_with_Nobjects_sharding.yaml
+++ b/rgw/v2/tests/s3_swift/mutisiste_configs/test_Mbuckets_with_Nobjects_sharding.yaml
@@ -1,0 +1,20 @@
+# upload type: non multipart
+# script: test_Mbuckets_with_Nobjects.py
+config:
+ user_count: 1
+ bucket_count: 1
+ objects_count: 1
+ objects_size_range:
+  min: 1000
+  max: 1500
+ test_ops:
+      create_bucket: true
+      create_object: true
+      download_object: false
+      delete_bucket_object: true
+      sharding:
+        enable: true
+        max_shards: 32
+      compression:
+        enable: false
+        type: zlib

--- a/rgw/v2/tests/s3_swift/mutisiste_configs/test_bucket_listing_flat_ordered.yaml
+++ b/rgw/v2/tests/s3_swift/mutisiste_configs/test_bucket_listing_flat_ordered.yaml
@@ -1,0 +1,17 @@
+config:
+ user_count: 1
+ bucket_count: 1
+ objects_count: 30
+ objects_size_range:
+  min: 15
+  max: 15
+ local_file_delete: true
+ test_ops:
+      create_bucket: true
+      create_object: true
+      object_structure: flat
+      radosgw_listing_ordered : true
+      radoslist: true
+      delete_bucket_object: true
+
+

--- a/rgw/v2/tests/s3_swift/mutisiste_configs/test_bucket_listing_flat_ordered_versionsing.yaml
+++ b/rgw/v2/tests/s3_swift/mutisiste_configs/test_bucket_listing_flat_ordered_versionsing.yaml
@@ -1,0 +1,19 @@
+config:
+ user_count: 1
+ bucket_count: 1
+ objects_count: 30
+ version_count: 3
+ objects_size_range:
+  min: 15
+  max: 15
+ local_file_delete: true
+ test_ops:
+      create_bucket: true
+      create_object: true
+      enable_version: true
+      object_structure: flat
+      radosgw_listing_ordered : true
+      radoslist: true
+      delete_bucket_object: true
+
+

--- a/rgw/v2/tests/s3_swift/mutisiste_configs/test_bucket_listing_flat_unordered.yaml
+++ b/rgw/v2/tests/s3_swift/mutisiste_configs/test_bucket_listing_flat_unordered.yaml
@@ -1,0 +1,15 @@
+config:
+ user_count: 1
+ bucket_count: 1
+ objects_count: 30
+ objects_size_range:
+  min: 15
+  max: 15
+ local_file_delete: true
+ test_ops:
+      create_bucket: true
+      create_object: true
+      object_structure: flat
+      radosgw_listing_ordered: false
+      radoslist: false
+      delete_bucket_object: true

--- a/rgw/v2/tests/s3_swift/mutisiste_configs/test_bucket_listing_pseudo_ordered.yaml
+++ b/rgw/v2/tests/s3_swift/mutisiste_configs/test_bucket_listing_pseudo_ordered.yaml
@@ -1,0 +1,18 @@
+config:
+ user_count: 1
+ bucket_count: 1
+ objects_count: 10
+ pseudo_dir_count: 5
+ objects_size_range:
+  min: 10
+  max: 10
+ local_file_delete: true
+ test_ops:
+      create_bucket: true
+      create_object: true
+      object_structure: pseudo
+      radosgw_listing_ordered : true
+      radoslist : true
+      delete_bucket_object: true
+
+

--- a/rgw/v2/tests/s3_swift/mutisiste_configs/test_bucket_listing_pseudo_ordered_dir_only.yaml
+++ b/rgw/v2/tests/s3_swift/mutisiste_configs/test_bucket_listing_pseudo_ordered_dir_only.yaml
@@ -1,0 +1,17 @@
+config:
+ user_count: 1
+ bucket_count: 1
+ pseudo_dir_count: 50
+ objects_count: 0
+ objects_size_range:
+  min: 1
+  max: 1
+ local_file_delete: true
+ test_ops:
+      create_bucket: true
+      create_object: false
+      object_structure: pseudo-dir-only
+      radosgw_listing_ordered : true
+      radoslist : true  
+      delete_bucket_object: true
+

--- a/rgw/v2/tests/s3_swift/mutisiste_configs/test_bucket_policy_delete.yaml
+++ b/rgw/v2/tests/s3_swift/mutisiste_configs/test_bucket_policy_delete.yaml
@@ -1,0 +1,6 @@
+# script: test_bucket_policy_ops.py
+# bucket policy will be modified to take additional policies with already existing policy.
+# TC 11213
+config:
+ bucket_policy_op: delete
+

--- a/rgw/v2/tests/s3_swift/mutisiste_configs/test_bucket_policy_modify.yaml
+++ b/rgw/v2/tests/s3_swift/mutisiste_configs/test_bucket_policy_modify.yaml
@@ -1,0 +1,6 @@
+# script: test_bucket_policy_ops.py
+# bucket policy will be modified to take additional policies with already existing policy.
+# TC 11214
+config:
+ bucket_policy_op: modify
+

--- a/rgw/v2/tests/s3_swift/mutisiste_configs/test_bucket_policy_replace.yaml
+++ b/rgw/v2/tests/s3_swift/mutisiste_configs/test_bucket_policy_replace.yaml
@@ -1,0 +1,6 @@
+# script: test_bucket_policy_ops.py
+# completely add new policy, replacing the existing policy
+# TC 11215
+config:
+ bucket_policy_op: replace
+

--- a/rgw/v2/tests/s3_swift/mutisiste_configs/test_versioning_copy_objects.yaml
+++ b/rgw/v2/tests/s3_swift/mutisiste_configs/test_versioning_copy_objects.yaml
@@ -1,0 +1,6 @@
+# script: test_versioning_copy_objects.py
+# polarion id: CEPH-9221
+config:
+ objects_size_range:
+  min: 5
+  max: 15

--- a/rgw/v2/tests/s3_swift/mutisiste_configs/test_versioning_enable.yaml
+++ b/rgw/v2/tests/s3_swift/mutisiste_configs/test_versioning_enable.yaml
@@ -1,0 +1,15 @@
+# upload type: non multipart
+# script: test_versioning_with_objects.py
+config:
+ user_count: 1
+ bucket_count: 1
+ objects_count: 0
+ version_count: 0
+ objects_size_range:
+  min: 5
+  max: 15
+ test_ops:
+      enable_version: true
+      suspend_version: false
+      copy_to_version: false
+

--- a/rgw/v2/tests/s3_swift/mutisiste_configs/test_versioning_objects_acls.yaml
+++ b/rgw/v2/tests/s3_swift/mutisiste_configs/test_versioning_objects_acls.yaml
@@ -1,0 +1,18 @@
+# upload type: non multipart
+# script: test_versioning_with_objects.py
+# CEPH - 9190
+config:
+ user_count: 1
+ bucket_count: 1
+ objects_count: 2
+ version_count: 2
+ objects_size_range:
+  min: 5
+  max: 15
+ test_ops:
+      enable_version: true
+      copy_to_version: false # this is same as revert and restore object
+      suspend_version: false
+      delete_object_versions: false
+      upload_after_suspend: false
+      set_acl: true

--- a/rgw/v2/tests/s3_swift/mutisiste_configs/test_versioning_objects_copy.yaml
+++ b/rgw/v2/tests/s3_swift/mutisiste_configs/test_versioning_objects_copy.yaml
@@ -1,0 +1,16 @@
+# upload type: non multipart
+# script: test_versioning_with_objects.py
+config:
+ user_count: 1
+ bucket_count: 1
+ objects_count: 2
+ version_count: 4
+ objects_size_range:
+  min: 5
+  max: 15
+ test_ops:
+      enable_version: true
+      suspend_version: false
+      copy_to_version: true # this is same as revert and restore object
+      delete_object_versions: false
+      upload_after_suspend: false

--- a/rgw/v2/tests/s3_swift/mutisiste_configs/test_versioning_objects_delete.yaml
+++ b/rgw/v2/tests/s3_swift/mutisiste_configs/test_versioning_objects_delete.yaml
@@ -1,0 +1,16 @@
+# upload type: non multipart
+# script: test_versioning_with_objects.py
+config:
+ user_count: 1
+ bucket_count: 1
+ objects_count: 2
+ version_count: 4
+ objects_size_range:
+  min: 5
+  max: 15
+ test_ops:
+      enable_version: true
+      suspend_version: false
+      copy_to_version: false # this is same as revert and restore object
+      delete_object_versions: true
+      upload_after_suspend: false

--- a/rgw/v2/tests/s3_swift/mutisiste_configs/test_versioning_objects_enable.yaml
+++ b/rgw/v2/tests/s3_swift/mutisiste_configs/test_versioning_objects_enable.yaml
@@ -1,0 +1,16 @@
+# upload type: non multipart
+# script: test_versioning_with_objects.py
+config:
+ user_count: 1
+ bucket_count: 1
+ objects_count: 2
+ version_count: 4
+ objects_size_range:
+  min: 5
+  max: 15
+ test_ops:
+      enable_version: true
+      suspend_version: false
+      copy_to_version: false
+      delete_object_versions: false
+      upload_after_suspend: false

--- a/rgw/v2/tests/s3_swift/mutisiste_configs/test_versioning_objects_suspend.yaml
+++ b/rgw/v2/tests/s3_swift/mutisiste_configs/test_versioning_objects_suspend.yaml
@@ -1,0 +1,17 @@
+# upload type: non multipart
+# script: test_versioning_with_objects.py
+config:
+ user_count: 1
+ bucket_count: 1
+ objects_count: 2
+ version_count: 4
+ objects_size_range:
+  min: 5
+  max: 15
+ test_ops:
+      enable_version: true
+      suspend_version: true
+      copy_to_version: false
+      delete_object_versions: false
+      upload_after_suspend: false
+

--- a/rgw/v2/tests/s3_swift/test_bucket_listing.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_listing.py
@@ -203,7 +203,8 @@ def test_exec(config):
     crash_info=reusable.check_for_crash()
     if crash_info:
         raise TestExecError("ceph daemon crash found!")
-    reusable.remove_user(each_user)
+    if config.user_remove is True:
+    	reusable.remove_user(each_user)
     
 
 if __name__ == '__main__':


### PR DESCRIPTION
In this PR, have identified the test scenarios (based on the yamls) that can be run on a multisite environment.
Have created a separate folder "multisite_configs" at s3_swift/ path that contains the scenarios which can be run on a simplet multisite clutser.

Also, as part of this PR, have removed the multisiste folder that was present at "ceph-qe-scripts/rgw/v2/tests/" path to avoid redundancy.

Signed-off-by: vimishra <vimishra@redhat.com>