### PR TITLE
../test_bucket_lifecycle_object_expiration.py : LC to work in pacific

### DIFF
--- a/rgw/v2/tests/s3_swift/test_bucket_lifecycle_object_expiration.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_lifecycle_object_expiration.py
@@ -61,9 +61,12 @@ def test_exec(config):
     ceph_conf.set_to_ceph_conf('global', ConfigOpts.rgw_lc_debug_interval, str(config.rgw_lc_debug_interval))
     ceph_version = utils.exec_shell_cmd("ceph version")
     op = ceph_version.split()
-    for i in op:
-        if i in ['nautilus','pacific']:
-                ceph_conf.set_to_ceph_conf('global', ConfigOpts.rgw_lc_max_worker, str(config.rgw_lc_max_worker))
+    if "pacific" in op:
+        commands = [f"ceph config set client.rgw rgw_lc_max_worker {config.rgw_lc_max_worker}",
+                                    "ceph config set client.rgw rgw_lc_debug_interval 30"]
+        for command in commands: utils.exec_shell_cmd(command)
+    if 'nautilus' in op:
+            ceph_conf.set_to_ceph_conf('global', ConfigOpts.rgw_lc_max_worker, str(config.rgw_lc_max_worker))
     log.info('trying to restart services')
     srv_restarted = rgw_service.restart()
     time.sleep(30)


### PR DESCRIPTION
ceph config option instead of the ceph.conf to set the lc_debug_interval, makes the LC scripts work in Pacific.


Logs http://pastebin.test.redhat.com/954635
Signed-off-by: viduship <vimishra@redhat.com>