### PR TITLE
Adds support of compression supported by ceph

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_compression_snappy.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_compression_snappy.yaml
@@ -1,0 +1,20 @@
+# upload type: non multipart
+# script: test_Mbuckets_with_Nobjects.py
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 2
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    create_bucket: true
+    create_object: true
+    download_object: false
+    delete_bucket_object: false
+    sharding:
+      enable: false
+      max_shards: 0
+    compression:
+      enable: true
+      type: snappy

--- a/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_compression_zstd.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_compression_zstd.yaml
@@ -1,0 +1,20 @@
+# upload type: non multipart
+# script: test_Mbuckets_with_Nobjects.py
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 2
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    create_bucket: true
+    create_object: true
+    download_object: false
+    delete_bucket_object: false
+    sharding:
+      enable: false
+      max_shards: 0
+    compression:
+      enable: true
+      type: zstd

--- a/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
+++ b/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
@@ -129,16 +129,22 @@ def test_exec(config):
                         == compression_type
                     ):
                         log.info("Compression enabled successfully")
+                    else:
+                        log.error("Compression is not enabled on cluster")
+                        raise TestExecError("Compression is not enabled on cluster")
 
                 else:
-                    if ceph_version in ["nautilus", "octopus"]:
-                        if (
-                            data["placement_pools"][0]["val"]["storage_classes"][
-                                "STANDARD"
-                            ]["compression_type"]
-                            == compression_type
-                        ):
-                            log.info("Compression enabled successfully")
+                    if (
+                        data["placement_pools"][0]["val"]["storage_classes"][
+                            "STANDARD"
+                        ]["compression_type"]
+                        == compression_type
+                    ):
+                        log.info("Compression enabled successfully")
+                    else:
+                        log.error("Compression is not enabled on cluster")
+                        raise TestExecError("Compression is not enabled on cluster")
+
             except ValueError as e:
                 exit(str(e))
             log.info("trying to restart rgw services ")


### PR DESCRIPTION
Adds support of compression supported by ceph

Following is the log location of successful run:
compression with zstd		http://pastebin.test.redhat.com/1063600
compression with snappy	http://pastebin.test.redhat.com/1063601

Signed-off-by: uday kurundwade <ukurundw@redhat.com>