### PR TITLE
Logging correct message when MS sync is slow or stuck

### DIFF
--- a/rgw/v2/lib/sync_status.py
+++ b/rgw/v2/lib/sync_status.py
@@ -48,15 +48,15 @@ def sync_status(retry=10, delay=60):
             "behind" in check_sync_status or "recovering" in check_sync_status
         ):
             raise SyncFailedError(
-                f"sync is still in progress. with {retry} retries and sleep of {delay}secs between each retry"
+                f"sync looks slow or stuck. with {retry} retries and sleep of {delay}secs between each retry"
             )
 
     # check metadata sync status
     if "metadata is behind" in check_sync_status:
-        raise Exception("metadata sync is either in progress or stuck")
+        raise Exception("metadata sync looks slow or stuck.")
 
     # check status for complete sync
     if "data is caught up with source" in check_sync_status:
         log.info("sync status complete")
     else:
-        raise SyncFailedError("sync is either in progress or stuck")
+        raise SyncFailedError("sync is either slow or stuck")


### PR DESCRIPTION
Logging correct message when MS sync is slow or stuck.

[BZ2011686] Rados gateway replication is slow in a multisite setup.

Signed-off-by: viduship <viduship vimishra@redhat.com>