### PR TITLE
fix rgw_max_objs_per_shard command

### DIFF
--- a/rgw/v2/lib/rgw_config_opts.py
+++ b/rgw/v2/lib/rgw_config_opts.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import sys
@@ -116,7 +117,16 @@ class CephConfigSet:
     def set_to_ceph_cli(self, key, value):
         log.info("setting key and value using ceph config set cli")
         self.prefix = "sudo ceph config set"
-        self.who = "client.rgw"  # naming convention as ceph conf
+
+        cmd_ps = "ceph orch ps --daemon_type rgw -f json"
+        out_ps = utils.exec_shell_cmd(cmd_ps)
+        out = json.loads(out_ps)
+        daemon_name_list = []
+        for node in out:
+            daemon_name = node.get("daemon_name")
+            daemon_name_list.append(daemon_name)
+
+        self.who = "client." + daemon_name_list[0]  # naming convention as ceph conf
         if value is True:
             value = "true"
         log.info(f"got key: {key}")


### PR DESCRIPTION
Signed-off-by: ameenasuhani <ameenasuhani@gmail.com>
Fix rgw_max_objs_per_shard command to take rgw service name instead of default `rgw.client` service

Failure logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-MDTA5U/Test_dynamic_resharding_brownfield_scenario_after_upgrade_0.log 

test logs: http://magna002.ceph.redhat.com/cephci-jenkins/ameena/test_multisite_dynamic_resharding_brownfield.verbose.log