### PR TITLE
CEPH-11197 - Enable lifecycle and check if both existing and future objects get expired

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_bucket_lc_enable_object_exp.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_lc_enable_object_exp.yaml
@@ -1,0 +1,18 @@
+# CEPH-11197 - Enable lifecycle and check if both existing and future objects get expired
+# script: test_bucket_lifecycle_config_ops.py
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 4
+  rgw_lc_debug_interval: 1
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    enable_versioning: false
+    version_count: 0
+    create_bucket: true
+    create_object: true
+    rgw_lc_debug: true
+    add_more_objects: true
+    new_objects_count: 6


### PR DESCRIPTION
Signed-off-by: Anuchaithra Rao <anrao@redhat.com>

Enable lifecycle on a bucket with existing objects. Add more objects later--> The objects added later should also get scheduled for delete

Log: 
if add_more_objects = true
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/CEPH-11197.log
if add_more_objects = false
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/CEPH-11197_1.log