### PR TITLE
T2 automation of CEPH-83575154 and CEPH-83574036

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_sse_kms_per_bucket_encryption_multipart_object_upload.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_kms_per_bucket_encryption_multipart_object_upload.yaml
@@ -2,7 +2,7 @@ config:
  user_count: 1
  encryption_keys: kms
  bucket_count: 2
- objects_count: 100
+ objects_count: 50
  objects_size_range:
   min: 5
   max: 15
@@ -12,3 +12,5 @@ config:
   enable_version: false
   sse_s3_per_bucket: true
   upload_type: multipart
+  delete_bucket_object: false
+  delete_bucket_object_version: false

--- a/rgw/v2/tests/s3_swift/configs/test_sse_kms_per_bucket_encryption_normal_object_upload.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_kms_per_bucket_encryption_normal_object_upload.yaml
@@ -2,7 +2,7 @@ config:
  user_count: 1
  encryption_keys: kms
  bucket_count: 2
- objects_count: 100
+ objects_count: 50
  objects_size_range:
   min: 5
   max: 15
@@ -12,3 +12,5 @@ config:
   enable_version: false
   sse_s3_per_bucket: true
   upload_type: normal
+  delete_bucket_object: false
+  delete_bucket_object_version: false

--- a/rgw/v2/tests/s3_swift/configs/test_sse_kms_per_bucket_encryption_version_enabled.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_kms_per_bucket_encryption_version_enabled.yaml
@@ -12,3 +12,5 @@ config:
   enable_version: true
   sse_s3_per_bucket: true
   upload_type: normal
+  delete_bucket_object: false
+  delete_bucket_object_version: true

--- a/rgw/v2/tests/s3_swift/configs/test_sse_kms_per_object.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_kms_per_object.yaml
@@ -2,7 +2,7 @@ config:
  user_count: 1
  encryption_keys: kms
  bucket_count: 2
- objects_count: 100
+ objects_count: 50
  objects_size_range:
   min: 5
   max: 15
@@ -11,3 +11,5 @@ config:
   create_object: true
   enable_version: false
   sse_s3_per_bucket: false
+  delete_bucket_object: false
+  delete_bucket_object_version: false

--- a/rgw/v2/tests/s3_swift/configs/test_sse_kms_per_object_versioninig_enabled.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_kms_per_object_versioninig_enabled.yaml
@@ -11,3 +11,5 @@ config:
   create_object: true
   enable_version: true
   sse_s3_per_bucket: false
+  delete_bucket_object: false
+  delete_bucket_object_version: true

--- a/rgw/v2/tests/s3_swift/configs/test_sse_s3_per_bucket_encryption_multipart_object_upload.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_s3_per_bucket_encryption_multipart_object_upload.yaml
@@ -2,7 +2,7 @@ config:
  user_count: 1
  encryption_keys: s3
  bucket_count: 2
- objects_count: 100
+ objects_count: 50
  objects_size_range:
   min: 5
   max: 15
@@ -12,3 +12,5 @@ config:
   enable_version: false
   sse_s3_per_bucket: true
   upload_type: multipart
+  delete_bucket_object: true
+  delete_bucket_object_version: false

--- a/rgw/v2/tests/s3_swift/configs/test_sse_s3_per_bucket_encryption_normal_object_upload.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_s3_per_bucket_encryption_normal_object_upload.yaml
@@ -2,7 +2,7 @@ config:
  user_count: 1
  encryption_keys: s3
  bucket_count: 2
- objects_count: 100
+ objects_count: 50
  objects_size_range:
   min: 5
   max: 15
@@ -12,3 +12,5 @@ config:
   enable_version: false
   sse_s3_per_bucket: true
   upload_type: normal
+  delete_bucket_object: false
+  delete_bucket_object_version: false

--- a/rgw/v2/tests/s3_swift/configs/test_sse_s3_per_bucket_encryption_version_enabled.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_s3_per_bucket_encryption_version_enabled.yaml
@@ -12,3 +12,5 @@ config:
   enable_version: true
   sse_s3_per_bucket: true
   upload_type: normal
+  delete_bucket_object: false
+  delete_bucket_object_version: true

--- a/rgw/v2/tests/s3_swift/configs/test_sse_s3_per_object.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_s3_per_object.yaml
@@ -11,3 +11,5 @@ config:
   create_object: true
   enable_version: false
   sse_s3_per_bucket: false
+  delete_bucket_object: true
+  delete_bucket_object_version: false

--- a/rgw/v2/tests/s3_swift/configs/test_sse_s3_per_object_versioninig_enabled.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_s3_per_object_versioninig_enabled.yaml
@@ -11,3 +11,5 @@ config:
   create_object: true
   enable_version: true
   sse_s3_per_bucket: false
+  delete_bucket_object: false
+  delete_bucket_object_version: false

--- a/rgw/v2/tests/s3_swift/test_sse_s3_kms_with_vault.py
+++ b/rgw/v2/tests/s3_swift/test_sse_s3_kms_with_vault.py
@@ -145,6 +145,14 @@ def test_exec(config, ssh_con):
                         log.info("s3 object name: %s" % s3_object_name)
                         s3_object_path = os.path.join(TEST_DATA_PATH, s3_object_name)
                         log.info("s3 object path: %s" % s3_object_path)
+                        # write a few objects and then enabled encryption on the bucket
+                        reusable.get_object_upload_type(
+                            s3_object_name,
+                            bucket,
+                            TEST_DATA_PATH,
+                            config,
+                            each_user,
+                        )
                         # Choose encryption type, per-object or per-bucket:
                         log.info("Choose encryption type, per-object or per-bucket")
                         # Choose the encryption_method sse-s3 or sse-kms
@@ -163,24 +171,13 @@ def test_exec(config, ssh_con):
                             sse_s3.get_bucket_encryption(
                                 s3_client, bucket_name_to_create
                             )
-                            if config.test_ops.get("upload_type") == "multipart":
-                                log.info("upload type: multipart")
-                                reusable.upload_mutipart_object(
-                                    s3_object_name,
-                                    bucket,
-                                    TEST_DATA_PATH,
-                                    config,
-                                    each_user,
-                                )
-                            else:
-                                log.info("upload type: normal")
-                                reusable.upload_object(
-                                    s3_object_name,
-                                    bucket,
-                                    TEST_DATA_PATH,
-                                    config,
-                                    each_user,
-                                )
+                            reusable.get_object_upload_type(
+                                s3_object_name,
+                                bucket,
+                                TEST_DATA_PATH,
+                                config,
+                                each_user,
+                            )
 
                         else:
                             log.info(f"Encryption type is per-object.")
@@ -200,6 +197,16 @@ def test_exec(config, ssh_con):
                         sse_s3.get_object_encryption(
                             s3_client, bucket_name_to_create, s3_object_name
                         )
+                        if config.test_ops["delete_bucket_object"]:
+                            reusable.delete_objects(bucket)
+                        elif config.test_ops["delete_bucket_object_version"]:
+                            reusable.delete_versioned_object(
+                                bucket,
+                                s3_object_name,
+                                s3_object_path,
+                                rgw_conn,
+                                each_user,
+                            )
     # check sync status if a multisite cluster
     reusable.check_sync_status()
 


### PR DESCRIPTION
T2 automation of CEPH-83575154 and CEPH-83574036

1. https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83575154 and
    testing encryption on older buckets.
2. https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574036
    object deletion that are encrypted with sse-s3 or kms.

log: http://magna002.ceph.redhat.com/ceph-qe-logs/vidushi/automation_logs/pr-387/



Signed-off-by: viduship <vimishra@redhat.com>