### PR TITLE
Setting rgw_enable_lc_threads to true(default) at the end of testcase

### DIFF
--- a/rgw/v2/tests/s3_swift/test_bucket_lifecycle_object_expiration.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_lifecycle_object_expiration.py
@@ -265,10 +265,6 @@ def test_exec(config, ssh_con):
                                     )
                         time.sleep(30)
                         lc_ops.validate_and_rule(bucket, config)
-                        ceph_conf.set_to_ceph_conf(
-                            "global", ConfigOpts.rgw_enable_lc_threads, "true"
-                        )
-                        rgw_service.restart()
                     else:
                         bucket_life_cycle = s3lib.resource_op(
                             {
@@ -307,6 +303,12 @@ def test_exec(config, ssh_con):
                 else:
                     lc_ops.validate_prefix_rule(bucket, config)
 
+        if not config.rgw_enable_lc_threads:
+            ceph_conf.set_to_ceph_conf(
+                "global", ConfigOpts.rgw_enable_lc_threads, "true", ssh_con
+            )
+            rgw_service.restart()
+            time.sleep(30)
         reusable.remove_user(each_user)
         # check for any crashes during the execution
         crash_info = reusable.check_for_crash()


### PR DESCRIPTION
Signed-off-by: Anuchaithra Rao <anrao@redhat.com>
This failure has been seen for using more than 1 buckets for execution. Since at the end of 1st bucket execution "rgw_enable_lc_threads set to true", but we exepect it to be false for rest of the bucket as well for this tesetcase. So made changes to set Setting rgw_enable_lc_threads to true(default) at the end of testcase
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-AFAXIF/Control_functionality_for_RGW_lifecycle_0.log

LOG: http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_rgw_enable_lc_threads.console.log