### PR TITLE
Include config for dynamic bucket resharding with custom values

### DIFF
--- a/rgw/v2/lib/resource_op.py
+++ b/rgw/v2/lib/resource_op.py
@@ -195,6 +195,12 @@ class Config(object):
         self.shards = self.doc["config"].get("shards")
         # todo: better suited to be added under ceph_conf
         self.max_objects_per_shard = self.doc["config"].get("max_objects_per_shard")
+        self.max_rgw_dynamic_shards = self.doc["config"].get(
+            "max_rgw_dynamic_shards", 1999
+        )
+        self.rgw_reshard_thread_interval = self.doc["config"].get(
+            "rgw_reshard_thread_interval", 600
+        )
         self.max_objects = None
         self.user_count = self.doc["config"].get("user_count")
         self.user_remove = self.doc["config"].get("user_remove", True)

--- a/rgw/v2/lib/rgw_config_opts.py
+++ b/rgw/v2/lib/rgw_config_opts.py
@@ -18,6 +18,8 @@ class ConfigOpts(object):
     rgw_bucket_default_quota_max_objects = "rgw_bucket_default_quota_max_objects"
     rgw_dynamic_resharding = "rgw_dynamic_resharding"
     rgw_max_objs_per_shard = "rgw_max_objs_per_shard"
+    rgw_max_dynamic_shards = "rgw_max_dynamic_shards"
+    rgw_reshard_thread_interval = "rgw_reshard_thread_interval"
     rgw_lc_debug_interval = "rgw_lc_debug_interval"
     rgw_lc_max_worker = "rgw_lc_max_worker"
     debug_rgw = "debug_rgw"

--- a/rgw/v2/tests/s3_swift/configs/test_dbr_with_custom_objs_per_shard_and_max_dynamic_shard.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dbr_with_custom_objs_per_shard_and_max_dynamic_shard.yaml
@@ -1,0 +1,11 @@
+# test case id: CEPH-83575266
+config:
+  objects_count: 100
+  objects_size_range:
+    min: 5
+    max: 10
+  sharding_type: dynamic
+  max_objects_per_shard: 1
+  max_rgw_dynamic_shards: 200
+  test_ops:
+    delete_bucket_object: true

--- a/rgw/v2/tests/s3_swift/configs/test_dbr_with_custom_objs_per_shard_max_dynamic_shard_and_reshard_thread_interval.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dbr_with_custom_objs_per_shard_max_dynamic_shard_and_reshard_thread_interval.yaml
@@ -1,0 +1,12 @@
+# test case id: CEPH-83575267
+config:
+  objects_count: 100
+  objects_size_range:
+    min: 5
+    max: 10
+  sharding_type: dynamic
+  max_objects_per_shard: 1
+  max_rgw_dynamic_shards: 200
+  rgw_reshard_thread_interval: 120
+  test_ops:
+    delete_bucket_object: true

--- a/rgw/v2/tests/s3_swift/test_dynamic_bucket_resharding.py
+++ b/rgw/v2/tests/s3_swift/test_dynamic_bucket_resharding.py
@@ -73,7 +73,20 @@ def test_exec(config):
             ConfigOpts.rgw_max_objs_per_shard,
             str(config.max_objects_per_shard),
         )
+
         ceph_conf.set_to_ceph_conf("global", ConfigOpts.rgw_dynamic_resharding, "True")
+        ceph_conf.set_to_ceph_conf(
+            "global",
+            ConfigOpts.rgw_max_dynamic_shards,
+            str(config.max_rgw_dynamic_shards),
+        )
+
+        ceph_conf.set_to_ceph_conf(
+            "global",
+            ConfigOpts.rgw_reshard_thread_interval,
+            str(config.rgw_reshard_thread_interval),
+        )
+
         num_shards_expected = config.objects_count / config.max_objects_per_shard
         log.info("num_shards_expected: %s" % num_shards_expected)
         log.info("trying to restart services ")


### PR DESCRIPTION
Signed-off-by: ckulal <ckulal@redhat.com>

Include config files for dynamic bucket resharding
1. With custom rgw_max_objs_per_shard=1, rgw_max_dynamic_shards=  200
2. With custom rgw_max_objs_per_shard=1, rgw_max_dynamic_shards=  200, rgw_reshard_thread_interval=120

Log: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/dbr_automation_enhance