### PR TITLE
added support of 204 http response

### DIFF
--- a/rgw/v2/tests/s3_swift/test_bucket_policy_ops.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_policy_ops.py
@@ -97,7 +97,7 @@ def test_exec(config):
         raise TestExecError("Resource execution failed: bucket creation faield")
     if put_policy is not None:
         response = HttpResponseParser(put_policy)
-        if response.status_code == 200:
+        if response.status_code == 200 or response.status_code == 204:
             log.info('bucket policy created')
         else:
             raise TestExecError("bucket policy creation failed")


### PR DESCRIPTION
In 5.0 http is sending 204 response for bucket policy.

following is the log info from 5.0 cluster

debug 2021-05-11T06:27:12.483+0000 7f0398fa4700  2 req 30 0.000999978s s3:put_bucket_policy verifying op params
debug 2021-05-11T06:27:12.483+0000 7f0398fa4700  2 req 30 0.000999978s s3:put_bucket_policy pre-executing
debug 2021-05-11T06:27:12.483+0000 7f0398fa4700  2 req 30 0.000999978s s3:put_bucket_policy executing
debug 2021-05-11T06:27:12.621+0000 7f038ff92700  2 req 30 0.138996869s s3:put_bucket_policy completing
debug 2021-05-11T06:27:12.621+0000 7f038ff92700  2 req 30 0.138996869s s3:put_bucket_policy op status=1902
debug 2021-05-11T06:27:12.621+0000 7f038ff92700  2 req 30 0.138996869s s3:put_bucket_policy http status=204
debug 2021-05-11T06:27:12.621+0000 7f038ff92700  1 ====== req done req=0x7f04dd574620 op status=1902 http_status=204 latency=0.138996869s ======
debug 2021-05-11T06:27:12.621+0000 7f038ff92700  1 beast: 0x7f04dd574620: 10.8.128.5 - tenant1$t_user1 [11/May/2021:06:27:12.482 +0000] "PUT /my-new-bucket/?policy HTTP/1.1" 204 0 - - - latency=0.138996869s
debug 2021-05-11T06:27:12.637+0000 7f04a49bb700  2 DELETED::tj1[adacbe1b-02b4-41b8-b11d-0d505b442ed4.225280.2]):obj37243 wp_thrd: 1, 0
debug 2021-05-11T06:27:12.761+0000 7f04a39b9700  2 DELETED::tj1[adacbe1b-02b4-41b8-b11d-0d505b442ed4.225280.2]):obj37085 wp_thrd: 1, 2
debug 2021-05-11T06:27:12.839+0000 7f04a41ba700  2 DELETED::tj1[adacbe1b-02b4-41b8-b11d-0d505b442ed4.225280.2]):obj37043 wp_thrd: 1, 1
debug 2021-05-11T06:27:12.906+0000 7f04a49bb700  2 DELETED::tj1[adacbe1b-02b4-41b8-b11d-0d505b442ed4.225280.2]):obj38111 wp_thrd: 1, 0
debug 2021-05-11T06:27:12.989+0000 7f04a39b9700  2 DELETED::tj1[adacbe1b-02b4-41b8-b11d-0d505b442ed4.225280.2]):obj3805 wp_thrd: 1, 2



Following test cases are failed on 5.0 due to response code 204

http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1620650361913/Bucket_policy_tests_0.log
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1620650361913/Bucket_policy_tests_1.log
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1620650361913/Bucket_policy_tests_2.log