### PR TITLE
Delete bucket after suspend is enabled

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_versioning_objects_suspended_delete.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_versioning_objects_suspended_delete.yaml
@@ -1,0 +1,17 @@
+# upload type: non multipart
+# script: test_versioning_with_objects.py
+config:
+     user_count: 1
+     bucket_count: 2
+     objects_count: 100
+     version_count: 4
+     objects_size_range:
+          min: 5
+          max: 15
+     test_ops:
+          enable_version: true
+          suspend_version: true
+          copy_to_version: false # this is same as revert and restore object
+          delete_object_versions: false
+          upload_after_suspend: false
+          delete_after_suspend: true


### PR DESCRIPTION
Description: Delete bucket after suspend is enabled
jira: https://issues.redhat.com/browse/RHCEPHQE-4660

Polarion ID - [CEPH-9195](https://polarion.engineering.redhat.com/polarion/redirect/project/CEPH/workitem?id=CEPH-9195) - [RGW]: Delete objects in a version suspended bucket 

As per aws doc it is expected that after bucket version is suspended the delete can happen using version id
https://docs.aws.amazon.com/AmazonS3/latest/userguide/DeletingObjectsfromVersioningSuspendedBuckets.html