### PR TITLE
Adds support of setting 5.x config parameter

### DIFF
--- a/rgw/v2/lib/rgw_config_opts.py
+++ b/rgw/v2/lib/rgw_config_opts.py
@@ -87,12 +87,18 @@ class CephConfOp(FileOps, ConfigParse):
                 option:
                 value:
         """
-        log.info('adding to ceph conf')
-        log.info('section: %s' % section)
-        log.info('option: %s' % option)
-        log.info('value: %s' % value)
-        cfg = self.set(section, option, value)
-        self.add_data(cfg)
+        ceph_version_id, ceph_version_name = utils.get_ceph_version()
+        if ceph_version_name == 'pacific':
+            cmd = 'sudo ceph config set {section} {option} {value}'.format(section=section, option=option, value=value)
+            executed = utils.exec_shell_cmd(cmd)
+            return executed
+        else:
+            log.info('adding to ceph conf')
+            log.info('section: %s' % section)
+            log.info('option: %s' % option)
+            log.info('value: %s' % value)
+            cfg = self.set(section, option, value)
+            self.add_data(cfg)
 
 
 class CephConfigSet:


### PR DESCRIPTION
Adds support of setting 5.x config parameter

Following is the log link of successful run
http://pastebin.test.redhat.com/967662

Following is the config dump output
(venv) [root@ceph-uday-1622453017721-node5-osd-rgw s3_swift]# ceph config dump
WHO                                                                  MASK  LEVEL     OPTION                                 VALUE                                                                                                                         RO
global                                                                     basic     container_image                        registry-proxy.engineering.redhat.com/rh-osbs/rhceph@sha256:7f0955515463a058506a1fce036127fd44c7e74d0113178d0400bba67872ba1a  * 
global                                                                     advanced  rgw_swift_versioning_enabled           true                                                                                                                            
  mon                                                                      advanced  auth_allow_insecure_global_id_reclaim  false                                                                                                                           
  mon                                                                      advanced  public_network                         10.0.208.0/22                                                                                                                 * 
  mgr                                                                      advanced  mgr/cephadm/container_init             True                                                                                                                          * 
  mgr                                                                      advanced  mgr/cephadm/migration_current          2                                                                                                                             * 
  mgr                                                                      advanced  mgr/cephadm/registry_password          MTQj5t3n5K86p3gH                                                                                                              * 
  mgr                                                                      advanced  mgr/cephadm/registry_url               registry.redhat.io                                                                                                            * 
  mgr                                                                      advanced  mgr/cephadm/registry_username          qa@redhat.com                                                                                                                 * 
  mgr                                                                      advanced  mgr/dashboard/ssl_server_port          8443                                                                                                                          * 
  mgr                                                                      advanced  mgr/orchestrator/orchestrator          cephadm                                                                                                                         
    client.rgw.rgw.all.ceph-uday-1622453017721-node5-osd-rgw.vbvqcv        basic     rgw_frontends                          beast port=80 


Signed-off-by: udaysk23 <ukurundw@redhat.com>