### PR TITLE
adding support of bucket notifications for lifecycle events

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_bucket_lc_object_exp_multipart_notifications.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_lc_object_exp_multipart_notifications.yaml
@@ -1,0 +1,27 @@
+# test_bucket_lc_object_exp_multipart.py
+config:
+  user_count: 1
+  bucket_count: 2
+  objects_count: 100
+  rgw_lc_debug_interval: 1
+  objects_size_range:
+    min: 16
+    max: 25
+  local_file_delete: true
+  test_ops:
+    create_bucket: true
+    create_object: true
+    send_bucket_notifications: true
+    create_topic: true
+    get_topic_info: true
+    endpoint: kafka
+    persistent_flag: true
+    ack_type: broker
+    event_type: LifecycleExpiration
+  lifecycle_conf:
+    - ID: LC_Rule_1
+      Filter:
+        Prefix: multipart-obj
+      Status: Enabled
+      Expiration:
+        Days: 1

--- a/rgw/v2/tests/s3_swift/configs/test_lc_rule_delete_marker_notifications.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_rule_delete_marker_notifications.yaml
@@ -1,0 +1,32 @@
+# test_bucket_lifecycle_object_expiration.py
+config:
+  objects_count: 100
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    enable_versioning: true
+    create_object: true
+    version_count: 2
+    delete_marker: true
+    send_bucket_notifications: true
+    create_topic: true
+    get_topic_info: true
+    endpoint: kafka
+    persistent_flag: true
+    ack_type: broker
+    event_type: LifecycleExpiration
+  lifecycle_conf:
+    - ID: LC_Rule_1
+      Filter:
+        Prefix: key2
+      Status: Enabled
+      Expiration:
+        Days: 20
+  delete_marker_ops:
+    - ID: delete_marker_rule
+      Filter:
+        Prefix: key2
+      Status: Enabled
+      Expiration:
+        ExpiredObjectDeleteMarker: true

--- a/rgw/v2/tests/s3_swift/configs/test_lc_rule_expiration_notifications.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_rule_expiration_notifications.yaml
@@ -1,0 +1,25 @@
+# test_bucket_lifecycle_object_expiration.py
+config:
+  objects_count: 100
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    enable_versioning: false
+    create_object: true
+    version_count: 3
+    delete_marker: false
+    send_bucket_notifications: true
+    create_topic: true
+    get_topic_info: true
+    endpoint: kafka
+    persistent_flag: true
+    ack_type: broker
+    event_type: LifecycleExpiration
+  lifecycle_conf:
+    - ID: LC_Rule_1
+      Filter:
+        Prefix: key2
+      Status: Enabled
+      Expiration:
+        Days: 20

--- a/rgw/v2/tests/s3_swift/configs/test_lc_rule_expiration_parallel_notifications.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_rule_expiration_parallel_notifications.yaml
@@ -1,0 +1,28 @@
+# test_bucket_lifecycle_object_expiration.py
+config:
+  bucket_count: 2
+  objects_count: 100
+  parallel_lc: True
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    create_bucket: true
+    enable_versioning: false
+    create_object: true
+    version_count: 3
+    delete_marker: false
+    send_bucket_notifications: true
+    create_topic: true
+    get_topic_info: true
+    endpoint: kafka
+    persistent_flag: true
+    ack_type: broker
+    event_type: LifecycleExpiration
+  lifecycle_conf:
+    - ID: LC_Rule_1
+      Filter:
+        Prefix: single-obj
+      Status: Enabled
+      Expiration:
+        Days: 1

--- a/rgw/v2/tests/s3_swift/configs/test_lc_rule_prefix_non_current_days_notifications.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_rule_prefix_non_current_days_notifications.yaml
@@ -1,0 +1,25 @@
+# script: test_bucket_lifecycle_object_expiration.py
+config:
+  objects_count: 100
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    enable_versioning: true
+    create_object: true
+    version_count: 3
+    delete_marker: false
+    send_bucket_notifications: true
+    create_topic: true
+    get_topic_info: true
+    endpoint: kafka
+    persistent_flag: true
+    ack_type: broker
+    event_type: LifecycleExpiration
+  lifecycle_conf:
+    - ID: LC_Rule_2
+      Filter:
+        Prefix: key1
+      Status: Enabled
+      NoncurrentVersionExpiration:
+        NoncurrentDays: 20

--- a/rgw/v2/tests/s3_swift/test_bucket_notifications.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_notifications.py
@@ -121,13 +121,14 @@ def test_exec(config, ssh_con):
                 # put bucket notification with topic configured for event
                 if config.test_ops["put_get_bucket_notification"] is True:
                     event = config.test_ops.get("event_type")
+                    events = ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
                     notification_name = "notification-" + str(event)
                     notification.put_bucket_notification(
                         rgw_s3_client,
                         bucket_name_to_create,
                         notification_name,
                         topic,
-                        event,
+                        events,
                     )
 
                     # get bucket notification

--- a/rgw/v2/utils/utils.py
+++ b/rgw/v2/utils/utils.py
@@ -13,6 +13,7 @@ import time
 from random import randint
 from re import S
 
+import botocore
 import paramiko
 import yaml
 from v2.lib.exceptions import SyncFailedError
@@ -738,3 +739,23 @@ def disable_async_data_notifications():
     if not (search_string in open(rgw_log_file, encoding="latin1").read()):
         return True
     return False
+
+
+def add_service2_sdk_extras():
+    """
+    download service-2.sdk-extras.json into botocore python module path
+    """
+    log.info(
+        "downloading service-2.sdk-extras.json to enable extra functionality supported by Ceph Extension"
+    )
+    botocore_paths = botocore.__path__
+    log.info(f"botocore python module path: {botocore_paths[0]}")
+    extras_json_path = (
+        f"{botocore_paths[0]}/data/s3/2006-03-01/service-2.sdk-extras.json"
+    )
+    exec_shell_cmd(
+        f"sudo curl -o {extras_json_path} -L https://github.com/ceph/ceph/blob/main/examples/boto3/service-2.sdk-extras.json?raw=true"
+    )
+    log.info(f"service-2.sdk-extras.json is downloaded to {extras_json_path}")
+    time.sleep(10)
+    return True


### PR DESCRIPTION
the current changes for lifecycle expiration event notifications will work only for rhcs6. refer https://docs.ceph.com/en/quincy/radosgw/s3-notification-compatibility/#event-types
moreover ceph extension support should be enabled for lifecycle event notifications

pass logs:
http://magna002.ceph.redhat.com/ceph-qe-logs/HemanthSai/lifecycle_event_notification_PR_logs/

had issue with object size:0 in event record for lifecycle events, the test is passed by commenting out size:0 check
raised bz for the above issue: https://bugzilla.redhat.com/show_bug.cgi?id=2153533