### PR TITLE
Pinning the version of click to 8.0.4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ deps =
     isort
     black == 21.9b0
     yamllint
+    click == 8.0.4
 
 commands =
     isort -c .


### PR DESCRIPTION
This is to avoid failures due to -
<ghub>/psf/black/issues/2964

Signed-off-by: Vasishta <vashastr@redhat.com>