### PR TITLE
Add support for archive zone in sync status

### DIFF
--- a/rgw/v2/lib/sync_status.py
+++ b/rgw/v2/lib/sync_status.py
@@ -58,5 +58,9 @@ def sync_status(retry=10, delay=60):
     # check status for complete sync
     if "data is caught up with source" in check_sync_status:
         log.info("sync status complete")
+    elif (
+        "archive" in check_sync_status and "not syncing from zone" in check_sync_status
+    ):
+        log.info("data from archive zone does not sync to source zone as per design")
     else:
         raise SyncFailedError("sync is either slow or stuck")


### PR DESCRIPTION
Signed-off-by: MadhaviKasturi <mkasturi@redhat.com>

Add support for archive zone, while checking sync status

failure logs - http://magna002.ceph.redhat.com/ceph-qe-logs/madhavi/PRs/archive/ceph-qe-scripts/rgw_failure.log 
Pass logs - http://magna002.ceph.redhat.com/ceph-qe-logs/madhavi/PRs/archive/ceph-qe-scripts/test_Mbuckets_with_Nobjects_console.log 