### PR TITLE
Optimize reshard time, by decreasing reshard thread interval

### DIFF
--- a/rgw/v2/lib/resource_op.py
+++ b/rgw/v2/lib/resource_op.py
@@ -199,7 +199,7 @@ class Config(object):
             "max_rgw_dynamic_shards", 1999
         )
         self.rgw_reshard_thread_interval = self.doc["config"].get(
-            "rgw_reshard_thread_interval", 600
+            "rgw_reshard_thread_interval", 180
         )
         self.max_objects = None
         self.user_max_objects = self.doc["config"].get("user_max_objects")

--- a/rgw/v2/tests/s3_swift/test_dynamic_bucket_resharding.py
+++ b/rgw/v2/tests/s3_swift/test_dynamic_bucket_resharding.py
@@ -143,7 +143,10 @@ def test_exec(config, ssh_con):
         if cmd_exec is False:
             raise TestExecError("manual resharding command execution failed")
 
-    sleep_time = 600
+    log.info(
+        "the sleep time chosen is 180 sec owing to the value of reshard_thread_interval"
+    )
+    sleep_time = 180
     log.info(f"verification starts after waiting for {sleep_time} seconds")
     time.sleep(sleep_time)
     op = utils.exec_shell_cmd("radosgw-admin bucket stats --bucket %s" % bucket.name)


### PR DESCRIPTION
Optimize dynamic reshard time for a bucket, by decreasing reshard thread interval.

earlier we used to induce a sleep of 600 seconds (10mins), for testing if a bucket was dynamically resharded.
These 600 seconds are basically the default value of rgw_reshard_thread_interval (maximum time between rounds of reshard thread processing.)

If we reduce this config to a lower value, we would not have to wait for 10mins.

**This in turn will optimize automation time in all the suite files in cephci across all stages that have the dynamic resharding script.**

Logs for 2 successful runs:
http://magna002.ceph.redhat.com/ceph-qe-logs/vidushi/automation_logs/dbr_logs_180-1-pr-338
http://magna002.ceph.redhat.com/ceph-qe-logs/vidushi/automation_logs/dbr_logs_180-2-pr-338

Signed-off-by: viduship <vimishra@redhat.com>