### PR TITLE
fix create rest admin user

### DIFF
--- a/rgw/v2/lib/admin.py
+++ b/rgw/v2/lib/admin.py
@@ -97,7 +97,7 @@ class UserMgmt(object):
             write_user_info = AddUserInfo()
             basic_io_structure = BasicIOInfoStructure()
             log.info("cluster name: %s" % cluster_name)
-            cmd = f"radosgw-admin user info --uid={user_id} --cluster {cluster_name}"
+            cmd = f"radosgw-admin user create --uid='{user_id}' --display-name='{displayname}' --cluster {cluster_name}"
             log.info("cmd to execute:\n%s" % cmd)
             variable = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
             time.sleep(10)


### PR DESCRIPTION
Signed-off-by: MadhaviKasturi <mkasturi@redhat.com>

issue:
2022-01-29 14:34:18,279 INFO: cmd to execute:
radosgw-admin user info --uid=admin_user_vbz --cluster ceph
could not fetch user info: no user info saved
2022-01-29 14:34:28,291 INFO: cmd to execute:
radosgw-admin caps add --uid=admin_user_vbz --caps="users=*" --cluster ceph
could not add caps: user info was not populated
failure [log](https://159.23.92.24/job/tier-x/40/artifact/logs/6xker-40/test_REST_api_operation_0.log)

this PR fixes the user creation
[log](http://magna002.ceph.redhat.com/ceph-qe-logs/madhavi/PRs/rest_api/nautilus_console.log) 