### PR TITLE
Fix failure caused due to missing config parameter

### DIFF
--- a/rgw/v2/lib/resource_op.py
+++ b/rgw/v2/lib/resource_op.py
@@ -234,6 +234,7 @@ class Config(object):
         self.multiple_delete_marker_check = self.doc["config"].get(
             "multiple_delete_marker_check", False
         )
+        self.delete_marker_check = self.doc["config"].get("delete_marker_check", False)
         self.invalid_date = self.doc["config"].get("invalid_date", False)
         self.dynamic_resharding = self.doc["config"].get("dynamic_resharding", False)
         self.manual_resharding = self.doc["config"].get("manual_resharding", False)


### PR DESCRIPTION
Signed-off-by: ckulal <ckulal@redhat.com>

fix issue seen due to missing config parameter,
https://159.23.92.24/blue/rest/organizations/jenkins/pipelines/rhceph-test-execution-pipeline/runs/710/nodes/58/steps/83/log/?start=0

while raising https://github.com/red-hat-storage/ceph-qe-scripts/pull/306
missed to add config parameter in resource_op


Logs:
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/log_with_config(PASS)
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/log_without_config(FAIL)