### PR TITLE
Renames name from cluster_type to dbr_scenario in DBR test script

### DIFF
--- a/rgw/v2/tests/s3_swift/test_check_sharding_enabled.py
+++ b/rgw/v2/tests/s3_swift/test_check_sharding_enabled.py
@@ -44,7 +44,7 @@ def test_exec(config):
     ceph_conf = CephConfOp()
     rgw_service = RGWService()
 
-    if config.cluster_type == "brownfield":
+    if config.dbr_scenario == "brownfield":
         log.info("Check sharding is enabled or not")
         cmd = "radosgw-admin zonegroup get"
         out = utils.exec_shell_cmd(cmd)
@@ -81,7 +81,7 @@ def test_exec(config):
             else:
                 raise TestExecError("sharding has not enabled")
 
-    if config.cluster_type == "greenfield":
+    if config.dbr_scenario == "greenfield":
         log.info("Check sharding is enabled or not")
         cmd = "radosgw-admin zonegroup get"
         out = utils.exec_shell_cmd(cmd)


### PR DESCRIPTION
Due to `cluster_type` parameter `dbr feature check` TC got failed
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-XCOEQX/Verify_DBR_feature_0.log

Renamed `cluster_type` to `dbr_scenario` in DBR test script
Signed-off-by: udaysk23 <ukurundw@redhat.com>