### PR TITLE
CEPH-11199 - Add a new lifecycle configuration to a bucket

### DIFF
--- a/rgw/v2/lib/resource_op.py
+++ b/rgw/v2/lib/resource_op.py
@@ -224,6 +224,7 @@ class Config(object):
         self.split_size = self.doc["config"].get("split_size", 5)
         self.test_ops = self.doc["config"].get("test_ops", {})
         self.lifecycle_conf = self.doc["config"].get("lifecycle_conf")
+        self.new_lifecycle_conf = self.doc["config"].get("new_lifecycle_conf")
         self.delete_marker_ops = self.doc["config"].get("delete_marker_ops")
         self.mapped_sizes = self.doc["config"].get("mapped_sizes")
         self.bucket_policy_op = self.doc["config"].get("bucket_policy_op")

--- a/rgw/v2/tests/s3_swift/configs/test_add_new_lc_to_bucket.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_add_new_lc_to_bucket.yaml
@@ -1,0 +1,24 @@
+# script: test_bucket_lifecycle_config_ops.py
+config:
+  user_count: 1
+  bucket_count: 2
+  objects_count: 10
+  rgw_lc_debug_interval: 3600
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    create_bucket: true
+    create_object: true
+    enable_versioning: false
+    version_count: 0
+    delete_marker: false
+    apply_new_lc: true
+    rgw_lc_debug: true
+  new_lifecycle_conf:
+    - ID: new_lc_rule
+      Filter:
+        Prefix: newkey
+      Status: Enabled
+      Expiration:
+        Days: 5


### PR DESCRIPTION
Signed-off-by: Anuchaithra Rao <anrao@redhat.com>
StepExpected: Add a lifecycle config to a bucket that already has an existing lifecycle config
Result: Should replace the older one

log: http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_add_new_lc_to_bucket.console.log