### PR TITLE
Changed bucket count for bucket_sync_cmd_crash.yaml file to avoid verification failure

### DIFF
--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_sync_cmd_crash.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_sync_cmd_crash.yaml
@@ -2,7 +2,7 @@
 # script: test_Mbuckets_with_Nobjects.py
 config:
   user_count: 1
-  bucket_count: 2
+  bucket_count: 1
   objects_count: 10
   objects_size_range:
     min: 5M


### PR DESCRIPTION
We are seeing failure while running verification part of `test_bucket_sync_cmd_crash.yaml`. This is happening due to hard coded value of bucket name and on second iteration, it is overwriting data. This causing verification failure with md5sum mismatch issue.

To avoid this issue, Reduced iteration to only one.

JIRA link: https://issues.redhat.com/browse/RHCEPHQE-5386
Log of successful run with verification: http://pastebin.test.redhat.com/1074728
Signed-off-by: uday kurundwade <ukurundw@redhat.com>