### PR TITLE
Adding Intelligence to verify-io-on-site on post deletion objects

### DIFF
--- a/rgw/v2/lib/read_io_info.py
+++ b/rgw/v2/lib/read_io_info.py
@@ -42,23 +42,23 @@ def verify_key(each_key, bucket):
         key(char): key to be verified
         bucket(char): bucket name
     """
-    log.info("verifying data for key: %s" % os.path.basename(each_key["name"]))
+    log.info(f"verifying data for key: {os.path.basename(each_key['name'])}")
     check_object_exists(os.path.basename(each_key["name"]), bucket)
     key_from_s3 = bucket.Object(os.path.basename(each_key["name"]))
     log.info("verifying size")
-    log.info("size from yaml: %s" % each_key["size"])
-    log.info("size from s3: %s" % key_from_s3.content_length)
+    log.info(f"size from yaml: {each_key['size']}")
+    log.info(f"size from s3: {key_from_s3.content_length}")
     if int(each_key["size"]) != int(key_from_s3.content_length):
         raise TestExecError("Size not matched")
     log.info("verifying md5")
-    log.info("md5_local: %s" % each_key["md5_local"])
+    log.info(f"md5_local: {each_key['md5_local']}")
     key_from_s3.download_file("download.temp")
     downloaded_md5 = utils.get_md5("download.temp")
-    log.info("md5_from_s3: %s" % downloaded_md5)
+    log.info(f"md5_from_s3: {downloaded_md5}")
     if each_key["md5_local"] != downloaded_md5:
         raise TestExecError("Md5 not matched")
     utils.exec_shell_cmd("sudo rm -rf download.temp")
-    log.info("verification complete for the key: %s" % key_from_s3.key)
+    log.info(f"verification complete for the key: {key_from_s3.key}")
 
 
 def verify_key_with_version(each_key, bucket):
@@ -72,32 +72,31 @@ def verify_key_with_version(each_key, bucket):
     Returns:
 
     """
-    log.info("verifying data for key: %s" % os.path.basename(each_key["name"]))
+    log.info(f"verifying data for key: {os.path.basename(each_key['name'])}")
     check_object_exists(os.path.basename(each_key["name"]), bucket)
     key_from_s3 = bucket.Object(os.path.basename(each_key["name"]))
     no_of_versions = len(each_key["versioning_info"])
-    log.info("no of versions: %s" % no_of_versions)
+    log.info(f"no of versions: {no_of_versions}")
     for each_version in each_key["versioning_info"]:
-        log.info("version_id: %s" % each_version["version_id"])
+        log.info(f"version_id: {each_version['version_id']}")
         key_from_s3_with_version = key_from_s3.get(VersionId=each_version["version_id"])
         log.info("verifying size")
-        log.info("size from yaml: %s" % each_version["size"])
-        log.info("size from s3 %s" % key_from_s3_with_version["ContentLength"])
+        log.info(f"size from yaml: {each_version['size']}")
+        log.info(f"size from s3 {key_from_s3_with_version['ContentLength']}")
         if int(each_version["size"] != int(key_from_s3_with_version["ContentLength"])):
             raise TestExecError("Size not matched")
         log.info("verifying md5")
-        log.info("md5_local: %s" % each_version["md5_local"])
+        log.info(f"md5_local: {each_version['md5_local']}")
         key_from_s3.download_file(
             "download.temp", ExtraArgs={"VersionId": each_version["version_id"]}
         )
         downloaded_md5 = utils.get_md5("download.temp")
-        log.info("md5_from_s3: %s" % downloaded_md5)
+        log.info(f"md5_from_s3: {downloaded_md5}")
         if each_version["md5_local"] != downloaded_md5:
             raise TestExecError("Md5 not matched")
         utils.exec_shell_cmd("sudo rm -rf download.temp")
         log.info(
-            "verification complete for the key: %s ---> version_id: %s"
-            % (key_from_s3.key, each_version["version_id"])
+            f"verification complete for the key: {key_from_s3.key} ---> version_id: {each_version['version_id']}"
         )
 
 
@@ -127,38 +126,91 @@ class ReadIOInfo(object):
         endpoint_url = f"{endpoint_proto}://{host}:{endpoint_port}"
 
         for each_user in users:
-            log.info("verifying data for the user: \n")
-            log.info("user_id: %s" % each_user["user_id"])
-            log.info("access_key: %s" % each_user["access_key"])
-            log.info("secret_key: %s" % each_user["secret_key"])
-            conn = boto3.resource(
-                "s3",
-                aws_access_key_id=each_user["access_key"],
-                aws_secret_access_key=each_user["secret_key"],
-                endpoint_url=endpoint_url,
-                use_ssl=is_secure,
-                verify=False,
-            )
+            if each_user["deleted"] is False:
+                log.info("verifying data for the user: \n")
+                log.info(f"user_id: {each_user['user_id']}")
+                log.info(f"access_key: {each_user['access_key']}")
+                log.info(f"secret_key: {each_user['secret_key']}")
+                conn = boto3.resource(
+                    "s3",
+                    aws_access_key_id=each_user["access_key"],
+                    aws_secret_access_key=each_user["secret_key"],
+                    endpoint_url=endpoint_url,
+                    use_ssl=is_secure,
+                    verify=False,
+                )
 
-            for each_bucket in each_user["bucket"]:
-                log.info("verifying data for bucket: %s" % each_bucket["name"])
-                bucket_from_s3 = conn.Bucket(each_bucket["name"])
-                curr_versioning_status = each_bucket["curr_versioning_status"]
-                log.info("curr_versioning_status: %s" % curr_versioning_status)
-                if not each_bucket["keys"]:
-                    log.info("keys are not created")
-                else:
-                    no_of_keys = len(each_bucket["keys"])
-                    log.info("no_of_keys: %s" % no_of_keys)
-                    for each_key in each_bucket["keys"]:
-                        versioned_keys = len(each_key["versioning_info"])
-                        log.info("versioned_keys: %s" % versioned_keys)
-                        if not each_key["versioning_info"]:
-                            log.info("not versioned key")
-                            verify_key(each_key, bucket_from_s3)
+                for each_bucket in each_user["bucket"]:
+                    if each_bucket["deleted"] is False:
+                        log.info(f"verifying data for bucket: {each_bucket['name']}")
+                        bucket_from_s3 = conn.Bucket(each_bucket["name"])
+                        curr_versioning_status = each_bucket["curr_versioning_status"]
+                        log.info(f"curr_versioning_status: {curr_versioning_status}")
+                        if not each_bucket["keys"]:
+                            log.info("keys are not created")
                         else:
-                            log.info("versioned key")
-                            verify_key_with_version(each_key, bucket_from_s3)
+                            no_of_keys = len(each_bucket["keys"])
+                            log.info(f"no_of_keys: {no_of_keys}")
+                            for each_key in each_bucket["keys"]:
+                                if each_key["deleted"] is False:
+                                    versioned_keys = len(each_key["versioning_info"])
+                                    log.info(f"versioned_keys: {versioned_keys}")
+                                    if not each_key["versioning_info"]:
+                                        log.info("not versioned key")
+                                        verify_key(each_key, bucket_from_s3)
+                                    else:
+                                        log.info("versioned key")
+                                        verify_key_with_version(
+                                            each_key, bucket_from_s3
+                                        )
+                                else:
+                                    key_name = each_key["name"]
+                                    log.info(
+                                        f"Verification of deleted key '{key_name}' starts"
+                                    )
+                                    try:
+                                        key_from_s3 = bucket_from_s3.Object(
+                                            os.path.basename(key_name)
+                                        )
+                                        log.info(key_from_s3.get())
+                                        raise AssertionError(
+                                            f"Verification of deleted object '{key_name}' failed"
+                                        )
+                                    except botocore.exceptions.ClientError as e:
+                                        log.info(
+                                            f"Verification of deleted object '{key_name}' successful"
+                                        )
+                    else:
+                        bucket_name = each_bucket["name"]
+                        log.info(
+                            f"Verification of deleted bucket '{bucket_name}' starts"
+                        )
+                        try:
+                            conn.meta.client.head_bucket(Bucket=bucket_name)
+                            raise AssertionError(
+                                f"Verification of deleted bucket '{bucket_name}' failed"
+                            )
+                        except botocore.exceptions.ClientError as e:
+                            error_code = int(e.response["Error"]["Code"])
+                            if error_code == 404:
+                                log.info(
+                                    f"Verification of deleted bucket '{bucket_name}' successful"
+                                )
+                            else:
+                                raise AssertionError(
+                                    f"Verification of deleted bucket '{bucket_name}' failed"
+                                )
+            else:
+                user_id = each_user["user_id"]
+                log.info(f"Verification of deleted user '{user_id}' starts")
+                cmd = f"radosgw-admin user list"
+                out = utils.exec_shell_cmd(cmd)
+                if user_id not in out:
+                    log.info(f"Verification of deleted user '{user_id}' successful")
+                else:
+                    raise AssertionError(
+                        f"Verification of deleted user '{user_id}' failed"
+                    )
         log.info("verification of data completed")
 
 

--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -15,6 +15,7 @@ import v2.utils.utils as utils
 from v2.lib.exceptions import DefaultDatalogBackingError, MFAVersionError, TestExecError
 from v2.lib.rgw_config_opts import ConfigOpts
 from v2.lib.s3.write_io_info import (
+    AddUserInfo,
     BasicIOInfoStructure,
     BucketIoInfo,
     IOInfoInitialize,
@@ -573,6 +574,9 @@ def remove_user(user_info, cluster_name="ceph", tenant=False):
             user_info["user_id"]
         )
     out = utils.exec_shell_cmd(cmd)
+    if out is not False:
+        write_user_data = AddUserInfo()
+        write_user_data.set_user_deleted(user_info["access_key"])
     return out
 
 

--- a/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
+++ b/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
@@ -564,8 +564,7 @@ def test_exec(config, ssh_con):
                 raise TestExecError("Failed to enable user")
         if config.delete_user:
             user_id = each_user["user_id"]
-            cmd = f"radosgw-admin user rm --uid='{user_id}'"
-            out = utils.exec_shell_cmd(cmd)
+            out = reusable.remove_user(each_user)
             cmd = f"radosgw-admin user list"
             out = utils.exec_shell_cmd(cmd)
             if user_id not in out:


### PR DESCRIPTION
We have issue if conf file has both create_object and delete_bucket_object set to true, and verify-io-on-site raises "HeadObject operation: Not Found" Exception because deleted object is being verified here.
This PR fixes the issue of verify-io for deleted user, bucket and object.
logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-MSHOU9/
logs of happy path: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-MKOB1R/

Signed-off-by: Hemanth Maheswarla <hmaheswa@hmaheswa.remote.csb>