### PR TITLE
TFA: Enabling rgw logs to test async notifications

### DIFF
--- a/rgw/v2/lib/rgw_config_opts.py
+++ b/rgw/v2/lib/rgw_config_opts.py
@@ -26,6 +26,7 @@ class ConfigOpts(object):
     rgw_lifecycle_work_time = "rgw_lifecycle_work_time"
     rgw_lc_max_worker = "rgw_lc_max_worker"
     debug_rgw = "debug_rgw"
+    log_to_file = "log_to_file"
     rgw_crypt_require_ssl = "rgw_crypt_require_ssl"
     bluestore_block_size = "bluestore_block_size"
     rgw_gc_max_queue_size = "rgw_gc_max_queue_size"

--- a/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
+++ b/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
@@ -193,6 +193,11 @@ def test_exec(config, ssh_con):
                     f"ceph config set client.{rgw_process_name} rgw_data_notify_interval_msec 0"
                 )
             ceph_conf.set_to_ceph_conf(
+                "global",
+                ConfigOpts.log_to_file,
+                "true",
+            )
+            ceph_conf.set_to_ceph_conf(
                 "global", ConfigOpts.debug_rgw, str(config.debug_rgw), ssh_con
             )
 


### PR DESCRIPTION
TFA: Enabling rgw logs to test async notifications
Issue https://issues.redhat.com/browse/RHCEPHQE-5003

Logs : http://magna002.ceph.redhat.com/ceph-qe-logs/vidushi/async_data_notifications_test_log

Signed-off-by: viduship <vimishra@redhat.com>