### PR TITLE
Connect to rgw host as cephuser instead of root user

### DIFF
--- a/rgw/v2/utils/utils.py
+++ b/rgw/v2/utils/utils.py
@@ -52,7 +52,7 @@ def exec_shell_cmd(cmd, debug_info=False):
         return False
 
 
-def connect_remote(rgw_host, user_nm="root", passw="passwd"):
+def connect_remote(rgw_host, user_nm="cephuser", passw="cephuser"):
     ssh = paramiko.SSHClient()
     ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
     ssh.connect(rgw_host, port=22, username=user_nm, password=passw, timeout=3)


### PR DESCRIPTION
Signed-off-by: ckulal <ckulal@redhat.com>

Connect to rgw host as cephuser instead of root user

Pass Log: run from client node
s3cmd: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-KNCY25/
Tier-0: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-KWW5WQ/

Pass log: run from rgw node
tier-0: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-BLWND9/
s3cmd: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-EHNXRP/



**Runs from IBM**
```
python run.py --osp-cred /home/cephuser/osp-cred-ci-2.yaml --instances-name ci-anrao --log-level DEBUG --xunit-results --cloud ibmc _--suite suites/pacific/rgw/tier-0_rgw.yaml_ --global-conf conf/pacific/rgw/tier-0_rgw.yaml --_platform rhel-8 --rhbuild 5.3_ --inventory conf/inventory/ibm-vpc-rhel-8-latest.yaml --build latest
All test logs located here: /tmp/cephci-run-98HIXZ

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
setup pre-requisites             Install software pre-requisites for cluster deployment.        0:12:34.510292                   Pass                             
RHCS deploy cluster using ceph   bootstrap with registry-url option and deployment services.    0:09:33.021055                   Pass                             
Monitoring Service(s) deployme   Add monitoring services using spec file.                       0:09:29.682535                   Pass                             
configure client                 Configure the RGW client system                                0:00:22.319992                   Pass                             
Test M buckets with N objects    test to create "M" no of buckets and "N" no of objects         0:01:35.616722                   Pass                             
Test delete using M buckets wi   test to create "M" no of buckets and "N" no of objects with    0:01:40.096445                   Pass                             
Test download with M buckets w   test to create "M" no of buckets and "N" no of objects with    0:00:59.982962                   Pass                             
Test multipart upload of M buc   test to create "M" no of buckets and "N" no of objects with    0:01:33.986917                   Pass                             
Swift based tests                Test object operations with swift                              0:00:38.836662                   Pass                             
2022-11-24 05:01:39,844 - INFO - cephci.run.py:1069 - final rc of test run 0


python run.py --osp-cred /home/cephuser/osp-cred-ci-2.yaml --instances-name ci-60-anrao --log-level DEBUG --xunit-results _--cloud ibmc --suite suites/quincy/rgw/tier-2_rgw_test_bucket_notifications.yaml_ --global-conf conf/quincy/rgw/tier-0_rgw.yaml _--platform rhel-9 --rhbuild 6.0_ --inventory conf/inventory/ibm-vpc-rhel-9-latest.yaml --custom-config grafana_image=ceph-qe-registry.syd.qe.rhceph.local/rh-osbs/grafana:ceph-6.0-rhel-9-containers-candidate-99494-20221026123006 --custom-config promtail_image=ceph-qe-registry.syd.qe.rhceph.local/rh-osbs/promtail:ceph-6.0-rhel-9-containers-candidate-10191-20221026120801 --custom-config haproxy_image=ceph-qe-registry.syd.qe.rhceph.local/rh-osbs/haproxy:ceph-6.0-rhel-9-containers-candidate-53939-20221026121907 --custom-config keepalived_image=ceph-qe-registry.syd.qe.rhceph.local/rh-osbs/keepalived:ceph-6.0-rhel-9-containers-candidate-18945-20221026120854 --custom-config snmp_gateway_image=ceph-qe-registry.syd.qe.rhceph.local/rh-osbs/snmp-notifier:ceph-6.0-rhel-9-containers-candidate-15559-20221026120853 --build latest
All test logs located here: /tmp/cephci-run-RQU7DS

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
setup pre-requisites             Install software pre-requisites for cluster deployment.        0:08:47.621641                   Pass                             
deploy cluster                   RHCS cluster deployment using cephadm.                         0:11:59.455829                   Pass                             
notify put,delete events with    notify put,delete events with kafka_broker_persistent          0:04:39.444355                   Pass                             
notify copy events with kafka_   notify copy events with kafka_broker_persistent                0:01:48.442507                   Pass                             
notify on multipart upload eve   notify on multipart upload events with kafka_broker_persiste   0:01:47.357766                   Failed (https://bugzilla.redhat.com/show_bug.cgi?id=1959254)                 
notify put,delete events with    notify put,delete events with kafka_none_persistent            0:02:09.743591                   Pass                             
notify copy events with kafka_   notify copy events with kafka_none_persistent                  0:01:46.816476                   Pass                             
notify on multipart upload eve   notify on multipart upload events with kafka_none_persistent   0:01:44.311301                   Pass                             
notify put,delete events with    notify put,delete events with kafka_none                       0:02:08.339844                   Pass                             
notify copy events with kafka_   notify copy events with kafka_none                             0:01:44.031707                   Pass                             
notify on multipart upload eve   notify on multipart upload events with kafka_none              0:01:45.013559                   Pass                             
notify put,delete events with    notify put,delete events with kafka_broker                     0:04:37.092954                   Pass                             
notify copy events with kafka_   notify copy events with kafka_broker                           0:03:17.771008                   Pass                             
notify on multipart upload eve   notify on multipart upload events with kafka_broker            0:02:52.412355                   Failed (https://bugzilla.redhat.com/show_bug.cgi?id=1959254)
check-ceph-health                Check for ceph health debug info                               0:00:02.528020                   Pass                             



python run.py --osp-cred /home/cephuser/osp-cred-ci-2.yaml --instances-name ci-anrao-s3cmd --log-level DEBUG --xunit-results _--cloud ibmc --suite suites/pacific/rgw/tier-2_rgw_test-using-s3cmd.yaml_ --global-conf conf/pacific/rgw/tier-0_rgw.yaml _--platform rhel-9 --rhbuild 5.3_ --inventory conf/inventory/ibm-vpc-rhel-9-latest.yaml --build latest
All test logs located here: /tmp/cephci-run-19JNBZ

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
setup pre-requisites             Install software pre-requisites for cluster deployment.        0:08:55.653745                   Pass                             
deploy cluster                   RHCS cluster deployment using cephadm.                         0:11:43.767420                   Pass                             
Monitoring Services deployment   Add monitoring services using spec file.                       0:11:19.280438                   Pass                             
S3CMD basic  operations          S3CMD basic  operations                                        0:00:49.050326                   Pass                             
S3CMD large object download wi   S3CMD large object download with GC                            0:02:40.398233                   Pass                             
S3CMD bucket stats consistency   S3CMD bucket stats consistency                                 0:04:06.680077                   Pass                             
S3CMD object header size check   S3CMD object header size check                                 0:00:16.354988                   Pass                             
S3CMD tests                      S3CMD tests, Testing rgw opslog                                0:00:16.453459                   Pass                             
Test single delete marker for    Test single delete marker for versioned object using s3cmd     0:00:16.838015                   Pass                             
2022-11-24 05:32:59,042 - INFO - cephci.run.py:1069 - final rc of test run 0


python run.py --osp-cred /home/cephuser/osp-cred-ci-2.yaml --instances-name ci-anrao-ms --log-level DEBUG --xunit-results _--cloud ibmc --suite suites/pacific/rgw/tier-1-extn_rgw_multisite-secondary-to-primary.yaml_ --global-conf conf/pacific/rgw/rgw_multisite.yaml _--platform rhel-8 --rhbuild 5.3_ --inventory conf/inventory/ibm-vpc-rhel-8-latest.yaml --build latest
All test logs located here: /tmp/cephci-run-XPTUEO

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
setup pre-requisites             Install software pre-requisites for cluster deployment.        0:49:21.360219                   Pass                             
deploy cluster                   RHCS cluster deployment using cephadm.                         0:29:31.349207                   Pass                             
Monitoring Service deployment    Add monitoring services using spec file.                       0:19:06.584113                   Pass                             
configure client                 Configure the RGW client system                                0:00:44.666728                   Pass                             
setup multisite                  Setting up RGW multisite replication environment               0:03:10.042390                   Pass                             
get shared realm info on prima   Retrieve the configured environment details                    0:00:09.644595                   Pass                             
get shared realm info on secon   Retrieve the configured environment details                    0:00:10.870182                   Pass                             
create non-tenanted user         create non-tenanted user                                       0:03:45.628923                   Pass                             
datalog omap offload on second   Execute datalog omap offload on secondary                      0:11:10.105532                   Failed  (metadata sync: https://github.com/red-hat-storage/ceph-qe-scripts/pull/362)                       
datalog omap offload with mult   Execute datalog omap offload with multipart objects on secon   0:12:40.588417                   Pass                             
datalog omap offload on versio   Execute datalog omap offload on versioned bucket on secondar   0:05:18.761774                   Pass                             
datalog trim command with dele   Execute datalog trim command with delete marker enabled on s   0:05:24.513580                   Pass                             
Test DBR reshard list and canc   Test DBR reshard list and cancel command on secondary          0:05:16.944344                   Pass ```