### PR TITLE
Support quota-management testcase to execute from client node

### DIFF
--- a/rgw/v2/tests/s3_swift/test_quota_management.py
+++ b/rgw/v2/tests/s3_swift/test_quota_management.py
@@ -41,7 +41,7 @@ import logging
 log = logging.getLogger()
 
 
-def test_exec(config):
+def test_exec(config, ssh_con):
 
     io_info_initialize = IOInfoInitialize()
     basic_io_structure = BasicIOInfoStructure()
@@ -51,7 +51,7 @@ def test_exec(config):
     all_users_info = s3lib.create_users(config.user_count)
 
     for each_user in all_users_info:
-        auth = Auth(each_user, ssl=config.ssl)
+        auth = Auth(each_user, ssh_con, ssl=config.ssl)
         rgw_conn = auth.do_auth()
         log.info(f"Creating {config.bucket_count} buckets for {each_user['user_id']}")
         for bc in range(config.bucket_count):
@@ -124,13 +124,20 @@ if __name__ == "__main__":
             help="Set Log Level [DEBUG, INFO, WARNING, ERROR, CRITICAL]",
             default="info",
         )
+        parser.add_argument(
+            "--rgw-node", dest="rgw_node", help="RGW Node", default="127.0.0.1"
+        )
         args = parser.parse_args()
         yaml_file = args.config
+        rgw_node = args.rgw_node
+        ssh_con = None
+        if rgw_node != "127.0.0.1":
+            ssh_con = utils.connect_remote(rgw_node)
         log_f_name = os.path.basename(os.path.splitext(yaml_file)[0])
         configure_logging(f_name=log_f_name, set_level=args.log_level.upper())
         config = Config(yaml_file)
         config.read()
-        test_exec(config)
+        test_exec(config, ssh_con)
         test_info.success_status("test passed")
         sys.exit(0)
 


### PR DESCRIPTION
Signed-off-by: ckulal <ckulal@redhat.com>
Support quota-management testcase to execute from client node

log: 

6.0:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-0LC9Q9/test_bucket_quota_max_objects_0.log
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-0LC9Q9/test_bucket_quota_max_size_0.log
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-0LC9Q9/test_user_quota_max_objects_0.log
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-0LC9Q9/test_user_quota_max_size_0.log

5.3:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-REX65N/test_bucket_quota_max_objects_0.log
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-REX65N/test_bucket_quota_max_size_0.log
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-REX65N/test_user_quota_max_objects_0.log
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-REX65N/test_user_quota_max_size_0.log
