### PR TITLE
add support for empty bucket notification

### DIFF
--- a/rgw/v2/lib/resource_op.py
+++ b/rgw/v2/lib/resource_op.py
@@ -258,6 +258,9 @@ class Config(object):
         self.persistent_flag = self.test_ops.get("persistent_flag", False)
         self.copy_object = self.test_ops.get("copy_object", False)
         self.get_topic_info = self.test_ops.get("get_topic_info", False)
+        self.put_empty_bucket_notification = self.test_ops.get(
+            "put_empty_bucket_notification", False
+        )
         ceph_version_id, ceph_version_name = utils.get_ceph_version()
         # todo: improve Frontend class
         if ceph_version_name in ["luminous", "nautilus"]:

--- a/rgw/v2/tests/s3_swift/configs/test_empty_bucket_notification_kafka_broker.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_empty_bucket_notification_kafka_broker.yaml
@@ -1,0 +1,20 @@
+config:
+ user_count: 1
+ bucket_count: 1
+ objects_count: 1
+ objects_size_range:
+  min: 5
+  max: 5
+ test_ops:
+  create_bucket: true
+  create_object: true
+  enable_version: false
+  create_topic: true
+  get_topic_info: true
+  endpoint: kafka
+  ack_type: broker
+  put_get_bucket_notification: true
+  event_type: Delete
+  upload_type: normal
+  put_empty_bucket_notification: true
+  delete_bucket_object: true

--- a/rgw/v2/tests/s3_swift/reusables/bucket_notification.py
+++ b/rgw/v2/tests/s3_swift/reusables/bucket_notification.py
@@ -105,7 +105,21 @@ def put_bucket_notification(
         raise TestExecError("put bucket notification failed")
 
 
-def get_bucket_notification(rgw_s3_client, bucketname):
+def put_empty_bucket_notification(rgw_s3_client, bucketname):
+    """
+    put empty bucket notification. Ref BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2017389
+    """
+    log.info(f"put empty bucket notification on {bucketname}")
+    put_empty_bkt_notification = rgw_s3_client.put_bucket_notification_configuration(
+        Bucket=bucketname,
+        NotificationConfiguration={},
+    )
+    if put_empty_bkt_notification is False:
+        raise TestExecError("put empty bucket notifcation failed")
+    get_bucket_notification(rgw_s3_client, bucketname, empty=True)
+
+
+def get_bucket_notification(rgw_s3_client, bucketname, empty=False):
     """
     get bucket notification for a given bucket
     """
@@ -113,9 +127,10 @@ def get_bucket_notification(rgw_s3_client, bucketname):
         Bucket=bucketname
     )
     if get_bkt_notification is False:
-        raise TestExecError(
-            f"failed to get bucket notification for bucket : {bucketname}"
-        )
+        if not empty:
+            raise TestExecError(
+                f"failed to get bucket notification for bucket : {bucketname}"
+            )
     get_bucket_notification_json = json.dumps(get_bkt_notification, indent=2)
     log.info(
         f"bucket notification for bucket: {bucketname} is {get_bucket_notification_json}"

--- a/rgw/v2/tests/s3_swift/test_bucket_notifications.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_notifications.py
@@ -193,7 +193,7 @@ def test_exec(config):
                     reusable.delete_objects(bucket)
 
             # start kafka broker and consumer
-            event_record_path = "/home/cephuser/event_record"
+            event_record_path = "/tmp/event_record"
             start_consumer = notification.start_kafka_broker_consumer(
                 topic_name, event_record_path
             )
@@ -209,6 +209,12 @@ def test_exec(config):
                 raise EventRecordDataError(
                     "Event record is empty! notification is not seen"
                 )
+        # put empty bucket notification to remove existing configuration
+        if config.test_ops.get("put_empty_bucket_notification", False):
+            notification.put_empty_bucket_notification(
+                rgw_s3_client,
+                bucket_name_to_create,
+            )
 
         # delete topic logs on kafka broker
         notification.del_topic_from_kafka_broker(topic_name)


### PR DESCRIPTION
Signed-off-by: MadhaviKasturi <mkasturi@redhat.com>

This PR to verify empty bucket notification removes existing bucket notification.
Logs:
5.2 -  http://magna002.ceph.redhat.com/ceph-qe-logs/madhavi/PRs/empty_notify/test_empty_bucket_notification_kafka_broker_console.log
4.x - http://magna002.ceph.redhat.com/ceph-qe-logs/madhavi/PRs/empty_notify/4.x-test_bucket_notification_kafka_none_delete_console.log 

 