### PR TITLE
add yamls to retain buckets after reshard 

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_dynamic_resharding_with_version_without_bucket_delete.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dynamic_resharding_with_version_without_bucket_delete.yaml
@@ -1,0 +1,12 @@
+# test case id: CEPH-83571740
+config:
+  objects_count: 100
+  objects_size_range:
+    min: 15
+    max: 20
+  sharding_type: dynamic
+  max_objects_per_shard: 5
+  version_count: 4
+  test_ops:
+    enable_verison: true
+    delete_bucket_object: false

--- a/rgw/v2/tests/s3_swift/configs/test_dynamic_resharding_without_bucket_delete.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dynamic_resharding_without_bucket_delete.yaml
@@ -1,0 +1,9 @@
+config:
+  objects_count: 100
+  objects_size_range:
+    min: 15
+    max: 20
+  sharding_type: dynamic
+  max_objects_per_shard: 5
+  test_ops:
+    delete_bucket_object: false

--- a/rgw/v2/tests/s3_swift/configs/test_manual_resharding_without_bucket_delete.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_manual_resharding_without_bucket_delete.yaml
@@ -1,0 +1,9 @@
+config:
+  objects_count: 10
+  objects_size_range:
+    min: 15
+    max: 20
+  sharding_type: manual
+  shards: 97
+  test_ops:
+    delete_bucket_object: false

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_dynamic_resharding_with_version_without_bucket_delete.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_dynamic_resharding_with_version_without_bucket_delete.yaml
@@ -1,0 +1,1 @@
+../configs/test_dynamic_resharding_with_version_without_bucket_delete.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_dynamic_resharding_without_bucket_delete.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_dynamic_resharding_without_bucket_delete.yaml
@@ -1,0 +1,1 @@
+../configs/test_dynamic_resharding_without_bucket_delete.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_manual_resharding_without_bucket_delete.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_manual_resharding_without_bucket_delete.yaml
@@ -1,0 +1,1 @@
+../configs/test_manual_resharding_without_bucket_delete.yaml


### PR DESCRIPTION
Signed-off-by: MadhaviKasturi <mkasturi@redhat.com>
Adding yamls to reshard tests to retain the bucket without deleting. This would be need for upgrade path testing.

logs are here http://magna002.ceph.redhat.com/ceph-qe-logs/madhavi/PRs/reshard/ 
