### PR TITLE
Added Missing yaml file required for bucket sync crash command

### DIFF
--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_sync_cmd_crash.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_sync_cmd_crash.yaml
@@ -1,0 +1,21 @@
+# upload type: non multipart
+# script: test_Mbuckets_with_Nobjects.py
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 2
+  objects_size_range:
+    min: 5M
+    max: 15M
+  bucket_sync_crash: true
+  test_ops:
+    create_bucket: true
+    create_object: true
+    download_object: false
+    delete_bucket_object: false
+    sharding:
+      enable: false
+      max_shards: 0
+    compression:
+      enable: false
+      type: zlib


### PR DESCRIPTION
Added Missing yaml file required for bucket sync crash command

The successfull log link is already attached in following PR
https://github.com/red-hat-storage/ceph-qe-scripts/pull/218

Signed-off-by: udaysk23 <ukurundw@redhat.com>