### PR TITLE
Decresing bucket count to 1 for disable lc testcase

### DIFF
--- a/rgw/standalone/stat_observation.py
+++ b/rgw/standalone/stat_observation.py
@@ -5,36 +5,45 @@ import json
 import subprocess
 import time
 
-bucket_name = <bucket name>
+bucket_name = "<bucket_name>"
 while True:
-        p = subprocess.Popen("cephadm shell -- radosgw-admin sync status", stdout=subprocess.PIPE, shell=True)
-        check_sync_status, err = p.communicate()
-        check_sync_status = str(check_sync_status)
+    p = subprocess.Popen(
+        "cephadm shell -- radosgw-admin sync status", stdout=subprocess.PIPE, shell=True
+    )
+    check_sync_status, err = p.communicate()
+    check_sync_status = str(check_sync_status)
 
-        p = subprocess.Popen("cephadm shell -- date", stdout=subprocess.PIPE, shell=True)
-        dt, err = p.communicate()
-        
+    p = subprocess.Popen("cephadm shell -- date", stdout=subprocess.PIPE, shell=True)
+    dt, err = p.communicate()
 
-        cmd = f"cephadm shell -- radosgw-admin bucket stats --bucket {bucket_name} --format json"
-        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
-        out, err = p.communicate()
+    cmd = f"cephadm shell -- radosgw-admin bucket stats --bucket {bucket_name} --format json"
+    p = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
+    out, err = p.communicate()
 
-        op = json.loads(out)
-        num_object = op["usage"]["rgw.main"]["num_objects"]
-        num_shards = op["num_shards"]
-        bucket = op["bucket"]
-        bucket_id = op["id"]
-        actual_size = op["usage"]["rgw.main"]["size_actual"]
-        current_data =("DATE: " + str(dt)+"\t" + 
-            "Bucket: " + str(bucket) + 
-            " Bucket_ID: " + str(bucket_id) + 
-            " OBJECT_COUNT: " + str(num_object) + 
-            " NUM_SHARDS: " + str(num_shards) + 
-            " Actual_size: " + str(actual_size)
-        )
+    op = json.loads(out)
+    num_object = op["usage"]["rgw.main"]["num_objects"]
+    num_shards = op["num_shards"]
+    bucket = op["bucket"]
+    bucket_id = op["id"]
+    actual_size = op["usage"]["rgw.main"]["size_actual"]
+    current_data = (
+        "DATE: "
+        + str(dt)
+        + "\t"
+        + "Bucket: "
+        + str(bucket)
+        + " Bucket_ID: "
+        + str(bucket_id)
+        + " OBJECT_COUNT: "
+        + str(num_object)
+        + " NUM_SHARDS: "
+        + str(num_shards)
+        + " Actual_size: "
+        + str(actual_size)
+    )
 
-        cmd = f"echo {current_data} >> observation_{bucket_name}"
-        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
-        time.sleep(5)
-        if "data is caught up with source" in check_sync_status:
-                break
+    cmd = f"echo {current_data} >> observation_{bucket_name}"
+    p = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
+    time.sleep(5)
+    if "data is caught up with source" in check_sync_status:
+        break

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_lc_disable_object_exp.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_lc_disable_object_exp.yaml
@@ -2,7 +2,7 @@
 # script: test_bucket_lifecycle_config_ops.py
 config:
   user_count: 1
-  bucket_count: 2
+  bucket_count: 1
   objects_count: 100
   rgw_lc_debug_interval: 60
   objects_size_range:

--- a/rgw/v2/tests/s3_swift/configs/test_dbr_with_custom_objs_per_shard_max_dynamic_shard_and_reshard_thread_interval.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dbr_with_custom_objs_per_shard_max_dynamic_shard_and_reshard_thread_interval.yaml
@@ -7,6 +7,6 @@ config:
   sharding_type: dynamic
   max_objects_per_shard: 1
   max_rgw_dynamic_shards: 200
-  rgw_reshard_thread_interval: 120
+  rgw_reshard_thread_interval: 180
   test_ops:
     delete_bucket_object: true


### PR DESCRIPTION
Signed-off-by: Anuchaithra Rao <anrao@redhat.com>
Setting bucket count to 1 for tesetcase of disabling lc and verifing the behaviour
Testcase getting failed for bucket count >1, since lc debug interval is given as 60sec .
after completion of bucket 1's verification, for 2nd bucket while object upload is in progress lc interval starts and objects starts expiring due to this disble lc verifiaction getting failed
 
dbr : setting rgw_reshard_thread_interval = 180


lc :RGW FAILED (https://reportportal-rhcephqe.apps.ocp-c1.prod.psi.redhat.com/ui/#cephci/launches/all/5360)
	tier-1_rgw_test-lc-multiple-bucket.yaml: Enable lifecycle and disable it on a bucket before objects expires
dbr: RGW Failed (https://reportportal-rhcephqe.apps.ocp-c1.prod.psi.redhat.com/ui/#cephci/launches/5/5395)
	tier-1_rgw_ssl_test-upgrade-5-to-latest.yaml :
		pre upgrade DBR tests with custom objs_per : Expected number of shards not created'
		post upgrade DBR tests with custom objs_per : Expected number of shards not created'
       RGW failed (https://reportportal-rhcephqe.apps.ocp-c1.prod.psi.redhat.com/ui/#cephci/launches/all/5387)
        tier-2_rgw_test_5.3_specific_fixes.yaml: parallel run failure (v2.lib.exceptions.TestExecError: Resource execution failed: object upload failed')
	
Pass log: 
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_bucket_lc_disable_object_exp.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_dbr_with_custom_objs_per_shard_max_dynamic_shard_and_reshard_thread_interval.console.log
