### PR TITLE
adding support for testing s3cmd malformed url

### DIFF
--- a/rgw/v2/lib/resource_op.py
+++ b/rgw/v2/lib/resource_op.py
@@ -328,6 +328,7 @@ class Config(object):
         self.user_max_read_bytes = self.doc["config"].get("user_max_read_bytes")
         self.user_max_write_ops = self.doc["config"].get("user_max_write_ops")
         self.user_max_write_bytes = self.doc["config"].get("user_max_write_bytes")
+        self.permutation_count = self.doc["config"].get("permutation_count")
         ceph_version_id, ceph_version_name = utils.get_ceph_version()
         # todo: improve Frontend class
         if ceph_version_name in ["luminous", "nautilus"]:

--- a/rgw/v2/tests/s3cmd/configs/test_s3cmd_malformed_url_cp.yaml
+++ b/rgw/v2/tests/s3cmd/configs/test_s3cmd_malformed_url_cp.yaml
@@ -1,0 +1,10 @@
+# script: test_bucket_stats.py
+config:
+  user_count: 1
+  bucket_count: 1
+  permutation_count: 3
+  test_ops:
+    operation: "cp"
+    params:
+      - "s3://{bucket_name}/{object_name}"
+      - "s3uri"

--- a/rgw/v2/tests/s3cmd/configs/test_s3cmd_malformed_url_del.yaml
+++ b/rgw/v2/tests/s3cmd/configs/test_s3cmd_malformed_url_del.yaml
@@ -1,0 +1,9 @@
+# script: test_bucket_stats.py
+config:
+  user_count: 1
+  bucket_count: 1
+  permutation_count: 3
+  test_ops:
+    operation: "del"
+    params:
+      - "s3uri"

--- a/rgw/v2/tests/s3cmd/configs/test_s3cmd_malformed_url_get.yaml
+++ b/rgw/v2/tests/s3cmd/configs/test_s3cmd_malformed_url_get.yaml
@@ -1,0 +1,9 @@
+# script: test_bucket_stats.py
+config:
+  user_count: 1
+  bucket_count: 1
+  permutation_count: 3
+  test_ops:
+    operation: "get"
+    params:
+      - "s3uri"

--- a/rgw/v2/tests/s3cmd/configs/test_s3cmd_malformed_url_ls.yaml
+++ b/rgw/v2/tests/s3cmd/configs/test_s3cmd_malformed_url_ls.yaml
@@ -1,0 +1,9 @@
+# script: test_bucket_stats.py
+config:
+  user_count: 1
+  bucket_count: 1
+  permutation_count: 3
+  test_ops:
+    operation: "ls"
+    params:
+      - "s3uri"

--- a/rgw/v2/tests/s3cmd/configs/test_s3cmd_malformed_url_multipart.yaml
+++ b/rgw/v2/tests/s3cmd/configs/test_s3cmd_malformed_url_multipart.yaml
@@ -1,0 +1,9 @@
+# script: test_bucket_stats.py
+config:
+  user_count: 1
+  bucket_count: 1
+  permutation_count: 3
+  test_ops:
+    operation: "multipart"
+    params:
+      - "s3uri"

--- a/rgw/v2/tests/s3cmd/configs/test_s3cmd_malformed_url_mv.yaml
+++ b/rgw/v2/tests/s3cmd/configs/test_s3cmd_malformed_url_mv.yaml
@@ -1,0 +1,10 @@
+# script: test_bucket_stats.py
+config:
+  user_count: 1
+  bucket_count: 1
+  permutation_count: 3
+  test_ops:
+    operation: "mv"
+    params:
+      - "s3://{bucket_name}/{object_name}"
+      - "s3uri"

--- a/rgw/v2/tests/s3cmd/configs/test_s3cmd_malformed_url_put.yaml
+++ b/rgw/v2/tests/s3cmd/configs/test_s3cmd_malformed_url_put.yaml
@@ -1,0 +1,10 @@
+# script: test_bucket_stats.py
+config:
+  user_count: 1
+  bucket_count: 1
+  permutation_count: 3
+  test_ops:
+    operation: "put"
+    params:
+      - "{object_name}"
+      - "s3uri"

--- a/rgw/v2/tests/s3cmd/configs/test_s3cmd_malformed_url_sync.yaml
+++ b/rgw/v2/tests/s3cmd/configs/test_s3cmd_malformed_url_sync.yaml
@@ -1,0 +1,10 @@
+# script: test_bucket_stats.py
+config:
+  user_count: 1
+  bucket_count: 1
+  permutation_count: 3
+  test_ops:
+    operation: "sync"
+    params:
+      - "s3uri"
+      - "/tmp"

--- a/rgw/v2/tests/s3cmd/reusables/malformed_url.py
+++ b/rgw/v2/tests/s3cmd/reusables/malformed_url.py
@@ -1,0 +1,58 @@
+import logging
+import os
+from itertools import permutations
+
+import v2.utils.utils as utils
+from v2.lib.exceptions import TestExecError
+from v2.tests.s3_swift import reusable
+
+log = logging.getLogger()
+
+
+def execute_command_with_permutations(sample_cmd, config):
+    """executes command and checks for"""
+    special_characters = [
+        "ab",
+        "~",
+        "!",
+        "@",
+        "#",
+        "$",
+        "%",
+        "^",
+        "-",
+        "_",
+        "/",
+        "?",
+        "+",
+        "=",
+        ":",
+        ",",
+        ".",
+        "cd",
+    ]
+    random_strings_list = [
+        "".join(p) for p in permutations(special_characters, config.permutation_count)
+    ]
+    random_strings = " ".join(random_strings_list)
+
+    # execute the command with malformed s3uri, refer this bz https://bugzilla.redhat.com/show_bug.cgi?id=2138921
+    s3uri = "s3://https:///example.com/%2f.."
+    cmd = sample_cmd.replace("s3uri", s3uri)
+
+    # set the environment variable for the execution of shell script
+    os.environ["random_strings"] = random_strings
+
+    # execute the command with special characters at the end
+    utils.exec_shell_cmd(cmd)
+    cmd = (
+        "for i in ${random_strings[@]};"
+        + f"do echo {sample_cmd.replace('s3uri', 's3://${i}')};"
+        + f"{sample_cmd.replace('s3uri', 's3://${i}')};"
+        + "done;"
+    )
+    out = utils.exec_long_running_shell_cmd(cmd)
+    log.info(out)
+    crash_info = reusable.check_for_crash()
+    if crash_info:
+        raise TestExecError("ceph daemon crash found!")

--- a/rgw/v2/tests/s3cmd/test_s3cmd_malformed_url.py
+++ b/rgw/v2/tests/s3cmd/test_s3cmd_malformed_url.py
@@ -1,0 +1,129 @@
+"""
+test_s3cmd_malformed_url - test whether rgw daemon crash occurs while using malformed url in s3cmd command
+
+Usage: test_s3cmd_malformed_url.py -c <input_yaml>
+
+<input_yaml>
+    Note: Following yaml can be used
+    test_s3cmd_malformed_url_cp.yaml
+    test_s3cmd_malformed_url_del.yaml
+    test_s3cmd_malformed_url_get.yaml
+    test_s3cmd_malformed_url_ls.yaml
+    test_s3cmd_malformed_url_multipart.yaml
+    test_s3cmd_malformed_url_mv.yaml
+    test_s3cmd_malformed_url_put.yaml
+    test_s3cmd_malformed_url_sync.yaml
+
+Operation:
+    Create an user
+    Create a bucket with user credentials
+    test s3cmd malformed url with different permutations of special characters
+"""
+
+
+import argparse
+import logging
+import os
+import sys
+import traceback
+
+sys.path.append(os.path.abspath(os.path.join(__file__, "../../../..")))
+
+import v2.lib.manage_data as manage_data
+from v2.lib import resource_op
+from v2.lib.exceptions import RGWBaseException, TestExecError
+from v2.lib.s3.write_io_info import BasicIOInfoStructure, IOInfoInitialize
+from v2.lib.s3cmd import auth as s3_auth
+from v2.lib.s3cmd.resource_op import S3CMD
+from v2.tests.s3cmd import reusable as s3cmd_reusable
+from v2.tests.s3cmd.reusables.malformed_url import execute_command_with_permutations
+from v2.utils import utils
+from v2.utils.log import configure_logging
+from v2.utils.test_desc import AddTestInfo
+
+log = logging.getLogger()
+TEST_DATA_PATH = None
+
+
+def test_exec(config, ssh_con):
+    """
+    Executes test based on configuration passed
+    Args:
+        config(object): Test configuration
+    """
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+    user_info = resource_op.create_users(no_of_users_to_create=config.user_count)[0]
+    user_name = user_info["user_id"]
+
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    s3_auth.do_auth(user_info, ip_and_port)
+
+    object_name = "hello_world.txt"
+    data_info = manage_data.io_generator(object_name, 1)
+    if data_info is False:
+        TestExecError("data creation failed")
+
+    for bc in range(config.bucket_count):
+        bucket_name = utils.gen_bucket_name_from_userid(user_name, rand_no=bc)
+        s3cmd_reusable.create_bucket(bucket_name)
+        log.info(f"Bucket {bucket_name} created")
+        cmd = f"/home/cephuser/venv/bin/s3cmd put {object_name} s3://{bucket_name}"
+        utils.exec_shell_cmd(cmd)
+
+        operation = config.test_ops["operation"]
+        options = config.test_ops.get("options")
+        params = config.test_ops.get("params")
+        s3cmd_class = S3CMD(operation=operation, options=options)
+        cmd = s3cmd_class.command(params=params)
+        cmd = cmd.replace("{bucket_name}", bucket_name)
+        cmd = cmd.replace("{object_name}", object_name)
+        execute_command_with_permutations(cmd, config)
+
+
+if __name__ == "__main__":
+
+    test_info = AddTestInfo("test s3cmd malformed url")
+
+    try:
+        project_dir = os.path.abspath(os.path.join(__file__, "../../.."))
+        test_data_dir = "test_data"
+        TEST_DATA_PATH = os.path.join(project_dir, test_data_dir)
+        log.info(f"TEST_DATA_PATH: {TEST_DATA_PATH}")
+        if not os.path.exists(TEST_DATA_PATH):
+            log.info("test data dir not exists, creating.. ")
+            os.makedirs(TEST_DATA_PATH)
+        parser = argparse.ArgumentParser(description="RGW S3 bucket stats using s3cmd")
+        parser.add_argument("-c", dest="config", help="RGW S3 bucket stats using s3cmd")
+        parser.add_argument(
+            "-log_level",
+            dest="log_level",
+            help="Set Log Level [DEBUG, INFO, WARNING, ERROR, CRITICAL]",
+            default="info",
+        )
+        parser.add_argument(
+            "--rgw-node", dest="rgw_node", help="RGW Node", default="127.0.0.1"
+        )
+        args = parser.parse_args()
+        yaml_file = args.config
+        rgw_node = args.rgw_node
+        ssh_con = None
+        if rgw_node != "127.0.0.1":
+            ssh_con = utils.connect_remote(rgw_node)
+        log_f_name = os.path.basename(os.path.splitext(yaml_file)[0])
+        configure_logging(f_name=log_f_name, set_level=args.log_level.upper())
+        config = resource_op.Config(yaml_file)
+        config.read()
+        test_exec(config, ssh_con)
+        test_info.success_status("test passed")
+        sys.exit(0)
+
+    except (RGWBaseException, Exception) as e:
+        log.error(e)
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        sys.exit(1)
+
+    finally:
+        utils.cleanup_test_data_path(TEST_DATA_PATH)

--- a/rgw/v2/utils/utils.py
+++ b/rgw/v2/utils/utils.py
@@ -22,6 +22,37 @@ S3_OBJECT_NAME_PREFIX = "key"
 log = logging.getLogger()
 
 
+def exec_long_running_shell_cmd(cmd):
+    try:
+        log.info("executing cmd: %s" % cmd)
+        pr = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+            shell=True,
+        )
+        # Poll process.stdout to show stdout live
+        while True:
+            output = pr.stdout.readline()
+            if pr.poll() is not None:
+                break
+            if output:
+                log.info(output.strip())
+        print()
+        rc = pr.poll()
+        if rc == 0:
+            log.info("cmd excuted")
+            return True
+        else:
+            raise Exception("error occured \nreturncode: %s" % (rc))
+    except Exception as e:
+        log.error("cmd execution failed")
+        log.error(e)
+        get_crash_log()
+        return False
+
+
 def exec_shell_cmd(cmd, debug_info=False):
     try:
         log.info("executing cmd: %s" % cmd)


### PR DESCRIPTION
automating testing of s3cmd command with malformed bucket url
refer this bz: https://bugzilla.redhat.com/show_bug.cgi?id=2138921
pass logs: http://magna002.ceph.redhat.com/ceph-qe-logs/HemanthSai/s3cmd_malformed_url_PR_logs/latest