### PR TITLE
improving ceph config class

### DIFF
--- a/rgw/v2/lib/rgw_config_opts.py
+++ b/rgw/v2/lib/rgw_config_opts.py
@@ -103,8 +103,10 @@ class CephConfigSet:
         self.prefix = "sudo ceph config set"
         self.who = "client.rgw"  # naming convention as ceph conf
 
-    def set(self, key, value):
+    def set_to_ceph_cli(self, key, value):
         log.info('setting key and value using ceph config set cli')
+        self.prefix = "sudo ceph config set"
+        self.who = "client.rgw"  # naming convention as ceph conf
         if value is True:
             value = "true"
         log.info(f'got key: {key}')
@@ -122,18 +124,20 @@ class CephConfigSet:
 
 class CephConfOp(CephConfFileOP, CephConfigSet):
     def __init__(self) -> None:
-        super().__init__(self, CephConfFileOP)
-        super().__init__(self, CephConfigSet)
+        super().__init__()
 
-    
+
     def set_to_ceph_conf(self, section, option, value=None):
-        version_id, version_name  = utils.get_ceph_version()
-        log.info(f"ceph version id {version_id}")
+        version_id, version_name = utils.get_ceph_version()
+        log.info(f"ceph version id: {version_id}")
         log.info(f"version name: {version_name}")
         
-        if version_id < float(16):
+        if version_name in ['luminous','nautilus']:
             log.info("using ceph_conf to config values")
             self.set_to_ceph_conf_file(section, option, value)
         else:
             log.info("using ceph config cli to set the config values")
-            self.set_to_conf(section, option, value)
+            log.info(option)
+            log.info(value)
+            self.set_to_ceph_cli(option, value)
+

--- a/rgw/v2/lib/rgw_config_opts.py
+++ b/rgw/v2/lib/rgw_config_opts.py
@@ -34,7 +34,8 @@ class ConfigOpts(object):
     rgw_s3_auth_use_sts = "rgw_s3_auth_use_sts"
 
 
-class CephConfOp(FileOps, ConfigParse):
+
+class CephConfFileOP(FileOps, ConfigParse):
     """
         To check/create ceph.conf file
     """
@@ -78,7 +79,7 @@ class CephConfOp(FileOps, ConfigParse):
         new_section = self.add_section(section)
         self.add_data(new_section)
 
-    def set_to_ceph_conf(self, section, option, value=None):
+    def set_to_ceph_conf_file(self, section, option, value=None):
         """
             This function is to add section, option, value to the ceph.conf file
 
@@ -116,3 +117,23 @@ class CephConfigSet:
         config_set = utils.exec_shell_cmd(cmd)
         if config_set is False:
             raise InvalidCephConfigOption("Invalid ceph config options")
+
+
+
+class CephConfOp(CephConfFileOP, CephConfigSet):
+    def __init__(self) -> None:
+        super().__init__(self, CephConfFileOP)
+        super().__init__(self, CephConfigSet)
+
+    
+    def set_to_ceph_conf(self, section, option, value=None):
+        version_id, version_name  = utils.get_ceph_version()
+        log.info(f"ceph version id {version_id}")
+        log.info(f"version name: {version_name}")
+        
+        if version_id < float(16):
+            log.info("using ceph_conf to config values")
+            self.set_to_ceph_conf_file(section, option, value)
+        else:
+            log.info("using ceph config cli to set the config values")
+            self.set_to_conf(section, option, value)

--- a/rgw/v2/tests/s3_swift/test_sts_using_boto.py
+++ b/rgw/v2/tests/s3_swift/test_sts_using_boto.py
@@ -32,7 +32,7 @@ from v2.utils.log import configure_logging
 import v2.utils.utils as utils
 from v2.utils.utils import RGWService
 from v2.tests.s3_swift import reusable
-from v2.lib.rgw_config_opts import CephConfigSet, ConfigOpts
+from v2.lib.rgw_config_opts import CephConfOp, ConfigOpts
 from v2.utils.utils import HttpResponseParser
 import traceback
 import argparse
@@ -50,7 +50,7 @@ def test_exec(config):
     io_info_initialize = IOInfoInitialize()
     basic_io_structure = BasicIOInfoStructure()
     io_info_initialize.initialize(basic_io_structure.initial())
-    ceph_config_set = CephConfigSet()
+    ceph_config_set = CephConfOp()
     rgw_service = RGWService()
 
     # create users
@@ -60,8 +60,8 @@ def test_exec(config):
     user1, user2 = users_info[0], users_info[1]
     log.info('adding sts config to ceph.conf')
     sesison_encryption_token = 'abcdefghijklmnoq'
-    ceph_config_set.set(ConfigOpts.rgw_sts_key, sesison_encryption_token)
-    ceph_config_set.set(ConfigOpts.rgw_s3_auth_use_sts, True)
+    ceph_config_set.set_to_ceph_conf('global', ConfigOpts.rgw_sts_key, sesison_encryption_token)
+    ceph_config_set.set_to_ceph_conf('global', ConfigOpts.rgw_s3_auth_use_sts, True)
     srv_restarted = rgw_service.restart()
     time.sleep(30)
     if srv_restarted is False:


### PR DESCRIPTION
renamed `CephConfOp` to `CephConfFileOP` and created another class with the existing class name `CephConfOp` to minimise the code changes needed in test scripts 

ceph config set will be used for the ceph versions which are greater than `16.x` and lesser versions will use ceph_config_file to set the values. 


Signed-off-by: rakeshgm <rakeshgm@redhat.com>