### PR TITLE
fix radoslist check

### DIFF
--- a/rgw/v2/tests/s3_swift/test_bucket_listing.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_listing.py
@@ -278,8 +278,7 @@ def test_exec(config):
             )
             cmd = "radosgw-admin bucket radoslist | grep ERROR"
             radoslist_all_error = utils.exec_shell_cmd(cmd)
-            print(radoslist_all_error)
-            if radoslist_all_error is False:
+            if radoslist_all_error:
                 raise TestExecError("ERROR in radoslist command")
 
         if config.test_ops.get("delete_bucket_object", False):


### PR DESCRIPTION
Signed-off-by: MadhaviKasturi <mkasturi@redhat.com>
Fixes the false positive
snippet:
2022-01-07 06:57:14,876 INFO: executing cmd: radosgw-admin bucket radoslist | grep ERROR
2022-01-07 06:57:15,272 ERROR: cmd execution failed
2022-01-07 06:57:15,273 ERROR: error:  
returncode: 1
False
2022-01-07 06:57:15,273 INFO: ERROR in radoslist command

(venv) [root@ceph-kafka-fx0koy-node5 s3_swift]# radosgw-admin bucket radoslist | grep ERROR
(venv) [root@ceph-kafka-fx0koy-node5 s3_swift]# 

PFA, the logs at http://magna002.ceph.redhat.com/ceph-qe-logs/madhavi/PRs/fix_radoslist/ 