### PR TITLE
Added log message instead of test result

### DIFF
--- a/rgw/v2/tests/s3_swift/test_swift_basic_ops.py
+++ b/rgw/v2/tests/s3_swift/test_swift_basic_ops.py
@@ -162,7 +162,7 @@ def test_exec(config):
                 num_obj_old = num_obj_old[0].get('usage').get('rgw.main').get('num_objects')
                 version_count_from_config = (config.objects_count * config.version_count) - config.objects_count
                 if (num_obj_current == config.objects_count) and (num_obj_old == version_count_from_config):
-                    test_info.success_status('test passed')
+                    log.info("objects and versioned obbjects are correct")
                 else:
                     test_info.failed_status('test failed')
         


### PR DESCRIPTION
Script is not iterating due to https://github.com/red-hat-storage/ceph-qe-scripts/blob/326b66353520d3ebfe58a6448f41162a85efc33c/rgw/v2/tests/s3_swift/test_swift_basic_ops.py#L165

Failure is occurring from cephci side since framework looks for "test_info.success_status('test passed')" and once cephci gets "success_status" method, it is not iterating further.

http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1623996623198/swift_versioning_tests_0.log

In above logs, script should iterate 3 times since container count is 3 but it has iterated only once.

I have added log info to avoid above failure and iterate script as expected.

Signed-off-by: udaysk23 <ukurundw@redhat.com>