### PR TITLE
Added fix for stabilizing STS server side copy

### DIFF
--- a/rgw/v2/tests/s3_swift/test_sts_using_boto_server_side_copy.py
+++ b/rgw/v2/tests/s3_swift/test_sts_using_boto_server_side_copy.py
@@ -121,7 +121,7 @@ def test_exec(config):
     log.info("assuming role")
     assume_role_response = sts_client.assume_role(
         RoleArn=create_role_response["Role"]["Arn"],
-        RoleSessionName=user1["user_id"],
+        RoleSessionName=user2["user_id"],
         DurationSeconds=3600,
     )
 


### PR DESCRIPTION
Added fix for stabilizing STS server-side copy

Tests failed due to credentials being taken from different users. Provided the fix for the same. Three consecutive runs were passed after the fix. Log: http://pastebin.test.redhat.com/1062990