### PR TITLE
Removing the test for non-existent bucket's stats from 4.3 to 5.1

### DIFF
--- a/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
+++ b/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
@@ -450,13 +450,18 @@ def test_exec(config):
                             time.sleep(10)
                             reusable.check_sync_status()
                             reusable.delete_bucket(bucket)
+                            ceph_version_id, _ = utils.get_ceph_version()
                             cmd = f"radosgw-admin bucket stats --bucket={bucket.name}"
                             ec, _ = sp.getstatusoutput(cmd)
                             log.info(f"Bucket stats for non-existent is {ec}")
-                            if ec != 2:
-                                raise TestExecError(
-                                    "Bucket stats for non-existent bucket should return failure (2) or ENOENT."
-                                )
+                            if (
+                                float(ceph_version_id[0]) >= 16
+                                and float(ceph_version_id[1]) >= 2.8
+                            ):
+                                if ec != 2:
+                                    raise TestExecError(
+                                        "Bucket stats for non-existent bucket should return failure (2) or ENOENT."
+                                    )
                     if config.bucket_sync_run_with_disable_sync_thread:
                         out = utils.check_bucket_sync(bucket.name)
                         if out is False:


### PR DESCRIPTION
Removing the test for non-existent bucket's stats from 4.3 to 5.1 so that tier-0 suites pass in RHVS-4.3

Signed-off-by: viduship <vimishra@redhat.com>

logs : http://pastebin.test.redhat.com/1064631