### PR TITLE
fixing <document_start> expected error while parsing io_info yaml file

### DIFF
--- a/rgw/v2/lib/read_io_info.py
+++ b/rgw/v2/lib/read_io_info.py
@@ -225,5 +225,5 @@ if __name__ == "__main__":
     yaml_file = args.config
     IO_INFO_FNAME = f"io_info_{os.path.basename(yaml_file)}"
     IoInfoConfig(io_info_fname=IO_INFO_FNAME)
-    read_io_info = ReadIOInfo()
+    read_io_info = ReadIOInfo(IO_INFO_FNAME)
     read_io_info.verify_io()

--- a/rgw/v2/lib/s3/write_io_info.py
+++ b/rgw/v2/lib/s3/write_io_info.py
@@ -3,6 +3,7 @@ import os
 import sys
 
 sys.path.append(os.path.abspath(os.path.join(__file__, "../../../")))
+from v2.utils.io_info_config import IoInfoConfig
 from v2.utils.utils import FileOps
 
 log = logging.getLogger()
@@ -87,7 +88,9 @@ class AddIOInfo(object):
     This class creates yaml with fname provided
     """
 
-    def __init__(self, yaml_fname=IO_INFO_FNAME):
+    def __init__(self, yaml_fname=None):
+        if yaml_fname == None:
+            yaml_fname = IoInfoConfig().io_info_fname
         self.yaml_fname = yaml_fname
         self.file_op = FileOps(self.yaml_fname, type="yaml")
 

--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -27,10 +27,6 @@ from v2.lib.s3.write_io_info import (
 from v2.lib.sync_status import sync_status
 from v2.utils.utils import HttpResponseParser, RGWService
 
-io_info_initialize = IOInfoInitialize()
-basic_io_structure = BasicIOInfoStructure()
-write_bucket_io_info = BucketIoInfo()
-write_key_io_info = KeyIoInfo()
 rgw_service = RGWService()
 
 log = logging.getLogger()
@@ -209,6 +205,7 @@ def upload_version_object(
             log.info("object uploaded")
             s3_obj = rgw_conn.Object(bucket.name, s3_object_name)
             log.info("current_version_id: %s" % s3_obj.version_id)
+            basic_io_structure = BasicIOInfoStructure()
             key_version_info = basic_io_structure.version_info(
                 **{
                     "version_id": s3_obj.version_id,
@@ -218,6 +215,7 @@ def upload_version_object(
                 }
             )
             log.info("key_version_info: %s" % key_version_info)
+            write_key_io_info = KeyIoInfo()
             write_key_io_info.add_versioning_info(
                 user_info["access_key"], bucket.name, s3_object_path, key_version_info
             )
@@ -803,6 +801,7 @@ def delete_version_object(
             response = HttpResponseParser(del_obj_version)
             if response.status_code == 204:
                 log.info("version deleted ")
+                write_key_io_info = KeyIoInfo()
                 write_key_io_info.delete_version_info(
                     user_info["access_key"],
                     bucket.name,

--- a/rgw/v2/utils/utils.py
+++ b/rgw/v2/utils/utils.py
@@ -16,7 +16,6 @@ from re import S
 import paramiko
 import yaml
 from v2.lib.exceptions import SyncFailedError
-from v2.utils.io_info_config import IoInfoConfig
 
 BUCKET_NAME_PREFIX = "bucky" + "-" + str(random.randrange(1, 5000))
 S3_OBJECT_NAME_PREFIX = "key"
@@ -147,7 +146,6 @@ class FileOps(object):
 
     def get_data(self):
         data = None
-        self.fname = IoInfoConfig().io_info_fname
         with open(self.fname, "r") as fp:
             if self.type == "json":
                 data = json.load(fp)
@@ -161,7 +159,6 @@ class FileOps(object):
         return data
 
     def add_data(self, data, ssh_con=None):
-        self.fname = IoInfoConfig().io_info_fname
         with open(self.fname, "w") as fp:
             if self.type == "json":
                 json.dump(data, fp, indent=4)


### PR DESCRIPTION
pass logs:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-VPUXF4/
failures in the above logs are known issue

logs of test cases which are calling upload_version_object and delete_version_object as small changes are made to those methods:
http://magna002.ceph.redhat.com/ceph-qe-logs/HemanthSai/revert_fileops_changes/

logs of testcases which calls reusable.enable_versioning() method as write_bucket_io_info is removed in this PR:
http://magna002.ceph.redhat.com/ceph-qe-logs/HemanthSai/revert_fileops/