### PR TITLE
Fix file does not exist failure with mutlipart upload

### DIFF
--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -406,7 +406,6 @@ def upload_mutipart_object(
         log.info("curr part_number: %s" % part_number)
     if config.local_file_delete is True:
         log.info("deleting local file part")
-        utils.exec_shell_cmd(f"rm -rf {s3_object_path}")
         utils.exec_shell_cmd(f"rm -rf {mp_dir}")
     # log.info('parts_info so far: %s'% parts_info)
     if len(parts_list) == part_number:

--- a/rgw/v2/tests/s3_swift/test_bucket_lc_object_exp_multipart.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_lc_object_exp_multipart.py
@@ -91,6 +91,9 @@ def test_exec(config, ssh_con):
                         reusable.upload_mutipart_object(
                             s3_object_name, bucket, TEST_DATA_PATH, config, each_user
                         )
+                        if config.local_file_delete is True:
+                            log.info("deleting local file created after the upload")
+                            utils.exec_shell_cmd("rm -rf %s" % s3_object_path)
                 time.sleep(config.rgw_lc_debug_interval)
 
                 for _ in range(1, 10):

--- a/rgw/v2/tests/s3_swift/test_bucket_lifecycle_config_ops.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_lifecycle_config_ops.py
@@ -61,16 +61,17 @@ def test_exec(config, ssh_con):
     io_info_initialize = IOInfoInitialize()
     basic_io_structure = BasicIOInfoStructure()
     io_info_initialize.initialize(basic_io_structure.initial())
-    ceph_conf = CephConfOp()
+    ceph_conf = CephConfOp(ssh_con)
     rgw_service = RGWService()
     if config.test_ops.get("rgw_lc_debug", False):
         ceph_conf.set_to_ceph_conf(
             "global",
             ConfigOpts.rgw_lc_debug_interval,
             str(config.rgw_lc_debug_interval),
+            ssh_con,
         )
         log.info("trying to restart services")
-        srv_restarted = rgw_service.restart()
+        srv_restarted = rgw_service.restart(ssh_con)
         time.sleep(30)
         if srv_restarted is False:
             raise TestExecError("RGW service restart failed")


### PR DESCRIPTION
Signed-off-by: Anuchaithra Rao <anrao@redhat.com>
To fix issue seen in http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-M1LASU/Test_multipart_upload_of_M_buckets_with_N_objects_pre_upgrade_0.log
"FileNotFoundError: [Errno 2] No such file or directory: '/home/cephuser/rgw-ms-tests/ceph-qe-scripts/rgw/v2/test_data/key_michaelh.520-bucky-4077-0_0'"


LOG: 
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_bucket_lc_object_exp_multipart.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_bucket_lc_multipart_object_expiration.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_Mbuckets_with_Nobjects_multipart.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_bucket_lc_disable_object_exp.console.log
