### PR TITLE
Added check for running reshard list command On or after 5.3 cluster

### DIFF
--- a/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
+++ b/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
@@ -382,23 +382,26 @@ def test_exec(config, ssh_con):
                                         )
 
                     if config.reshard_cancel_cmd:
-                        op = utils.exec_shell_cmd(
-                            f"radosgw-admin reshard add --bucket {bucket.name} --num-shards 29"
-                        )
-                        op = utils.exec_shell_cmd(f"radosgw-admin reshard list")
-                        if bucket.name in op:
+                        if utils.check_dbr_support():
                             op = utils.exec_shell_cmd(
-                                f"radosgw-admin reshard cancel --bucket {bucket.name}"
+                                f"radosgw-admin reshard add --bucket {bucket.name} --num-shards 29"
                             )
-                            cancel_op = utils.exec_shell_cmd(
-                                f"radosgw-admin reshard list"
-                            )
-                            if bucket.name in cancel_op:
-                                raise TestExecError("bucket is still in reshard queue")
-                        else:
-                            raise TestExecError(
-                                "Command failed....Bucket is not added into reshard queue"
-                            )
+                            op = utils.exec_shell_cmd(f"radosgw-admin reshard list")
+                            if bucket.name in op:
+                                op = utils.exec_shell_cmd(
+                                    f"radosgw-admin reshard cancel --bucket {bucket.name}"
+                                )
+                                cancel_op = utils.exec_shell_cmd(
+                                    f"radosgw-admin reshard list"
+                                )
+                                if bucket.name in cancel_op:
+                                    raise TestExecError(
+                                        "bucket is still in reshard queue"
+                                    )
+                            else:
+                                raise TestExecError(
+                                    "Command failed....Bucket is not added into reshard queue"
+                                )
                     if config.bucket_sync_run:
                         out = utils.check_bucket_sync(bucket.name)
                         if out is False:


### PR DESCRIPTION
Added check for running reshard list command only on or after 5.3 cluster

Following is the log link of successful run
http://magna002.ceph.redhat.com/ceph-qe-logs/pr_327/

Signed-off-by: uday kurundwade <ukurundw@redhat.com>