### PR TITLE
Test bucket sync status in a multi-site environment.

### DIFF
--- a/rgw/v2/lib/resource_op.py
+++ b/rgw/v2/lib/resource_op.py
@@ -231,6 +231,7 @@ class Config(object):
         self.ceph_conf = self.doc["config"].get("ceph_conf")
         self.gc_verification = self.doc["config"].get("gc_verification", False)
         self.bucket_sync_crash = self.doc["config"].get("bucket_sync_crash", False)
+        self.bucket_sync_status = self.doc["config"].get("bucket_sync_status", False)
         self.bucket_sync_run = self.doc["config"].get("bucket_sync_run", False)
         self.bucket_stats = self.doc["config"].get("bucket_stats", False)
         self.header_size = self.doc["config"].get("header_size", False)

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_sync_status.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_sync_status.yaml
@@ -1,0 +1,21 @@
+# upload type: non multipart
+# script: test_Mbuckets_with_Nobjects.py
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 10
+  objects_size_range:
+    min: 5M
+    max: 15M
+  bucket_sync_status: true
+  test_ops:
+    create_bucket: true
+    create_object: true
+    download_object: false
+    delete_bucket_object: false
+    sharding:
+      enable: false
+      max_shards: 0
+    compression:
+      enable: false
+      type: zlib

--- a/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
+++ b/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
@@ -338,6 +338,12 @@ def test_exec(config):
                             raise TestExecError(
                                 "Command is throwing error while running bucket sync run"
                             )
+
+                    if config.bucket_sync_status:
+                        out = utils.wait_till_bucket_synced(bucket.name)
+                        if not out:
+                            log.info("Bucket sync is not caught up with source.")
+
                     if config.bucket_sync_crash:
                         is_primary = utils.is_cluster_primary()
                         if is_primary is False:


### PR DESCRIPTION
This test tests the bucket sync status for a given bucket in a multisite environment and also performs a bucket sync run in case the bucket sync status is not caught up with the source zone.
**Logs:** 

1. When bucket  sync status is behind a few shards  and gets caught up by executing "radosgw-admin bucket sync run."
http://pastebin.test.redhat.com/1053287

2. when bucket sync status reports caught up with the source zone:
http://pastebin.test.redhat.com/1053288

3.  Recent logs: http://pastebin.test.redhat.com/1053841

**Addresses bugs:**
1. Bug 2023164 - [RGW] Multisite data sync stuck for some buckets and needs bucket sync run to sync bucket.
6. Bug 2021009 - [RGW] data sync stuck for buckets even after running bucket sync run.

Signed-off-by:viduship < vimishra@redhat.com>