### PR TITLE
adding support of bucket notifications for lifecycle events

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_lc_rule_delete_marker_notifications.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_rule_delete_marker_notifications.yaml
@@ -1,0 +1,32 @@
+# test_bucket_lifecycle_object_expiration.py
+config:
+  objects_count: 100
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    enable_versioning: true
+    create_object: true
+    version_count: 2
+    delete_marker: true
+    send_bucket_notifications: true
+    create_topic: true
+    get_topic_info: true
+    endpoint: kafka
+    persistent_flag: true
+    ack_type: broker
+    event_type: LifecycleExpiration
+  lifecycle_conf:
+    - ID: LC_Rule_1
+      Filter:
+        Prefix: key2
+      Status: Enabled
+      Expiration:
+        Days: 20
+  delete_marker_ops:
+    - ID: delete_marker_rule
+      Filter:
+        Prefix: key2
+      Status: Enabled
+      Expiration:
+        ExpiredObjectDeleteMarker: true

--- a/rgw/v2/tests/s3_swift/configs/test_lc_rule_expiration_notifications.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_rule_expiration_notifications.yaml
@@ -1,0 +1,25 @@
+# test_bucket_lifecycle_object_expiration.py
+config:
+  objects_count: 5
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    enable_versioning: false
+    create_object: true
+    version_count: 3
+    delete_marker: false
+    send_bucket_notifications: true
+    create_topic: true
+    get_topic_info: true
+    endpoint: kafka
+    persistent_flag: true
+    ack_type: broker
+    event_type: LifecycleExpiration
+  lifecycle_conf:
+    - ID: LC_Rule_1
+      Filter:
+        Prefix: key2
+      Status: Enabled
+      Expiration:
+        Days: 20

--- a/rgw/v2/tests/s3_swift/configs/test_lc_rule_expiration_parallel_notifications.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_rule_expiration_parallel_notifications.yaml
@@ -1,0 +1,28 @@
+# test_bucket_lifecycle_object_expiration.py
+config:
+  bucket_count: 2
+  objects_count: 5
+  parallel_lc: True
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    create_bucket: true
+    enable_versioning: false
+    create_object: true
+    version_count: 3
+    delete_marker: false
+    send_bucket_notifications: true
+    create_topic: true
+    get_topic_info: true
+    endpoint: kafka
+    persistent_flag: true
+    ack_type: broker
+    event_type: LifecycleExpiration
+  lifecycle_conf:
+    - ID: LC_Rule_1
+      Filter:
+        Prefix: single-obj
+      Status: Enabled
+      Expiration:
+        Days: 1

--- a/rgw/v2/tests/s3_swift/configs/test_lc_rule_prefix_non_current_days_notifications.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_rule_prefix_non_current_days_notifications.yaml
@@ -1,0 +1,25 @@
+# script: test_bucket_lifecycle_object_expiration.py
+config:
+  objects_count: 100
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    enable_versioning: true
+    create_object: true
+    version_count: 3
+    delete_marker: false
+    send_bucket_notifications: true
+    create_topic: true
+    get_topic_info: true
+    endpoint: kafka
+    persistent_flag: true
+    ack_type: broker
+    event_type: LifecycleExpiration
+  lifecycle_conf:
+    - ID: LC_Rule_2
+      Filter:
+        Prefix: key1
+      Status: Enabled
+      NoncurrentVersionExpiration:
+        NoncurrentDays: 20

--- a/rgw/v2/tests/s3_swift/reusables/bucket_notification.py
+++ b/rgw/v2/tests/s3_swift/reusables/bucket_notification.py
@@ -83,7 +83,7 @@ def del_topic_from_kafka_broker(topic_name):
 
 
 def put_bucket_notification(
-    rgw_s3_client, bucketname, notification_name, topic_arn, event
+    rgw_s3_client, bucketname, notification_name, topic_arn, events
 ):
     """
     put bucket notification on bucket for specified events with given endpoint and topic
@@ -96,7 +96,7 @@ def put_bucket_notification(
                 {
                     "Id": notification_name,
                     "TopicArn": topic_arn,
-                    "Events": ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"],
+                    "Events": events,
                 }
             ]
         },
@@ -169,12 +169,20 @@ def verify_event_record(event_type, bucket, event_record_path, ceph_version):
                 raise EventRecordDataError("eventName: s3 prefix present in eventName")
 
             # verify event record for a particular event type
+            events = []
             if "Delete" in event_type:
                 events = ["Put", "Delete"]
             if "Copy" in event_type:
                 events = ["Put", "Copy"]
             if "Multipart" in event_type:
                 events = ["Post", "Put", "CompleteMultipartUpload"]
+            if "LifecycleExpiration" in event_type:
+                events = [
+                    "Current",
+                    "NonCurrent",
+                    "DeleteMarker",
+                    "AbortMultipartUpload",
+                ]
             for event in events:
                 if event in eventName:
                     log.info(f"eventName: {eventName} in event record")

--- a/rgw/v2/tests/s3_swift/test_bucket_notifications.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_notifications.py
@@ -121,13 +121,14 @@ def test_exec(config, ssh_con):
                 # put bucket notification with topic configured for event
                 if config.test_ops["put_get_bucket_notification"] is True:
                     event = config.test_ops.get("event_type")
+                    events = ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
                     notification_name = "notification-" + str(event)
                     notification.put_bucket_notification(
                         rgw_s3_client,
                         bucket_name_to_create,
                         notification_name,
                         topic,
-                        event,
+                        events,
                     )
 
                     # get bucket notification

--- a/rgw/v2/utils/utils.py
+++ b/rgw/v2/utils/utils.py
@@ -13,6 +13,7 @@ import time
 from random import randint
 from re import S
 
+import botocore
 import paramiko
 import yaml
 from v2.lib.exceptions import SyncFailedError
@@ -738,3 +739,23 @@ def disable_async_data_notifications():
     if not (search_string in open(rgw_log_file, encoding="latin1").read()):
         return True
     return False
+
+
+def add_service2_sdk_extras():
+    """
+    download service-2.sdk-extras.json into botocore python module path
+    """
+    log.info(
+        "downloading service-2.sdk-extras.json to enable extra functionality supported by Ceph Extension"
+    )
+    botocore_paths = botocore.__path__
+    log.info(f"botocore python module path: {botocore_paths[0]}")
+    extras_json_path = (
+        f"{botocore_paths[0]}/data/s3/2006-03-01/service-2.sdk-extras.json"
+    )
+    exec_shell_cmd(
+        f"sudo curl -o {extras_json_path} -L https://github.com/ceph/ceph/blob/main/examples/boto3/service-2.sdk-extras.json?raw=true"
+    )
+    log.info(f"service-2.sdk-extras.json is downloaded to {extras_json_path}")
+    time.sleep(10)
+    return True


### PR DESCRIPTION
the current changes for lifecycle expiration event notifications will work only for rhcs6.
pass logs:
http://magna002.ceph.redhat.com/ceph-qe-logs/HemanthSai/lifecycle_notification_PR_logs/

had issue with object size:0 in event record for lifecycle events, the test is passed by commenting out size:0 check