### PR TITLE
For the multipart upload testing increasing object size from 5kB to ceratin MB

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_bucket_lc_multipart_object_expiration.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_lc_multipart_object_expiration.yaml
@@ -5,8 +5,8 @@ config:
   objects_count: 500
   rgw_lc_debug_interval: 600
   objects_size_range:
-    min: 16
-    max: 25
+    min: 16M
+    max: 25M
   local_file_delete: true
   test_ops:
     create_bucket: true

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_lc_object_exp_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_lc_object_exp_multipart.yaml
@@ -5,8 +5,8 @@ config:
   objects_count: 1000
   rgw_lc_debug_interval: 1
   objects_size_range:
-    min: 16
-    max: 25
+    min: 16M
+    max: 25M
   local_file_delete: true
   test_ops:
     create_bucket: true

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_lc_object_exp_multipart_notifications.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_lc_object_exp_multipart_notifications.yaml
@@ -5,8 +5,8 @@ config:
   objects_count: 100
   rgw_lc_debug_interval: 1
   objects_size_range:
-    min: 16
-    max: 25
+    min: 16M
+    max: 25M
   local_file_delete: true
   test_ops:
     create_bucket: true

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_kafka_broker_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_kafka_broker_multipart.yaml
@@ -2,9 +2,10 @@ config:
  user_count: 1
  bucket_count: 2
  objects_count: 100
+ local_file_delete: true
  objects_size_range:
-  min: 5
-  max: 25
+  min: 6M
+  max: 25M
  test_ops:
   create_bucket: true
   create_object: true

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_kafka_broker_persistent_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_kafka_broker_persistent_multipart.yaml
@@ -2,9 +2,10 @@ config:
  user_count: 1
  bucket_count: 2
  objects_count: 100
+ local_file_delete: true
  objects_size_range:
-  min: 5
-  max: 25
+  min: 6M
+  max: 25M
  test_ops:
   create_bucket: true
   create_object: true

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_kafka_none_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_kafka_none_multipart.yaml
@@ -3,8 +3,8 @@ config:
  bucket_count: 2
  objects_count: 100
  objects_size_range:
-  min: 5
-  max: 25
+  min: 6M
+  max: 25M
  test_ops:
   create_bucket: true
   create_object: true

--- a/rgw/v2/tests/s3_swift/configs/test_rgw_mfa_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_rgw_mfa_multipart.yaml
@@ -4,8 +4,8 @@ config:
   objects_count: 100
   version_count: 2
   objects_size_range:
-    min: 5
-    max: 25
+    min: 6M
+    max: 25M
   local_file_delete: true
   test_ops:
     mfa_create: true

--- a/rgw/v2/tests/s3_swift/configs/test_sse_kms_per_bucket_encryption_multipart_object_upload.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_kms_per_bucket_encryption_multipart_object_upload.yaml
@@ -3,9 +3,10 @@ config:
  encryption_keys: kms
  bucket_count: 2
  objects_count: 50
+ local_file_delete: true
  objects_size_range:
-  min: 5
-  max: 15
+  min: 6M
+  max: 15M
  test_ops:
   create_bucket: true
   create_object: true

--- a/rgw/v2/tests/s3_swift/configs/test_sse_s3_per_bucket_encryption_multipart_object_upload.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_s3_per_bucket_encryption_multipart_object_upload.yaml
@@ -3,9 +3,10 @@ config:
  encryption_keys: s3
  bucket_count: 2
  objects_count: 50
+ local_file_delete: true
  objects_size_range:
-  min: 5
-  max: 15
+  min: 6M
+  max: 15M
  test_ops:
   create_bucket: true
   create_object: true

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_data_omap_offload_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_data_omap_offload_multipart.yaml
@@ -3,8 +3,8 @@ config:
    bucket_count: 2
    objects_count: 100
    objects_size_range:
-      min: 20
-      max: 30
+      min: 20M
+      max: 30M
    local_file_delete: true
    test_ops:
       create_bucket: true


### PR DESCRIPTION
Signed-off-by: Anuchaithra Rao <anrao@redhat.com>
In multipart object is splited into objects of size 5MB
split -b5m /home/cephuser/rgw-tests/ceph-qe-scripts/rgw/v2/test_data/multipart-obj0 /home/cephuser/rgw-tests/ceph-qe-scripts/rgw/v2/test_data/multipart-obj0.mp.parts/'

http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_bucket_lc_multipart_object_expiration.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_bucket_lc_object_exp_multipart.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_bucket_lc_object_exp_multipart_notifications.console.log (failure not realted multipart upload)


