### PR TITLE
Enhance validate_prefix_rule to support non-current objcet expiration…

### DIFF
--- a/rgw/v2/lib/s3/lifecycle_validation.py
+++ b/rgw/v2/lib/s3/lifecycle_validation.py
@@ -42,13 +42,16 @@ def validate_prefix_rule(bucket, config):
         log.info(
             "Lifecycle expiration of current object version validated for prefix filter"
         )
-    if objects != objs_diff:
-        raise AssertionError(
-            "Lifecycle expiration of non_current object version for prefix filter failed"
-        )
-    log.info(
-        "Lifecycle expiration of non_current object version validated for prefix filter"
-    )
+    for lc_conf in config.lifecycle_conf:
+        log.info(f"lc config is {lc_conf}")
+        if "NoncurrentVersionExpiration" in lc_conf.keys():
+            if objects != objs_diff:
+                raise AssertionError(
+                    "Lifecycle expiration of non_current object version for prefix filter failed"
+                )
+            log.info(
+                "Lifecycle expiration of non_current object version validated for prefix filter"
+            )
 
 
 def validate_prefix_rule_non_versioned(bucket):


### PR DESCRIPTION
Enhance validate_prefix_rule to support non-current object expiration validation only during non-current expiration is included in lc configuration

Logs:
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/LC_validation_enhance/test_lc_current_version_object_expiration
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/LC_validation_enhance/test_lc_multiple_rule_prefix_current_days
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/LC_validation_enhance/test_lc_rule_prefix_non_current_days


Signed-off-by: ckulal <ckulal@redhat.com>