### PR TITLE
Add configuration file to support CEPH-11192

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_lc_with_prefix_dot.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_with_prefix_dot.yaml
@@ -1,0 +1,20 @@
+# script: test_bucket_lifecycle_object_expiration.py
+# CEPH-11192 - Test object prefixes with delimiter '/', '_', '-', '.'
+config:
+  bucket_count: 2
+  objects_count: 100
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    enable_versioning: true
+    create_object: true
+    version_count: 2
+    delete_marker: false
+  lifecycle_conf:
+    - ID: LC_Rule_1
+      Filter:
+        Prefix: '.'
+      Status: Enabled
+      Expiration:
+        Days: 20

--- a/rgw/v2/tests/s3_swift/configs/test_lc_with_prefix_hyphen.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_with_prefix_hyphen.yaml
@@ -1,0 +1,20 @@
+# script: test_bucket_lifecycle_object_expiration.py
+# CEPH-11192 - Test object prefixes with delimiter '/', '_', '-', '.'
+config:
+  bucket_count: 2
+  objects_count: 100
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    enable_versioning: true
+    create_object: true
+    version_count: 2
+    delete_marker: false
+  lifecycle_conf:
+    - ID: LC_Rule_1
+      Filter:
+        Prefix: '-'
+      Status: Enabled
+      Expiration:
+        Days: 20

--- a/rgw/v2/tests/s3_swift/configs/test_lc_with_prefix_slash.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_with_prefix_slash.yaml
@@ -1,0 +1,20 @@
+# script: test_bucket_lifecycle_object_expiration.py
+# CEPH-11192 - Test object prefixes with delimiter '/', '_', '-', '.'
+config:
+  bucket_count: 2
+  objects_count: 100
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    enable_versioning: true
+    create_object: true
+    version_count: 2
+    delete_marker: false
+  lifecycle_conf:
+    - ID: LC_Rule_1
+      Filter:
+        Prefix: '/'
+      Status: Enabled
+      Expiration:
+        Days: 20

--- a/rgw/v2/tests/s3_swift/configs/test_lc_with_prefix_underscore.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_with_prefix_underscore.yaml
@@ -1,0 +1,20 @@
+# script: test_bucket_lifecycle_object_expiration.py
+# CEPH-11192 - Test object prefixes with delimiter '/', '_', '-', '.'
+config:
+  bucket_count: 2
+  objects_count: 100
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    enable_versioning: true
+    create_object: true
+    version_count: 2
+    delete_marker: false
+  lifecycle_conf:
+    - ID: LC_Rule_1
+      Filter:
+        Prefix: '_'
+      Status: Enabled
+      Expiration:
+        Days: 20


### PR DESCRIPTION
Signed-off-by: ckulal <ckulal@redhat.com>

Adding Config file to support: CEPH-11192 - Test object prefixes with delimiter '/', '_', '-', '.'

Logs:
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/test_lc_with_prefix_dot.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/test_lc_with_prefix_hyphen.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/test_lc_with_prefix_slash.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/test_lc_with_prefix_underscore.console.log

http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/test_lc_with_prefix_slash_new.console.log
