### PR TITLE
Fix black failures

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ skipsdist = True
 [testenv]
 deps =
     isort
-    black
+    black == 21.9b0
     yamllint
 
 commands =


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

This repository contains some part of code that works only with `py2`. `Black` has removed support for `py2` from `22.0` hence we cannot use versions greater than `21.9b0`. This PR forces tox to use only `black==21.9b0`