### PR TITLE
modifying log.info to log.error if exception occurs

### DIFF
--- a/rgw/v2/lib/frontend_configure.py
+++ b/rgw/v2/lib/frontend_configure.py
@@ -138,8 +138,8 @@ class Frontend(RGWSectionOptions):
             return frontend
 
         except RGWBaseException as e:
-            log.info(e)
-            log.info(traceback.format_exc())
+            log.error(e)
+            log.error(traceback.format_exc())
             sys.exit(1)
 
 

--- a/rgw/v2/lib/pem.py
+++ b/rgw/v2/lib/pem.py
@@ -45,8 +45,8 @@ def create_pem():
         return PEM_FILE_PATH
 
     except Exception as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         sys.exit(1)
 
 

--- a/rgw/v2/tests/nfs_ganesha/test_on_nfs_io.py
+++ b/rgw/v2/tests/nfs_ganesha/test_on_nfs_io.py
@@ -198,7 +198,7 @@ if __name__ == "__main__":
         sys.exit(0)
 
     except (TestExecError, Exception) as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         test_info.failed_status("test failed")
         sys.exit(1)

--- a/rgw/v2/tests/nfs_ganesha/test_on_s3_io.py
+++ b/rgw/v2/tests/nfs_ganesha/test_on_s3_io.py
@@ -250,7 +250,7 @@ if __name__ == "__main__":
         sys.exit(0)
 
     except (TestExecError, Exception) as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         test_info.failed_status("test failed")
         sys.exit(1)

--- a/rgw/v2/tests/s3_swift/swift_stats.py
+++ b/rgw/v2/tests/s3_swift/swift_stats.py
@@ -130,7 +130,7 @@ if __name__ == "__main__":
         sys.exit(0)
 
     except (RGWBaseException, Exception) as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         test_info.failed_status("test failed")
         sys.exit(1)

--- a/rgw/v2/tests/s3_swift/test_LargeObjGet_GC.py
+++ b/rgw/v2/tests/s3_swift/test_LargeObjGet_GC.py
@@ -160,7 +160,7 @@ if __name__ == "__main__":
         sys.exit(0)
 
     except (RGWBaseException, Exception) as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         test_info.failed_status("test failed")
         sys.exit(1)

--- a/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
+++ b/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
@@ -148,6 +148,7 @@ def test_exec(config):
                         raise TestExecError("Compression is not enabled on cluster")
 
             except ValueError as e:
+                log.error(e)
                 exit(str(e))
             log.info("trying to restart rgw services ")
             srv_restarted = rgw_service.restart()
@@ -651,7 +652,7 @@ if __name__ == "__main__":
         sys.exit(0)
 
     except (RGWBaseException, Exception) as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         test_info.failed_status("test failed")
         sys.exit(1)

--- a/rgw/v2/tests/s3_swift/test_bucket_lifecycle_config_ops.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_lifecycle_config_ops.py
@@ -392,7 +392,7 @@ if __name__ == "__main__":
         sys.exit(0)
 
     except (RGWBaseException, Exception) as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         test_info.failed_status("test failed")
         sys.exit(1)

--- a/rgw/v2/tests/s3_swift/test_bucket_lifecycle_object_expiration.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_lifecycle_object_expiration.py
@@ -267,6 +267,6 @@ if __name__ == "__main__":
 
     except (RGWBaseException, Exception) as e:
         log.error(e)
-        log.info(traceback.format_exc())
+        log.error(traceback.format_exc())
         test_info.failed_status("test failed")
         sys.exit(1)

--- a/rgw/v2/tests/s3_swift/test_bucket_listing.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_listing.py
@@ -339,7 +339,7 @@ if __name__ == "__main__":
         sys.exit(0)
 
     except (RGWBaseException, Exception) as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         test_info.failed_status("test failed")
         sys.exit(1)

--- a/rgw/v2/tests/s3_swift/test_bucket_notifications.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_notifications.py
@@ -267,7 +267,7 @@ if __name__ == "__main__":
         sys.exit(0)
 
     except (RGWBaseException, Exception) as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         test_info.failed_status("test failed")
         sys.exit(1)

--- a/rgw/v2/tests/s3_swift/test_bucket_policy_ops.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_policy_ops.py
@@ -319,7 +319,7 @@ if __name__ == "__main__":
         sys.exit(0)
 
     except (RGWBaseException, Exception) as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         test_info.failed_status("test failed")
         sys.exit(1)

--- a/rgw/v2/tests/s3_swift/test_check_sharding_enabled.py
+++ b/rgw/v2/tests/s3_swift/test_check_sharding_enabled.py
@@ -130,7 +130,7 @@ if __name__ == "__main__":
         sys.exit(0)
 
     except (RGWBaseException, Exception) as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         test_info.failed_status("test failed")
         sys.exit(1)

--- a/rgw/v2/tests/s3_swift/test_data_omap_offload.py
+++ b/rgw/v2/tests/s3_swift/test_data_omap_offload.py
@@ -199,7 +199,7 @@ if __name__ == "__main__":
         sys.exit(0)
 
     except (RGWBaseException, Exception) as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         test_info.failed_status("test failed")
         sys.exit(1)

--- a/rgw/v2/tests/s3_swift/test_dynamic_bucket_resharding.py
+++ b/rgw/v2/tests/s3_swift/test_dynamic_bucket_resharding.py
@@ -211,7 +211,7 @@ if __name__ == "__main__":
         sys.exit(0)
 
     except (RGWBaseException, Exception) as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         test_info.failed_status("test failed")
         sys.exit(1)

--- a/rgw/v2/tests/s3_swift/test_frontends_with_ssl.py
+++ b/rgw/v2/tests/s3_swift/test_frontends_with_ssl.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
         sys.exit(0)
 
     except (RGWBaseException, Exception) as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         test_info.failed_status("test failed")
         sys.exit(1)

--- a/rgw/v2/tests/s3_swift/test_gc_with_resharding.py
+++ b/rgw/v2/tests/s3_swift/test_gc_with_resharding.py
@@ -246,7 +246,7 @@ if __name__ == "__main__":
         sys.exit(0)
 
     except (RGWBaseException, Exception) as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         test_info.failed_status("test failed")
         sys.exit(1)

--- a/rgw/v2/tests/s3_swift/test_indexless_buckets.py
+++ b/rgw/v2/tests/s3_swift/test_indexless_buckets.py
@@ -184,6 +184,6 @@ if __name__ == "__main__":
 
     except (RGWBaseException, Exception) as e:
         log.error(e)
-        log.info(traceback.format_exc())
+        log.error(traceback.format_exc())
         test_info.failed_status("test failed")
         sys.exit(1)

--- a/rgw/v2/tests/s3_swift/test_list_all_multipart_uploads.py
+++ b/rgw/v2/tests/s3_swift/test_list_all_multipart_uploads.py
@@ -173,7 +173,7 @@ def test_exec(config):
             % (tenant1_user2_info["user_id"], t1_u1_bucket2.name)
         )
     except ClientError as err:
-        log.info("Listing failed as expected with exception: %s" % err)
+        log.error("Listing failed as expected with exception: %s" % err)
 
     # check sync status if a multisite cluster
     reusable.check_sync_status()
@@ -221,7 +221,7 @@ if __name__ == "__main__":
         sys.exit(0)
 
     except (RGWBaseException, Exception) as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         test_info.failed_status("test failed")
         sys.exit(1)

--- a/rgw/v2/tests/s3_swift/test_multitenant_user_access.py
+++ b/rgw/v2/tests/s3_swift/test_multitenant_user_access.py
@@ -182,7 +182,7 @@ if __name__ == "__main__":
         sys.exit(0)
 
     except (RGWBaseException, Exception) as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         test_info.failed_status("test failed")
         sys.exit(1)

--- a/rgw/v2/tests/s3_swift/test_object_lock.py
+++ b/rgw/v2/tests/s3_swift/test_object_lock.py
@@ -184,7 +184,7 @@ if __name__ == "__main__":
         sys.exit(0)
 
     except (RGWBaseException, Exception) as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         test_info.failed_status("test failed")
         sys.exit(1)

--- a/rgw/v2/tests/s3_swift/test_rgw_mfa.py
+++ b/rgw/v2/tests/s3_swift/test_rgw_mfa.py
@@ -299,7 +299,7 @@ if __name__ == "__main__":
         sys.exit(0)
 
     except (RGWBaseException, Exception) as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         test_info.failed_status("test failed")
         sys.exit(1)

--- a/rgw/v2/tests/s3_swift/test_storage_policy.py
+++ b/rgw/v2/tests/s3_swift/test_storage_policy.py
@@ -237,7 +237,7 @@ if __name__ == "__main__":
         sys.exit(0)
 
     except (RGWBaseException, Exception) as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         test_info.failed_status("test failed")
         sys.exit(1)

--- a/rgw/v2/tests/s3_swift/test_sts_using_boto.py
+++ b/rgw/v2/tests/s3_swift/test_sts_using_boto.py
@@ -195,6 +195,7 @@ def test_exec(config):
         if crash_info:
             raise TestExecError("ceph daemon crash found!")
     except ClientError as e:
+        log.error(e)
         print("403 Forbidden, invalid arn in the policy")
 
 
@@ -233,7 +234,7 @@ if __name__ == "__main__":
         sys.exit(0)
 
     except (RGWBaseException, Exception) as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         test_info.failed_status("test failed")
         sys.exit(1)

--- a/rgw/v2/tests/s3_swift/test_sts_using_boto_server_side_copy.py
+++ b/rgw/v2/tests/s3_swift/test_sts_using_boto_server_side_copy.py
@@ -271,7 +271,7 @@ if __name__ == "__main__":
         sys.exit(0)
 
     except (RGWBaseException, Exception) as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         test_info.failed_status("test failed")
         sys.exit(1)

--- a/rgw/v2/tests/s3_swift/test_sts_using_boto_session_policy.py
+++ b/rgw/v2/tests/s3_swift/test_sts_using_boto_session_policy.py
@@ -224,7 +224,7 @@ if __name__ == "__main__":
         sys.exit(0)
 
     except (RGWBaseException, Exception) as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         test_info.failed_status("test failed")
         sys.exit(1)

--- a/rgw/v2/tests/s3_swift/test_sts_using_boto_unexisting_object.py
+++ b/rgw/v2/tests/s3_swift/test_sts_using_boto_unexisting_object.py
@@ -204,9 +204,9 @@ def test_exec(config):
         response = s3_client.head_object(Bucket=bucket_name, Key=unexisting_object)
     except botocore.exceptions.ClientError as e:
         response_code = e.response["Error"]["Code"]
-        log.info(response_code)
+        log.error(response_code)
         if e.response["Error"]["Code"] == "404":
-            log.info("404 Unexisting Object Not Found")
+            log.error("404 Unexisting Object Not Found")
         elif e.response["Error"]["Code"] == "403":
             raise TestExecError("Error code : 403 - HeadObject operation: Forbidden")
 
@@ -248,7 +248,7 @@ if __name__ == "__main__":
         sys.exit(0)
 
     except (RGWBaseException, Exception) as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         test_info.failed_status("test failed")
         sys.exit(1)

--- a/rgw/v2/tests/s3_swift/test_swift_basic_ops.py
+++ b/rgw/v2/tests/s3_swift/test_swift_basic_ops.py
@@ -436,7 +436,7 @@ if __name__ == "__main__":
         sys.exit(0)
 
     except (RGWBaseException, Exception) as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         test_info.failed_status("test failed")
         sys.exit(1)

--- a/rgw/v2/tests/s3_swift/test_swift_bulk_delete.py
+++ b/rgw/v2/tests/s3_swift/test_swift_bulk_delete.py
@@ -177,7 +177,7 @@ if __name__ == "__main__":
         sys.exit(0)
 
     except (RGWBaseException, Exception) as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         test_info.failed_status("test failed")
         sys.exit(1)

--- a/rgw/v2/tests/s3_swift/test_tenant_user_secret_key.py
+++ b/rgw/v2/tests/s3_swift/test_tenant_user_secret_key.py
@@ -161,7 +161,7 @@ if __name__ == "__main__":
         sys.exit(0)
 
     except (RGWBaseException, Exception) as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         test_info.failed_status("test failed")
         sys.exit(1)

--- a/rgw/v2/tests/s3_swift/test_user_bucket_rename.py
+++ b/rgw/v2/tests/s3_swift/test_user_bucket_rename.py
@@ -171,7 +171,7 @@ if __name__ == "__main__":
         # read_io.verify_io()
 
     except (RGWBaseException, Exception) as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         test_info.failed_status("test failed")
         sys.exit(1)

--- a/rgw/v2/tests/s3_swift/test_versioning_copy_objects.py
+++ b/rgw/v2/tests/s3_swift/test_versioning_copy_objects.py
@@ -198,7 +198,7 @@ if __name__ == "__main__":
         sys.exit(0)
 
     except (RGWBaseException, Exception) as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         test_info.failed_status("test failed")
         sys.exit(1)

--- a/rgw/v2/tests/s3_swift/test_versioning_with_objects.py
+++ b/rgw/v2/tests/s3_swift/test_versioning_with_objects.py
@@ -669,7 +669,7 @@ if __name__ == "__main__":
         sys.exit(0)
 
     except (RGWBaseException, Exception) as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         test_info.failed_status("test failed")
         sys.exit(1)

--- a/rgw/v2/tests/s3_swift/user_create.py
+++ b/rgw/v2/tests/s3_swift/user_create.py
@@ -48,13 +48,13 @@ def test_exec(config):
         test_info.success_status("test passed")
         sys.exit(0)
     except Exception as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         test_info.failed_status("user creation failed")
         sys.exit(1)
     except (RGWBaseException, Exception) as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         test_info.failed_status("user creation failed")
         sys.exit(1)
 

--- a/rgw/v2/tests/s3_swift/user_op_using_rest.py
+++ b/rgw/v2/tests/s3_swift/user_op_using_rest.py
@@ -178,7 +178,7 @@ if __name__ == "__main__":
         sys.exit(0)
 
     except (RGWBaseException, Exception) as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         test_info.failed_status("test failed")
         sys.exit(1)

--- a/rgw/v2/tests/s3cmd/test_bucket_stats.py
+++ b/rgw/v2/tests/s3cmd/test_bucket_stats.py
@@ -126,8 +126,8 @@ if __name__ == "__main__":
         sys.exit(0)
 
     except (RGWBaseException, Exception) as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         test_info.failed_status("test failed")
         sys.exit(1)
 

--- a/rgw/v2/tests/s3cmd/test_header_size.py
+++ b/rgw/v2/tests/s3cmd/test_header_size.py
@@ -147,8 +147,8 @@ if __name__ == "__main__":
         sys.exit(0)
 
     except (RGWBaseException, Exception) as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         test_info.failed_status("test failed")
         sys.exit(1)
 

--- a/rgw/v2/tests/s3cmd/test_large_object_gc.py
+++ b/rgw/v2/tests/s3cmd/test_large_object_gc.py
@@ -176,8 +176,8 @@ if __name__ == "__main__":
         sys.exit(0)
 
     except (RGWBaseException, Exception) as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         test_info.failed_status("test failed")
         sys.exit(1)
 

--- a/rgw/v2/tests/s3cmd/test_s3cmd.py
+++ b/rgw/v2/tests/s3cmd/test_s3cmd.py
@@ -130,7 +130,7 @@ if __name__ == "__main__":
         sys.exit(0)
 
     except (RGWBaseException, Exception) as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         test_info.failed_status("test failed")
         sys.exit(1)

--- a/rgw/v2/utils/utils.py
+++ b/rgw/v2/utils/utils.py
@@ -577,7 +577,7 @@ def get_hostname_ip():
         log.info("IP : %s" % ip)
         return hostname, ip
     except Exception as e:
-        log.info(e)
+        log.error(e)
         log.error("unable to get Hostname and IP")
 
 


### PR DESCRIPTION
This PR modifies log.info to log.error wherever it is present in ceph-qe-scripts to enable tfa analyser better classify errors.
logs: https://jenkins.ceph.redhat.com/view/RHCS%20QE/job/rhceph-test-executor/948/console