### PR TITLE
rgw/v2/utils/utils: fix systemd unit file name for nautilus

### DIFF
--- a/rgw/v2/utils/utils.py
+++ b/rgw/v2/utils/utils.py
@@ -191,8 +191,17 @@ class SystemCTL:
     class for constructing systemctl command
     """
 
-    def __init__(self, unit="ceph-radosgw.target"):
-        self.unit = unit
+    """
+    TODO : The below logic should be further enhanced to support running
+    multiple RGWs on the same node.
+    """
+
+    def __init__(self, unit="ceph-radosgw@rgw.`hostname -s`.rgw0.service"):
+        _, self.ceph_version_name = get_ceph_version()
+        if self.ceph_version_name == "luminous":
+            self.unit = "ceph-radosgw.target"
+        else:
+            self.unit = unit
 
     def cmd(self, option):
         """


### PR DESCRIPTION
Signed-off-by: Gaurav Sitlani <gsitlani@redhat.com>

Fix systemd unit file name for nautilus :

- utils.py

Logs-

- http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-BELS24/
- http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-6DQBTX/
- http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-5FEYUF/
- http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-TUS4GX/