### PR TITLE
RHCEPH-228: Fixing attribute error due to typo

### DIFF
--- a/rgw/v2/tests/s3_swift/test_swift_basic_ops.py
+++ b/rgw/v2/tests/s3_swift/test_swift_basic_ops.py
@@ -186,7 +186,7 @@ def test_exec(config):
                     test_info.failed_status(msg)
                     raise TestExecError(msg)
 
-        elif config.config.large_object_upload is True:
+        elif config.large_object_upload is True:
             container_name = utils.gen_bucket_name_from_userid(user_info['user_id'], rand_no=cc)
             container = swiftlib.resource_op({'obj': rgw,
                                               'resource': 'put_container',


### PR DESCRIPTION
## Description

RHCS 5.0 Object Tier-0 test suite failed with the below error

```
2021-06-21 22:50:42,862 INFO: 'Config' object has no attribute 'config'
2021-06-21 22:50:42,862 INFO: Traceback (most recent call last):
  File "/home/cephuser/rgw-tests/ceph-qe-scripts/rgw/v2/tests/s3_swift/test_swift_basic_ops.py", line 298, in <module>
    test_exec(config)
  File "/home/cephuser/rgw-tests/ceph-qe-scripts/rgw/v2/tests/s3_swift/test_swift_basic_ops.py", line 189, in test_exec
    elif config.config.large_object_upload is True:
AttributeError: 'Config' object has no attribute 'config'
```

This PR fixes this issue.

Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>