### PR TITLE
Fix RGW endpoint when SSL is enabled

### DIFF
--- a/rgw/v2/lib/s3/auth.py
+++ b/rgw/v2/lib/s3/auth.py
@@ -97,6 +97,7 @@ class Auth(object):
             aws_secret_access_key=self.secret_key,
             endpoint_url=self.endpoint_url,
             config=additional_config,
+            verify=False,
             aws_session_token=self.session_token if self.session_token else None,
         )
         return rgw

--- a/rgw/v2/lib/swift/auth.py
+++ b/rgw/v2/lib/swift/auth.py
@@ -19,14 +19,14 @@ class Auth(object):
     1. do_auth()
     """
 
-    def __init__(self, user_info):
+    def __init__(self, user_info, is_secure=False):
         """
         Initializes the user_info variables
         """
         self.secret_key = user_info["key"]
         self.hostname = socket.gethostname()
         self.port = int(utils.get_radosgw_port_no())
-        self.is_secure = False
+        self.is_secure = is_secure
         self.user_id = user_info["user_id"]
 
     def do_auth(self):
@@ -42,9 +42,12 @@ class Auth(object):
         # user = 'tenant3$tuffy3:swift'
         # key = 'm4NsRGjghOpUPX3OZZFeIYUylNjO22lMVDXATnNi' -- secret key
 
+        proto = "https" if self.is_secure else "http"
+
         rgw = swiftclient.Connection(
             user=self.user_id,
             key=self.secret_key,
-            authurl="http://%s:%s/auth" % (self.hostname, self.port),
+            insecure=True,
+            authurl=f"{proto}://{self.hostname}:{self.port}/auth",
         )
         return rgw

--- a/rgw/v2/tests/s3_swift/test_swift_basic_ops.py
+++ b/rgw/v2/tests/s3_swift/test_swift_basic_ops.py
@@ -130,7 +130,7 @@ def test_exec(config):
         tenant_name=tenant, user_id=user_names[0], displayname=user_names[0]
     )
     user_info = umgmt.create_subuser(tenant_name=tenant, user_id=user_names[0])
-    auth = Auth(user_info)
+    auth = Auth(user_info, config.ssl)
     rgw = auth.do_auth()
 
     for cc in range(config.container_count):

--- a/rgw/v2/tests/s3_swift/test_swift_bulk_delete.py
+++ b/rgw/v2/tests/s3_swift/test_swift_bulk_delete.py
@@ -96,7 +96,7 @@ def test_exec(config):
         tenant_name=tenant, user_id=user_names[1], displayname=user_names[1]
     )
     user_info = umgmt.create_subuser(tenant_name=tenant, user_id=user_names[1])
-    auth = Auth(user_info)
+    auth = Auth(user_info, config.ssl)
     rgw = auth.do_auth()
 
     container_name = utils.gen_bucket_name_from_userid(user_info["user_id"], rand_no=0)


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

RGW endpoint URL was set incorrectly. In this PR, the approach to retrieve the endpoint is modified. Also, disabling SSL certification verification.

__Logs__
http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/rgw_ssl/
http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/rgw_nossl/

__Required by__
https://github.com/red-hat-storage/cephci/pull/679