### PR TITLE
sts: use sts related policy doc from yaml

### DIFF
--- a/rgw/v2/lib/resource_op.py
+++ b/rgw/v2/lib/resource_op.py
@@ -213,6 +213,7 @@ class Config(object):
             "large_object_download", False
         )
         self.local_file_delete = self.doc["config"].get("local_file_delete", False)
+        self.sts = self.doc["config"].get("sts")
         self.ceph_conf = self.doc["config"].get("ceph_conf")
         self.gc_verification = self.doc["config"].get("gc_verification", False)
         self.rgw_gc_obj_min_wait = self.doc["config"].get("rgw_gc_obj_min_wait", False)

--- a/rgw/v2/tests/s3_swift/configs/test_sts_using_boto.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_using_boto.yaml
@@ -1,10 +1,33 @@
 # polarion test case id: CEPH-83572938
 config:
- bucket_count: 2
- objects_count: 5
- objects_size_range:
-  min: 5
-  max: 15
- test_ops:
-      create_bucket: true
-      create_object: true
+     bucket_count: 2
+     objects_count: 5
+     objects_size_range:
+          min: 5
+          max: 15
+     test_ops:
+          create_bucket: true
+          create_object: true
+     sts:
+          policy_document:
+               "Version": "2012-10-17"
+               "Statement":
+                    [
+                         {
+                              "Effect": "Allow",
+                              "Principal":
+                                   {
+                                        "AWS":
+                                             ["arn:aws:iam:::user/<user_name>"],
+                                   },
+                              "Action": ["sts:AssumeRole"],
+                         },
+                    ]
+          role_policy:
+               "Version": "2012-10-17"
+               "Statement":
+                    {
+                         "Effect": "Allow",
+                         "Action": "s3:*",
+                         "Resource": "arn:aws:s3:::*",
+                    }


### PR DESCRIPTION
STS related policy and policy docs can be set from yaml. 

[STS Test Log](http://magna002.ceph.redhat.com/ceph-qe-logs/rakesh/ceph_qe_scripts_PR/pr_sts/test_sts_using_boto.console.log)

Signed-off-by: rakeshgm <rakeshgm@redhat.com>