### PR TITLE
AttributeError: 'bool' object has no attribute 'split'

### DIFF
--- a/rgw/v2/utils/utils.py
+++ b/rgw/v2/utils/utils.py
@@ -329,10 +329,15 @@ def get_radosgw_port_no():
                 return config.split("=")[-1]
 
     op = exec_shell_cmd("sudo netstat -nltp | grep radosgw")
-    log.info("output: %s" % op)
+    log.info(f"output: {op}")
+
+    if not op:
+        raise Exception("Unable to determine the RADOSGW port.")
+
     x = op.split(" ")
     port = [i for i in x if ":" in i][0].split(":")[1]
-    log.info("radosgw is running in port: %s" % port)
+    log.info(f"RADOSGW port is: {port}")
+
     return port
 
 


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

## Description
In this PR, we handle and throw a proper execption when the RGW daemon port cannot be found.

__Error__
```
2021-11-23 06:46:19,592 INFO: Traceback (most recent call last):
  File "/home/cephuser/rgw-tests/ceph-qe-scripts/rgw/v2/tests/s3_swift/test_multitenant_user_access.py", line 174, in <module>
    config.read()
  File "/home/cephuser/rgw-tests/ceph-qe-scripts/rgw/v2/lib/resource_op.py", line 235, in read
    frontend_config = Frontend()
  File "/home/cephuser/rgw-tests/ceph-qe-scripts/rgw/v2/lib/frontend_configure.py", line 62, in __init__
    RGWSectionOptions.__init__(self)
  File "/home/cephuser/rgw-tests/ceph-qe-scripts/rgw/v2/lib/frontend_configure.py", line 53, in __init__
    self,
  File "/home/cephuser/rgw-tests/ceph-qe-scripts/rgw/v2/lib/frontend_configure.py", line 25, in __init__
    self._non_ssl_port = utils.get_radosgw_port_no()
  File "/home/cephuser/rgw-tests/ceph-qe-scripts/rgw/v2/utils/utils.py", line 333, in get_radosgw_port_no
    x = op.split(" ")
AttributeError: 'bool' object has no attribute 'split'
```
