### PR TITLE
fix false positive in sync status

### DIFF
--- a/rgw/v2/lib/sync_status.py
+++ b/rgw/v2/lib/sync_status.py
@@ -20,7 +20,7 @@ def sync_status(retry=10, delay=60):
     check_sync_status = utils.exec_shell_cmd(cmd)
 
     # check for 'failed' or 'ERROR' in sync status.
-    if "failed|ERROR" in check_sync_status:
+    if "failed" in check_sync_status or "ERROR" in check_sync_status:
         log.info("checking for any sync error")
         cmd = "sudo radosgw-admin sync error list"
         sync_error_list = utils.exec_shell_cmd(cmd)
@@ -33,7 +33,7 @@ def sync_status(retry=10, delay=60):
     )
     if "behind" in check_sync_status or "recovering" in check_sync_status:
         log.info("sync is in progress")
-        log.info("sleep of 30 secs for sync to complete")
+        log.info("sleep of {delay} secs for sync to complete")
         for retry_count in range(retry):
             time.sleep(delay)
             cmd = "sudo radosgw-admin sync status"


### PR DESCRIPTION
Signed-off-by: MadhaviKasturi <mkasturi@redhat.com>

Fix the false positive. 
snippet:
      zonegroup ce0e5776-f4b8-4ff5-96da-dd41ae2b49c5 (US)
           zone 8575f98f-94b6-43bc-afd6-2893bf7bc18d (US_EAST)
zonegroup features enabled: resharding
  metadata sync no sync (zone is master)
      data sync source: a2b2ac6c-2d7b-42fe-9f9d-755475341125 (US_WEST)
                        failed to retrieve sync info: (5) Input/output error

2021-12-05 12:20:41,570 INFO: No errors or failures in sync status

logs:
[before fix ](http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-I7GIB5/Buckets_and_Objects_test_0.log)
[after fix ](http://magna002.ceph.redhat.com/ceph-qe-logs/madhavi/PRs/sync_error/sync_error_list_console.log)