### PR TITLE
Support s3cmd testcases run from client node

### DIFF
--- a/rgw/v2/tests/s3cmd/test_bucket_stats.py
+++ b/rgw/v2/tests/s3cmd/test_bucket_stats.py
@@ -38,7 +38,7 @@ log = logging.getLogger()
 TEST_DATA_PATH = None
 
 
-def test_exec(config):
+def test_exec(config, ssh_con):
     """
     Executes test based on configuration passed
     Args:
@@ -50,7 +50,7 @@ def test_exec(config):
     user_info = resource_op.create_users(no_of_users_to_create=config.user_count)[0]
     user_name = user_info["user_id"]
 
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port()
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
     s3_auth.do_auth(user_info, ip_and_port)
 
     if config.bucket_stats:
@@ -118,13 +118,20 @@ if __name__ == "__main__":
             help="Set Log Level [DEBUG, INFO, WARNING, ERROR, CRITICAL]",
             default="info",
         )
+        parser.add_argument(
+            "--rgw-node", dest="rgw_node", help="RGW Node", default="127.0.0.1"
+        )
         args = parser.parse_args()
         yaml_file = args.config
+        rgw_node = args.rgw_node
+        ssh_con = None
+        if rgw_node != "127.0.0.1":
+            ssh_con = utils.connect_remote(rgw_node)
         log_f_name = os.path.basename(os.path.splitext(yaml_file)[0])
         configure_logging(f_name=log_f_name, set_level=args.log_level.upper())
         config = resource_op.Config(yaml_file)
         config.read()
-        test_exec(config)
+        test_exec(config, ssh_con)
         test_info.success_status("test passed")
         sys.exit(0)
 

--- a/rgw/v2/tests/s3cmd/test_header_size.py
+++ b/rgw/v2/tests/s3cmd/test_header_size.py
@@ -40,7 +40,7 @@ log = logging.getLogger(__name__)
 TEST_DATA_PATH = None
 
 
-def test_exec(config):
+def test_exec(config, ssh_con):
     """
     Executes test based on configuration passed
     Args:
@@ -54,7 +54,7 @@ def test_exec(config):
     for user in user_info:
         user_name = user["user_id"]
 
-        ip_and_port = s3cmd_reusable.get_rgw_ip_and_port()
+        ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
         s3_auth.do_auth(user, ip_and_port)
 
         if not config.header_size:
@@ -136,13 +136,20 @@ if __name__ == "__main__":
             help="Set Log Level [DEBUG, INFO, WARNING, ERROR, CRITICAL]",
             default="info",
         )
+        parser.add_argument(
+            "--rgw-node", dest="rgw_node", help="RGW Node", default="127.0.0.1"
+        )
         args = parser.parse_args()
         yaml_file = args.config
+        rgw_node = args.rgw_node
+        ssh_con = None
+        if rgw_node != "127.0.0.1":
+            ssh_con = utils.connect_remote(rgw_node)
         log_f_name = os.path.basename(os.path.splitext(yaml_file)[0])
         configure_logging(f_name=log_f_name, set_level=args.log_level.upper())
         config = resource_op.Config(yaml_file)
         config.read()
-        test_exec(config)
+        test_exec(config, ssh_con)
         test_info.success_status("test passed")
         sys.exit(0)
 

--- a/rgw/v2/tests/s3cmd/test_large_object_gc.py
+++ b/rgw/v2/tests/s3cmd/test_large_object_gc.py
@@ -47,7 +47,7 @@ log = logging.getLogger()
 TEST_DATA_PATH = None
 
 
-def test_exec(config):
+def test_exec(config, ssh_con):
     """
     Executes test based on configuration passed
     Args:
@@ -67,7 +67,7 @@ def test_exec(config):
     )
     umgmt.create_subuser(tenant_name=tenant, user_id=user_name)
 
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port()
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
     s3_auth.do_auth(tenant_user_info, ip_and_port)
 
     bucket_name = utils.gen_bucket_name_from_userid(user_name, rand_no=0)
@@ -165,13 +165,20 @@ if __name__ == "__main__":
             help="Set Log Level [DEBUG, INFO, WARNING, ERROR, CRITICAL]",
             default="info",
         )
+        parser.add_argument(
+            "--rgw-node", dest="rgw_node", help="RGW Node", default="127.0.0.1"
+        )
         args = parser.parse_args()
         yaml_file = args.config
+        rgw_node = args.rgw_node
+        ssh_con = None
+        if rgw_node != "127.0.0.1":
+            ssh_con = utils.connect_remote(rgw_node)
         log_f_name = os.path.basename(os.path.splitext(yaml_file)[0])
         configure_logging(f_name=log_f_name, set_level=args.log_level.upper())
         config = resource_op.Config(yaml_file)
         config.read()
-        test_exec(config)
+        test_exec(config, ssh_con)
         test_info.success_status("test passed")
         sys.exit(0)
 

--- a/rgw/v2/tests/s3cmd/test_rgw_ops_log.py
+++ b/rgw/v2/tests/s3cmd/test_rgw_ops_log.py
@@ -50,7 +50,7 @@ log = logging.getLogger()
 TEST_DATA_PATH = None
 
 
-def test_exec(config):
+def test_exec(config, ssh_con):
     """
     Executes test based on configuration passed
     Args:
@@ -63,7 +63,7 @@ def test_exec(config):
     user_name = user_info["user_id"]
     rgw_service = RGWService()
 
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port()
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
     s3_auth.do_auth(user_info, ip_and_port)
 
     if config.rgw_ops_log:
@@ -144,13 +144,20 @@ if __name__ == "__main__":
             help="Set Log Level [DEBUG, INFO, WARNING, ERROR, CRITICAL]",
             default="info",
         )
+        parser.add_argument(
+            "--rgw-node", dest="rgw_node", help="RGW Node", default="127.0.0.1"
+        )
         args = parser.parse_args()
         yaml_file = args.config
+        rgw_node = args.rgw_node
+        ssh_con = None
+        if rgw_node != "127.0.0.1":
+            ssh_con = utils.connect_remote(rgw_node)
         log_f_name = os.path.basename(os.path.splitext(yaml_file)[0])
         configure_logging(f_name=log_f_name, set_level=args.log_level.upper())
         config = resource_op.Config(yaml_file)
         config.read()
-        test_exec(config)
+        test_exec(config, ssh_con)
         test_info.success_status("test passed")
         sys.exit(0)
 

--- a/rgw/v2/tests/s3cmd/test_s3cmd.py
+++ b/rgw/v2/tests/s3cmd/test_s3cmd.py
@@ -45,7 +45,7 @@ from v2.utils.utils import RGWService
 log = logging.getLogger()
 
 
-def test_exec(config):
+def test_exec(config, ssh_con):
     """
     Executes test based on configuration passed
     Args:
@@ -58,12 +58,8 @@ def test_exec(config):
     umgmt = UserMgmt()
     ceph_conf = CephConfOp()
     rgw_service = RGWService()
-    # preparing data
-    hostname = socket.gethostname()
-    ip = socket.gethostbyname(hostname)
-    port = utils.get_radosgw_port_no()
 
-    ip_and_port = f"{ip}:{port}"
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
 
     # Verifying CEPH-83574806
     if config.delete_marker_check:
@@ -72,7 +68,7 @@ def test_exec(config):
         )
         user_info = resource_op.create_users(no_of_users_to_create=1)
         s3_auth.do_auth(user_info[0], ip_and_port)
-        auth = Auth(user_info[0], ssl=config.ssl)
+        auth = Auth(user_info[0], ssh_con, ssl=config.ssl)
         rgw_conn = auth.do_auth()
         bucket_name = utils.gen_bucket_name_from_userid(
             user_info[0]["user_id"], rand_no=1
@@ -172,13 +168,20 @@ if __name__ == "__main__":
             help="Set Log Level [DEBUG, INFO, WARNING, ERROR, CRITICAL]",
             default="info",
         )
+        parser.add_argument(
+            "--rgw-node", dest="rgw_node", help="RGW Node", default="127.0.0.1"
+        )
         args = parser.parse_args()
         yaml_file = args.config
+        rgw_node = args.rgw_node
+        ssh_con = None
+        if rgw_node != "127.0.0.1":
+            ssh_con = utils.connect_remote(rgw_node)
         log_f_name = os.path.basename(os.path.splitext(yaml_file)[0])
         configure_logging(f_name=log_f_name, set_level=args.log_level.upper())
         config = resource_op.Config(yaml_file)
         config.read()
-        test_exec(config)
+        test_exec(config, ssh_con)
         test_info.success_status("test passed")
         sys.exit(0)
 


### PR DESCRIPTION
Signed-off-by: ckulal <ckulal@redhat.com>

Support s3cmd test-cases run from client node.

6.0 Logs:
**S3CMD basic operations**:
 http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-EFW503/S3CMD_basic_operations_0.log	

**S3CMD large object download with GC**:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-EFW503/S3CMD_large_object_download_with_GC_0.log

**S3CMD bucket stats consistency** :
 http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-EFW503/S3CMD_bucket_stats_consistency_0.log

**S3CMD object header size check** : 
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-EFW503/S3CMD_object_header_size_check_0.log

**S3CMD tests** : 
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-EFW503/S3CMD_tests_0.log

**Test single delete marker for versioned object using s3cmd** : 
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-EFW503/Test_single_delete_marker_for_versioned_object_using_s3cmd_0.log


5.3 Logs:
**S3CMD basic operations**:
 http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-C1XG0N/S3CMD_basic_operations_0.log

**S3CMD large object download with GC**:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-C1XG0N/S3CMD_large_object_download_with_GC_0.log

**S3CMD bucket stats consistency** :
 http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-C1XG0N/S3CMD_bucket_stats_consistency_0.log

**S3CMD object header size check** : 
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-C1XG0N/S3CMD_object_header_size_check_0.log

**S3CMD tests** : 
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-C1XG0N/S3CMD_tests_0.log

**Test single delete marker for versioned object using s3cmd** : 
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-C1XG0N/Test_single_delete_marker_for_versioned_object_using_s3cmd_0.log
