### PR TITLE
Renames name from cluster_type to dbr_scenario in yaml file

### DIFF
--- a/rgw/v2/tests/s3_swift/multisite_configs/test_check_sharding_enabled_brownfield.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_check_sharding_enabled_brownfield.yaml
@@ -1,3 +1,3 @@
 config:
-  cluster_type: brownfield
+  dbr_scenario: brownfield
   enable_sharding: true

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_check_sharding_enabled_greenfield.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_check_sharding_enabled_greenfield.yaml
@@ -1,2 +1,2 @@
 config:
-  cluster_type: greenfield
+  dbr_scenario: greenfield

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_dynamic_resharding_greenfield.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_dynamic_resharding_greenfield.yaml
@@ -1,13 +1,13 @@
 config:
   user_count: 1
   bucket_count: 1
-  objects_count: 1000
+  objects_count: 100
   dynamic_resharding: true
   objects_size_range:
     min: 15K
     max: 5M
   dbr_scenario: greenfield
-  max_objects_per_shard: 5
+  max_objects_per_shard: 1
   local_file_delete: true
   test_ops:
     create_bucket: true

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_manual_resharding_greenfield.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_manual_resharding_greenfield.yaml
@@ -3,7 +3,7 @@
 config:
   user_count: 1
   bucket_count: 1
-  objects_count: 1000
+  objects_count: 100
   manual_resharding: true
   shards: 997
   objects_size_range:


### PR DESCRIPTION
Renames name from "cluster_type" to "dbr_scenario" in yaml file and reduced object count in DBR greenfield yaml due to limitation of cephci
Signed-off-by: udaysk23 <ukurundw@redhat.com>