### PR TITLE
Added user delete function to avoid user duplication in swift

### DIFF
--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -354,9 +354,12 @@ def put_get_bucket_lifecycle_test(bucket, rgw_conn, rgw_conn2, life_cycle_rule, 
             raise TestExecError('LC is not applied')
 
 
-def remove_user(user_info, cluster_name='ceph'):
+def remove_user(user_info, cluster_name='ceph', tenant=False):
     log.info('Removing user')
-    cmd = 'radosgw-admin user rm --purge-keys --purge-data --uid=%s' % (user_info['user_id'])
+    if tenant:
+        cmd = 'radosgw-admin user rm --purge-keys --purge-data --uid=%s --tenant=%s' % (user_info['user_id'], tenant)
+    else:
+        cmd = 'radosgw-admin user rm --purge-keys --purge-data --uid=%s' % (user_info['user_id'])
     out = utils.exec_shell_cmd(cmd)
     return out
 

--- a/rgw/v2/tests/s3_swift/test_swift_basic_ops.py
+++ b/rgw/v2/tests/s3_swift/test_swift_basic_ops.py
@@ -178,10 +178,12 @@ def test_exec(config):
             log.info('deleting swift container')
             rgw.delete_container(container_name)
 
+
     # check for any crashes during the execution
     crash_info=reusable.check_for_crash()
     if crash_info:
         raise TestExecError("ceph daemon crash found!")
+    reusable.remove_user(tenant_user_info, tenant=tenant)
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
Some TCs are failing due to same RGW user

Following is the failed suite link
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1622444603647

To avoid above failure, Deleted RGW user after completing TC

Following are the log links with tenanted as well as non tenanted user
Non-tenanted user
http://pastebin.test.redhat.com/967581

Tenanted user
http://pastebin.test.redhat.com/967582

Signed-off-by: udaysk23 <ukurundw@redhat.com>