### PR TITLE
SSE-S3 (per-bucket and per-object) with vault backend

### DIFF
--- a/rgw/v2/lib/resource_op.py
+++ b/rgw/v2/lib/resource_op.py
@@ -245,6 +245,24 @@ class Config(object):
         )
         self.delete_marker_check = self.doc["config"].get("delete_marker_check", False)
         self.invalid_date = self.doc["config"].get("invalid_date", False)
+        self.rgw_crypt_require_ssl = self.doc["config"].get(
+            "rgw_crypt_require_ssl", "false"
+        )
+        self.rgw_crypt_sse_s3_backend = self.doc["config"].get(
+            "rgw_crypt_sse_s3_backend", "vault"
+        )
+        self.rgw_crypt_sse_s3_vault_addr = self.doc["config"].get(
+            "rgw_crypt_sse_s3_vault_addr", "http://127.0.0.1:8100"
+        )
+        self.rgw_crypt_sse_s3_vault_auth = self.doc["config"].get(
+            "rgw_crypt_sse_s3_vault_auth", "agent"
+        )
+        self.rgw_crypt_sse_s3_vault_secret_engine = self.doc["config"].get(
+            "rgw_crypt_sse_s3_vault_secret_engine", "transit"
+        )
+        self.rgw_crypt_sse_s3_vault_prefix = self.doc["config"].get(
+            "rgw_crypt_sse_s3_vault_prefix", "/v1/cephTransit"
+        )
         self.dynamic_resharding = self.doc["config"].get("dynamic_resharding", False)
         self.manual_resharding = self.doc["config"].get("manual_resharding", False)
         self.reshard_cancel_cmd = self.doc["config"].get("reshard_cancel_cmd", False)
@@ -296,6 +314,7 @@ class Config(object):
         self.persistent_flag = self.test_ops.get("persistent_flag", False)
         self.copy_object = self.test_ops.get("copy_object", False)
         self.get_topic_info = self.test_ops.get("get_topic_info", False)
+        self.sse_s3_per_bucket = self.test_ops.get("sse_s3_per_bucket", False)
         self.test_bi_purge = self.doc["config"].get("test_bi_purge", False)
         self.set_acl = self.test_ops.get("set_acl", None)
         self.put_empty_bucket_notification = self.test_ops.get(

--- a/rgw/v2/lib/rgw_config_opts.py
+++ b/rgw/v2/lib/rgw_config_opts.py
@@ -41,6 +41,12 @@ class ConfigOpts(object):
     rgw_swift_versioning_enabled = "rgw_swift_versioning_enabled"
     rgw_sts_key = "rgw_sts_key"
     rgw_s3_auth_use_sts = "rgw_s3_auth_use_sts"
+    rgw_crypt_require_ssl = "rgw_crypt_require_ssl"
+    rgw_crypt_sse_s3_backend = "rgw_crypt_sse_s3_backend"
+    rgw_crypt_sse_s3_vault_addr = "rgw_crypt_sse_s3_vault_addr"
+    rgw_crypt_sse_s3_vault_auth = "rgw_crypt_sse_s3_vault_auth"
+    rgw_crypt_sse_s3_vault_prefix = "rgw_crypt_sse_s3_vault_prefix"
+    rgw_crypt_sse_s3_vault_secret_engine = "rgw_crypt_sse_s3_vault_secret_engine"
 
 
 class CephConfFileOP(FileOps, ConfigParse):

--- a/rgw/v2/tests/s3_swift/configs/test_sse_s3_per_bucket_encryption_normal_object_upload.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_s3_per_bucket_encryption_normal_object_upload.yaml
@@ -1,0 +1,13 @@
+config:
+ user_count: 1
+ bucket_count: 2
+ objects_count: 100
+ objects_size_range:
+  min: 5
+  max: 15
+ test_ops:
+  create_bucket: true
+  create_object: true
+  enable_version: false
+  sse_s3_per_bucket: true
+  upload_type: normal

--- a/rgw/v2/tests/s3_swift/configs/test_sse_s3_per_bucket_encryption_version_enabled.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_s3_per_bucket_encryption_version_enabled.yaml
@@ -1,0 +1,13 @@
+config:
+ user_count: 1
+ bucket_count: 2
+ objects_count: 50
+ objects_size_range:
+  min: 5
+  max: 15
+ test_ops:
+  create_bucket: true
+  create_object: true
+  enable_version: true
+  sse_s3_per_bucket: true
+  upload_type: normal

--- a/rgw/v2/tests/s3_swift/configs/test_sse_s3_per_object.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_s3_per_object.yaml
@@ -1,0 +1,12 @@
+config:
+ user_count: 1
+ bucket_count: 2
+ objects_count: 100
+ objects_size_range:
+  min: 5
+  max: 15
+ test_ops:
+  create_bucket: true
+  create_object: true
+  enable_version: false
+  sse_s3_per_bucket: false

--- a/rgw/v2/tests/s3_swift/configs/test_sse_s3_per_object_versioninig_enabled.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_s3_per_object_versioninig_enabled.yaml
@@ -1,0 +1,12 @@
+config:
+ user_count: 1
+ bucket_count: 2
+ objects_count: 50
+ objects_size_range:
+  min: 5
+  max: 15
+ test_ops:
+  create_bucket: true
+  create_object: true
+  enable_version: true
+  sse_s3_per_bucket: false

--- a/rgw/v2/tests/s3_swift/reusables/server_side_encryption_s3.py
+++ b/rgw/v2/tests/s3_swift/reusables/server_side_encryption_s3.py
@@ -1,0 +1,70 @@
+import json
+import logging
+import os
+import random
+import time
+import timeit
+from urllib import parse as urlparse
+
+import v2.utils.utils as utils
+from v2.lib.exceptions import EventRecordDataError
+
+log = logging.getLogger()
+
+
+def put_bucket_encryption(s3_client, bucketname):
+    """
+    put bucket encryption on a given bucket.
+    """
+    log.info(f"put bucket encryption on {bucketname}")
+    ssec_s3 = {
+        "Rules": [{"ApplyServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"}}]
+    }
+    put_bkt_encryption = s3_client.put_bucket_encryption(
+        Bucket=bucketname, ServerSideEncryptionConfiguration=ssec_s3
+    )
+
+    if put_bkt_encryption is False:
+        raise TestExecError("put bucket encryption failed")
+
+
+def get_bucket_encryption(s3_client, bucketname):
+    """
+    get bucket notification for a given bucket
+    """
+    get_bkt_encryption = s3_client.get_bucket_encryption(Bucket=bucketname)
+    if get_bkt_encryption is False:
+        raise TestExecError("get bucket encryption failed")
+
+    get_bkt_encryption_json = json.dumps(get_bkt_encryption, indent=2)
+    log.info(f"bucket encryption for bucket: {bucketname} is {get_bkt_encryption_json}")
+
+
+def get_object_encryption(s3_client, bucketname, s3_object_name):
+    """
+    get object encryption for an object, it should be AES256
+    """
+    log.info(f"Test if object uploaded is encrypted with AES256")
+    get_obj_encryption = s3_client.get_object(Bucket=bucketname, Key=s3_object_name)
+    log.info(
+        f"server side encryption enabled on {s3_object_name} is : {get_obj_encryption['ServerSideEncryption']}"
+    )
+    result = get_obj_encryption["ServerSideEncryption"]
+    if result != "AES256":
+        raise TestExecError("object encryption has failed")
+
+
+def put_object_encryption(s3_client, bucketname, s3_object_name):
+    """
+    put object encryption for an object, it should be AES256
+    """
+    log.info(f"Enable object encryption when object is uploaded.")
+    put_obj_encryption = s3_client.put_object(
+        Bucket=bucketname,
+        Key=s3_object_name,
+        Body="Sinister sisters hide in plain view",
+        ServerSideEncryption="AES256",
+    )
+
+    if not put_obj_encryption:
+        raise TestExecError("put object encryption failed")

--- a/rgw/v2/tests/s3_swift/test_ss3_s3_with_vault.py
+++ b/rgw/v2/tests/s3_swift/test_ss3_s3_with_vault.py
@@ -1,0 +1,248 @@
+"""
+test sse-s3 encryption with vault backend at per-bucket or per-object level.
+Usage: test_sse_s3_with_vault.py -c <input_yaml>
+<input_yaml>
+    Note: any one of these yamls can be used
+    test_sse_s3_per_bucket_encryption_normal_object_upload.yaml
+    test_sse_s3_per_bucket_encryption_multipart_object_upload.yaml
+    test_sse_s3_per_bucket_encryption_version_enabled.yaml
+    test_sse_s3_per_object.yaml
+    test_sse_s3_per_object_versioninig_enabled.yaml
+
+Operation:
+    Create a user and create a bucket with user credentials
+    enable per-bucket or per-object sse-s3 encryption with vault backend
+    test objects uploaded are encrypted with AES256. 
+
+"""
+
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(__file__, "../../../..")))
+import argparse
+import hashlib
+import json
+import logging
+import random
+import time
+import traceback
+import uuid
+
+import v2.lib.manage_data as manage_data
+import v2.lib.resource_op as s3lib
+import v2.utils.utils as utils
+from v2.lib.exceptions import EventRecordDataError, RGWBaseException, TestExecError
+from v2.lib.resource_op import Config
+from v2.lib.rgw_config_opts import CephConfOp, ConfigOpts
+from v2.lib.s3.auth import Auth
+from v2.lib.s3.write_io_info import BasicIOInfoStructure, BucketIoInfo, IOInfoInitialize
+from v2.tests.s3_swift import reusable
+from v2.tests.s3_swift.reusables import server_side_encryption_s3 as sse_s3
+from v2.utils.log import configure_logging
+from v2.utils.test_desc import AddTestInfo
+from v2.utils.utils import RGWService
+
+log = logging.getLogger()
+TEST_DATA_PATH = None
+import pdb
+
+pdb.set_trace()
+
+
+def test_exec(config, ssh_con):
+
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    write_bucket_io_info = BucketIoInfo()
+    io_info_initialize.initialize(basic_io_structure.initial())
+    ceph_conf = CephConfOp(ssh_con)
+    rgw_service = RGWService()
+
+    # create user
+    all_users_info = s3lib.create_users(config.user_count)
+    for each_user in all_users_info:
+        # authenticate
+        auth = Auth(each_user, ssh_con, ssl=config.ssl)
+        rgw_conn = auth.do_auth()
+
+        # authenticate with s3 client
+        s3_client = auth.do_auth_using_client()
+
+        # get ceph version
+        ceph_version_id, ceph_version_name = utils.get_ceph_version()
+        log.info("sse-s3 configuration will be added now.")
+        ceph_conf.set_to_ceph_conf(
+            "global",
+            ConfigOpts.rgw_crypt_require_ssl,
+            str(config.rgw_crypt_require_ssl),
+            ssh_con,
+        )
+        ceph_conf.set_to_ceph_conf(
+            "global",
+            ConfigOpts.rgw_crypt_sse_s3_backend,
+            str(config.rgw_crypt_sse_s3_backend),
+            ssh_con,
+        )
+        ceph_conf.set_to_ceph_conf(
+            "global",
+            ConfigOpts.rgw_crypt_sse_s3_vault_auth,
+            str(config.rgw_crypt_sse_s3_vault_auth),
+            ssh_con,
+        )
+        ceph_conf.set_to_ceph_conf(
+            "global",
+            ConfigOpts.rgw_crypt_sse_s3_vault_prefix,
+            str(config.rgw_crypt_sse_s3_vault_prefix),
+            ssh_con,
+        )
+        ceph_conf.set_to_ceph_conf(
+            "global",
+            ConfigOpts.rgw_crypt_sse_s3_vault_secret_engine,
+            str(config.rgw_crypt_sse_s3_vault_secret_engine),
+            ssh_con,
+        )
+        ceph_conf.set_to_ceph_conf(
+            "global",
+            ConfigOpts.rgw_crypt_sse_s3_vault_addr,
+            str(config.rgw_crypt_sse_s3_vault_addr),
+            ssh_con,
+        )
+        log.info("trying to restart services")
+        srv_restarted = rgw_service.restart(ssh_con)
+        time.sleep(30)
+        if srv_restarted is False:
+            raise TestExecError("RGW service restart failed")
+        else:
+            log.info("RGW service restarted")
+
+        objects_created_list = []
+        if config.test_ops["create_bucket"] is True:
+            log.info("no of buckets to create: %s" % config.bucket_count)
+            for bc in range(config.bucket_count):
+                bucket_name_to_create = utils.gen_bucket_name_from_userid(
+                    each_user["user_id"], rand_no=bc
+                )
+                bucket = reusable.create_bucket(
+                    bucket_name_to_create, rgw_conn, each_user
+                )
+                if config.test_ops.get("enable_version", False):
+                    log.info("enable bucket version")
+                    reusable.enable_versioning(
+                        bucket, rgw_conn, each_user, write_bucket_io_info
+                    )
+
+                # create objects
+                if config.test_ops["create_object"] is True:
+                    # uploading data
+                    log.info("s3 objects to create: %s" % config.objects_count)
+                    for oc, size in list(config.mapped_sizes.items()):
+                        config.obj_size = size
+                        s3_object_name = utils.gen_s3_object_name(
+                            bucket_name_to_create, oc
+                        )
+                        log.info("s3 object name: %s" % s3_object_name)
+                        s3_object_path = os.path.join(TEST_DATA_PATH, s3_object_name)
+                        log.info("s3 object path: %s" % s3_object_path)
+                        # Choose encryption type, per-object or per-bucket:
+                        log.info("Choose encryption type, per-object or per-bucket")
+                        if config.test_ops["sse_s3_per_bucket"] is True:
+                            log.info(
+                                f"Encryption type is per-bucket, enable it on bucket : {bucket_name_to_create}"
+                            )
+                            sse_s3.put_bucket_encryption(
+                                s3_client, bucket_name_to_create
+                            )
+                            # get bucket encryption
+                            log.info(
+                                f"get bucket encryption for bucket : {bucket_name_to_create}"
+                            )
+                            sse_s3.get_bucket_encryption(
+                                s3_client, bucket_name_to_create
+                            )
+                            if config.test_ops.get("upload_type") == "multipart":
+                                log.info("upload type: multipart")
+                                reusable.upload_mutipart_object(
+                                    s3_object_name,
+                                    bucket,
+                                    TEST_DATA_PATH,
+                                    config,
+                                    each_user,
+                                )
+                            else:
+                                log.info("upload type: normal")
+                                reusable.upload_object(
+                                    s3_object_name,
+                                    bucket,
+                                    TEST_DATA_PATH,
+                                    config,
+                                    each_user,
+                                )
+
+                        else:
+                            log.info(f"Encryption type is per-object.")
+                            sse_s3.put_object_encryption(
+                                s3_client, bucket_name_to_create, s3_object_name
+                            )
+                        # test the object uploaded is encrypted with AES256
+                        sse_s3.get_object_encryption(
+                            s3_client, bucket_name_to_create, s3_object_name
+                        )
+
+    # check sync status if a multisite cluster
+    reusable.check_sync_status()
+
+    # check for any crashes during the execution
+    crash_info = reusable.check_for_crash()
+    if crash_info:
+        raise TestExecError("ceph daemon crash found!")
+
+
+if __name__ == "__main__":
+
+    test_info = AddTestInfo("test bucket notification")
+    test_info.started_info()
+
+    try:
+        project_dir = os.path.abspath(os.path.join(__file__, "../../.."))
+        test_data_dir = "test_data"
+        rgw_service = RGWService()
+        TEST_DATA_PATH = os.path.join(project_dir, test_data_dir)
+        log.info("TEST_DATA_PATH: %s" % TEST_DATA_PATH)
+        if not os.path.exists(TEST_DATA_PATH):
+            log.info("test data dir not exists, creating.. ")
+            os.makedirs(TEST_DATA_PATH)
+        parser = argparse.ArgumentParser(description="RGW S3 Automation")
+        parser.add_argument("-c", dest="config", help="RGW Test yaml configuration")
+        parser.add_argument(
+            "-log_level",
+            dest="log_level",
+            help="Set Log Level [DEBUG, INFO, WARNING, ERROR, CRITICAL]",
+            default="info",
+        )
+        parser.add_argument(
+            "--rgw-node", dest="rgw_node", help="RGW Node", default="127.0.0.1"
+        )
+        args = parser.parse_args()
+        yaml_file = args.config
+        rgw_node = args.rgw_node
+        ssh_con = None
+        if rgw_node != "127.0.0.1":
+            ssh_con = utils.connect_remote(rgw_node)
+        log_f_name = os.path.basename(os.path.splitext(yaml_file)[0])
+        configure_logging(f_name=log_f_name, set_level=args.log_level.upper())
+        config = Config(yaml_file)
+        ceph_conf = CephConfOp(ssh_con)
+        config.read(ssh_con)
+        if config.mapped_sizes is None:
+            config.mapped_sizes = utils.make_mapped_sizes(config)
+
+        test_exec(config, ssh_con)
+        test_info.success_status("test passed")
+        sys.exit(0)
+
+    except (RGWBaseException, Exception) as e:
+        log.error(e)
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        sys.exit(1)


### PR DESCRIPTION
Testing sse-s3 (per-bucket and per-object) with the vault backend.

- Vault authentication is: agent and
- Vault secret engine: transit

Logs: http://magna002.ceph.redhat.com/ceph-qe-logs/vidushi/automation_logs/pr-368/


Signed-off-by: viduship <vimishra@redhat.com>