### PR TITLE
CEPH-11196 - Enable lifecycle and disable it on a bucket before the objects get expired

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_bucket_lc_disable_object_exp.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_lc_disable_object_exp.yaml
@@ -1,0 +1,19 @@
+# CEPH-11196 - Enable lifecycle and disable it on a bucket before the objects get expired
+# script: test_bucket_lifecycle_config_ops.py
+config:
+  user_count: 1
+  bucket_count: 2
+  objects_count: 100
+  rgw_lc_debug_interval: 60
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    enable_versioning: false
+    version_count: 0
+    create_bucket: true
+    create_object: true
+    rgw_lc_debug: true
+    disable_lifecycle: true
+    verify_lc_disable: true
+    lc_exp_date: "2022-02-19"


### PR DESCRIPTION
create bucket, enable lc and upload objects Then disable lc before its interval. Objects eligible for deltion should not vbe exipired.
LOGs:
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_bucket_lc_disable_object_exp.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_bucket_lc_enable_object_exp.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_rgw_enable_lc_threads.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_bucket_lifecycle_config_read.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_bucket_lifecycle_config_modify.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_bucket_lifecycle_config_disable.console.log

Signed-off-by: Anuchaithra Rao <anrao@redhat.com>