### PR TITLE
test_sts_using_boto: fix for automation failure

### DIFF
--- a/rgw/v2/lib/s3/auth.py
+++ b/rgw/v2/lib/s3/auth.py
@@ -116,6 +116,7 @@ class Auth(object):
             aws_secret_access_key=self.secret_key,
             endpoint_url=self.endpoint_url,
             region_name="",
+            verify=False,
         )
 
         return rgw
@@ -133,6 +134,7 @@ class Auth(object):
             aws_secret_access_key=self.secret_key,
             endpoint_url=self.endpoint_url,
             region_name="",
+            verify=False,
         )
 
         return sts_client

--- a/rgw/v2/tests/s3_swift/test_sts_using_boto.py
+++ b/rgw/v2/tests/s3_swift/test_sts_using_boto.py
@@ -76,7 +76,7 @@ def test_exec(config):
     else:
         log.info("RGW service restarted")
 
-    auth = Auth(user1)
+    auth = Auth(user1, ssl=config.ssl)
     iam_client = auth.do_auth_iam_client()
 
     policy_document = json.dumps(config.sts["policy_document"]).replace(" ", "")
@@ -114,7 +114,7 @@ def test_exec(config):
     log.info("put_policy_response")
     log.info(put_policy_response)
 
-    auth = Auth(user2)
+    auth = Auth(user2, ssl=config.ssl)
     sts_client = auth.do_auth_sts_client()
 
     log.info("assuming role")
@@ -134,7 +134,7 @@ def test_exec(config):
     }
 
     log.info("got the credentials after assume role")
-    s3client = Auth(assumed_role_user_info)
+    s3client = Auth(assumed_role_user_info, ssl=config.ssl)
     s3_client_rgw = s3client.do_auth()
 
     io_info_initialize.initialize(basic_io_structure.initial())


### PR DESCRIPTION
Signed-off-by: Gaurav Sitlani <gsitlani@redhat.com>

test_sts_using_boto: fix for automation failure

Failure log :- 

- http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-F515P7/STS_Tests_0.log

Test Passed Logs :- 

- From Non SSL configuration environment - https://privatebin-it-iso.int.open.paas.redhat.com/?a0056bfe171924a5#AdYuSnCCePxB2aH73mSDJbzb7AP5vCEVoB8mtpRGpJnh
- From SSL configuration environment - https://privatebin-it-iso.int.open.paas.redhat.com/?94ef31abf676b3b2#67BAWkbs3GWPMNAMEbSfXmwpeHAB2769PuFrkhovjRSk