### PR TITLE
Added reshard list and cancel command for multisite DBR feature

### DIFF
--- a/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_reshard_cancel_cmd.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_reshard_cancel_cmd.yaml
@@ -1,0 +1,20 @@
+# script: test_Mbuckets_with_Nobjects.py
+config:
+  user_count: 1
+  bucket_count: 2
+  objects_count: 100
+  reshard_cancel_cmd: true
+  objects_size_range:
+    min: 5K
+    max: 2M
+  test_ops:
+    create_bucket: true
+    create_object: true
+    download_object: true
+    delete_bucket_object: false
+    sharding:
+      enable: false
+      max_shards: 0
+    compression:
+      enable: false
+      type: zlib


### PR DESCRIPTION
Added script support to check reshard list and cancel command from multisite DBR feature is working as expected.
This yaml support will automate following bz
https://bugzilla.redhat.com/show_bug.cgi?id=1831737

Following is the log link of successful run
http://magna002.ceph.redhat.com/ceph-qe-logs/pr_326/
Signed-off-by: uday kurundwade <ukurundw@redhat.com>