### PR TITLE
enhancenment to ceph-qe-scripts to run rhcs 5.0

### DIFF
--- a/rgw/v2/lib/admin.py
+++ b/rgw/v2/lib/admin.py
@@ -38,7 +38,7 @@ class UserMgmt(object):
             write_user_info = AddUserInfo()
             basic_io_structure = BasicIOInfoStructure()
             log.info('cluster name: %s' % cluster_name)
-            cmd = 'radosgw-admin user create --uid=%s --display-name=%s --cluster %s' % (
+            cmd = 'radosgw-admin user create --uid="%s" --display-name="%s" --cluster %s' % (
                 user_id, displayname, cluster_name)
             log.info('cmd to execute:\n%s' % cmd)
             variable = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)

--- a/rgw/v2/lib/frontend_configure.py
+++ b/rgw/v2/lib/frontend_configure.py
@@ -114,3 +114,27 @@ class Frontend(RGWSectionOptions):
             log.info(traceback.format_exc())
             sys.exit(1)
 
+class RGWsections():
+    def __init__(self):
+        rgw_in_ceph_config = utils.exec_shell_cmd('sudo ceph config dump')
+        if 'client.rgw.' in rgw_in_ceph_config:
+            log.info('RGW section in ceph config')
+        else:
+            raise RGWBaseException('No RGW section in ceph config')
+
+class Frontend_CephAdm():
+    def __init__(self):
+        RGWsections()
+        rgw_in_ceph_config = utils.exec_shell_cmd('sudo ceph config dump')
+        self.curr_ssl = True if 'ssl' in list(filter(lambda section: 'ssl' in section, rgw_in_ceph_config)) else False
+        self.curr_frontend = 'beast'
+
+    def set_frontend(self, frontend, **kwargs):
+        ssl = kwargs.get('ssl', False)
+        frontend ='beast'
+        self.curr_frontend = frontend
+        self.curr_ssl = ssl
+        log.info('frontend is set: {}'.format(frontend))
+        log.info('ssl status updated: {}'.format(ssl))
+        return frontend
+

--- a/rgw/v2/lib/resource_op.py
+++ b/rgw/v2/lib/resource_op.py
@@ -189,7 +189,11 @@ class Config(object):
         self.ssl = self.doc['config'].get('ssl',)
         self.frontend = self.doc['config'].get('frontend')
         self.io_op_config = self.doc.get('config').get('io_op_config')
-        frontend_config = Frontend()
+        ceph_version_id, ceph_version_name = utils.get_ceph_version()
+        if ceph_version_name in ['luminous','nautilus']:
+            frontend_config = Frontend()
+        if ceph_version_name == 'Pacific':
+            frontend_config = Frontend_CephAdm()
 
         # if frontend is set in config yaml
         if self.frontend:

--- a/rgw/v2/utils/utils.py
+++ b/rgw/v2/utils/utils.py
@@ -133,16 +133,31 @@ class RGWService(object):
         pass
 
     def restart(self):
-        executed = exec_shell_cmd('sudo systemctl restart ceph-radosgw.target')
-        return executed
+        ceph_version_id, ceph_version_name = get_ceph_version()
+        if ceph_version_name in ['luminous','nautilus']:
+            executed = exec_shell_cmd('sudo systemctl restart ceph-radosgw.target')
+            return executed
+        if ceph_version_name == 'pacific':
+            executed = exec_shell_cmd('sudo ceph orch restart rgw')
+            return executed
 
     def stop(self):
-        executed = exec_shell_cmd('sudo systemctl stop ceph-radosgw.target')
-        return executed
-
+        ceph_version_id, ceph_version_name = get_ceph_version()
+        if ceph_version_name in ['luminous','nautilus']:
+            executed = exec_shell_cmd('sudo systemctl stop ceph-radosgw.target')
+            return executed
+        if ceph_version_name == 'pacific':
+            executed = exec_shell_cmd('sudo ceph orch stop rgw')
+            return executed
+    
     def start(self):
-        executed = exec_shell_cmd('sudo systemctl stop ceph-radosgw.target')
-        return executed
+        ceph_version_id, ceph_version_name = get_ceph_version()
+        if ceph_version_name in ['luminous','nautilus']:
+            executed = exec_shell_cmd('sudo systemctl start ceph-radosgw.target')
+            return executed
+        if ceph_version_name == 'pacific':
+            executed = exec_shell_cmd('sudo ceph orch start rgw')
+            return executed
 
 
 def get_radosgw_port_no():
@@ -169,8 +184,9 @@ def get_all_in_dir(path):
 
 
 def gen_bucket_name_from_userid(user_id, rand_no=0):
-    log.info('generating bucket name or basedir to create')
-    bucket_name_to_create = user_id + "_" + BUCKET_NAME_PREFIX + "_" + str(rand_no)
+    log.info('generating bucket name or basedir to create') 
+    # BZ1942136 : In pacific,bucket creation with underscore( _ ) fails with 'InvalidBucketName'
+    bucket_name_to_create = user_id + "-" + BUCKET_NAME_PREFIX + "-" + str(rand_no) 
     log.info('bucket or basedir name to create generated: %s' % bucket_name_to_create)
     return bucket_name_to_create
 


### PR DESCRIPTION
Add support to run tests for RHCS 5.0 in ceph-qe-scripts.
executed the following tests against ceph releases luminous, nautilus and pacific.

tests:
test_Mbuckets_with_Nobjects.py -c configs/test_Mbuckets_with_Nobjects.yaml
test_Mbuckets_with_Nobjects.py -c configs/test_Mbuckets_with_Nobjects_delete.yaml

logs:
http://magna002.ceph.redhat.com/ceph-qe-logs/madhavi/PRs/cephadm/release/


