### PR TITLE
BZ-1910503 radosgw-admin bi purge should not return error.

### DIFF
--- a/rgw/v2/lib/resource_op.py
+++ b/rgw/v2/lib/resource_op.py
@@ -285,6 +285,7 @@ class Config(object):
         self.persistent_flag = self.test_ops.get("persistent_flag", False)
         self.copy_object = self.test_ops.get("copy_object", False)
         self.get_topic_info = self.test_ops.get("get_topic_info", False)
+        self.test_bi_purge = self.doc["config"].get("test_bi_purge", False)
         self.set_acl = self.test_ops.get("set_acl", None)
         self.put_empty_bucket_notification = self.test_ops.get(
             "put_empty_bucket_notification", False

--- a/rgw/v2/tests/s3_swift/configs/test_bi_purge.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bi_purge.yaml
@@ -1,0 +1,22 @@
+# test bug 1910503: test_bi_purge
+# Polarian TC : CEPH-83575234
+# script: test_Mbuckets_with_Nobjects.py
+config:
+  user_count: 1
+  bucket_count: 2
+  objects_count: 100
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    create_bucket: true
+    create_object: true
+    download_object: false
+    delete_bucket_object: false
+    sharding:
+      enable: false
+      max_shards: 0
+    compression:
+      enable: false
+      type: zlib
+  test_bi_purge: true


### PR DESCRIPTION
BZ-1910503 radosgw-admin bi purge should not return an error.

In a multi-site environment, to clean up deleted bucket instances and index objects manually we are using the "bi purge" command but it is returning an Error: could not init current bucket info for bucket_name=testing-bucket: (2) No such file or directory

Logs: http://magna002.ceph.redhat.com/ceph-qe-logs/vidushi/logs_bi_purge_test 


Signed-off-by: viduship <vimishra@redhat.com>