### PR TITLE
TFA:fixes incorrect reporting of rgw crashes

### DIFF
--- a/rgw/v2/tests/s3_swift/test_bucket_policy_ops.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_policy_ops.py
@@ -82,9 +82,6 @@ def test_exec(config, ssh_con):
     basic_io_structure = BasicIOInfoStructure()
     io_info_initialize.initialize(basic_io_structure.initial())
 
-    if config.test_ops.get("upload_type") == "multipart":
-        srv_time_pre_op = get_svc_time(ssh_con)
-
     # create user
     config.user_count = 1
     tenant1 = "MountEverest"
@@ -157,6 +154,8 @@ def test_exec(config, ssh_con):
         raise TestExecError("bucket policy creation failed")
 
     if config.test_ops.get("upload_type") == "multipart":
+        # verifies bug 1960262 rgw: Crash on multipart upload to bucket with policy
+        srv_time_pre_op = get_svc_time(ssh_con)
         for oc, size in list(config.mapped_sizes.items()):
             config.obj_size = size
             s3_object_name = utils.gen_s3_object_name(t1_u1_bucket1.name, oc)


### PR DESCRIPTION
TFA: fixes incorrect reporting of rgw crashes

This was happening due to the module get_svc_time() that compares PIDs at the start and end of the test. Due to rgw restart required for some rgw configs (rgw_sync_lease_period) to take effect, the module incorrectly reports a crash based on the difference in the PIDs caused to rgw restarts.


fixes issue seen https://reportportal-rhcephqe.apps.ocp-c1.prod.psi.redhat.com/ui/#cephci/launches/all/6250/156282
passed logs: http://magna002.ceph.redhat.com/ceph-qe-logs/vidushi/automation_logs/mpu_bucketpol-logs




Signed-off-by: viduship <vimishra@redhat.com>