### PR TITLE
[T2-Automation][CEPH-83575407]:Bucket Notifications Using SASL SCRAM

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_kafka_broker_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_kafka_broker_multipart.yaml
@@ -5,7 +5,7 @@ config:
  local_file_delete: true
  objects_size_range:
   min: 6M
-  max: 25M
+  max: 8M
  test_ops:
   create_bucket: true
   create_object: true

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_kafka_broker_persistent_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_kafka_broker_persistent_multipart.yaml
@@ -5,7 +5,7 @@ config:
  local_file_delete: true
  objects_size_range:
   min: 6M
-  max: 25M
+  max: 8M
  test_ops:
   create_bucket: true
   create_object: true

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_kafka_none_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_kafka_none_multipart.yaml
@@ -4,7 +4,7 @@ config:
  objects_count: 100
  objects_size_range:
   min: 6M
-  max: 25M
+  max: 8M
  test_ops:
   create_bucket: true
   create_object: true

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_plaintext_plain_kafka_broker.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_plaintext_plain_kafka_broker.yaml
@@ -1,21 +1,25 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
  objects_count: 10
  objects_size_range:
-  min: 6M
-  max: 8M
- local_file_delete: true
+  min: 5
+  max: 15
  test_ops:
   create_bucket: true
   create_object: true
+  copy_object: true
+  delete_bucket_object: true
   enable_version: false
   create_topic: true
+  event_type:
+   - Copy
+   - Delete
   get_topic_info: true
   endpoint: kafka
-  persistent_flag: true
-  ack_type: none
+  ack_type: broker
+  security_type: SASL_PLAINTEXT
+  mechanism: PLAIN
   put_get_bucket_notification: true
-  event_type: Multipart
-  upload_type: multipart
-  delete_bucket_object: false
+  upload_type: normal

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_plaintext_plain_kafka_broker_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_plaintext_plain_kafka_broker_multipart.yaml
@@ -1,3 +1,4 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
@@ -5,17 +6,17 @@ config:
  objects_size_range:
   min: 6M
   max: 8M
- local_file_delete: true
  test_ops:
   create_bucket: true
   create_object: true
+  delete_bucket_object: false
   enable_version: false
   create_topic: true
-  get_topic_info: true
-  endpoint: kafka
-  persistent_flag: true
-  ack_type: none
-  put_get_bucket_notification: true
   event_type: Multipart
   upload_type: multipart
-  delete_bucket_object: false
+  get_topic_info: true
+  endpoint: kafka
+  ack_type: broker
+  security_type: SASL_PLAINTEXT
+  mechanism: PLAIN
+  put_get_bucket_notification: true

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_plaintext_plain_kafka_broker_persistent.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_plaintext_plain_kafka_broker_persistent.yaml
@@ -1,21 +1,26 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
  objects_count: 10
  objects_size_range:
-  min: 6M
-  max: 8M
- local_file_delete: true
+  min: 5
+  max: 15
  test_ops:
   create_bucket: true
   create_object: true
+  copy_object: true
+  delete_bucket_object: true
   enable_version: false
   create_topic: true
+  event_type:
+   - Copy
+   - Delete
   get_topic_info: true
   endpoint: kafka
+  ack_type: broker
   persistent_flag: true
-  ack_type: none
+  security_type: SASL_PLAINTEXT
+  mechanism: PLAIN
   put_get_bucket_notification: true
-  event_type: Multipart
-  upload_type: multipart
-  delete_bucket_object: false
+  upload_type: normal

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_plaintext_plain_kafka_broker_persistent_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_plaintext_plain_kafka_broker_persistent_multipart.yaml
@@ -1,3 +1,4 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
@@ -5,17 +6,18 @@ config:
  objects_size_range:
   min: 6M
   max: 8M
- local_file_delete: true
  test_ops:
   create_bucket: true
   create_object: true
+  delete_bucket_object: false
   enable_version: false
   create_topic: true
-  get_topic_info: true
-  endpoint: kafka
-  persistent_flag: true
-  ack_type: none
-  put_get_bucket_notification: true
   event_type: Multipart
   upload_type: multipart
-  delete_bucket_object: false
+  get_topic_info: true
+  endpoint: kafka
+  ack_type: broker
+  persistent_flag: true
+  security_type: SASL_PLAINTEXT
+  mechanism: PLAIN
+  put_get_bucket_notification: true

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_plaintext_plain_kafka_none.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_plaintext_plain_kafka_none.yaml
@@ -1,21 +1,25 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
  objects_count: 10
  objects_size_range:
-  min: 6M
-  max: 8M
- local_file_delete: true
+  min: 5
+  max: 15
  test_ops:
   create_bucket: true
   create_object: true
+  copy_object: true
+  delete_bucket_object: true
   enable_version: false
   create_topic: true
+  event_type:
+   - Copy
+   - Delete
   get_topic_info: true
   endpoint: kafka
-  persistent_flag: true
   ack_type: none
+  security_type: SASL_PLAINTEXT
+  mechanism: PLAIN
   put_get_bucket_notification: true
-  event_type: Multipart
-  upload_type: multipart
-  delete_bucket_object: false
+  upload_type: normal

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_plaintext_plain_kafka_none_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_plaintext_plain_kafka_none_multipart.yaml
@@ -1,3 +1,4 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
@@ -5,17 +6,17 @@ config:
  objects_size_range:
   min: 6M
   max: 8M
- local_file_delete: true
  test_ops:
   create_bucket: true
   create_object: true
+  delete_bucket_object: false
   enable_version: false
   create_topic: true
-  get_topic_info: true
-  endpoint: kafka
-  persistent_flag: true
-  ack_type: none
-  put_get_bucket_notification: true
   event_type: Multipart
   upload_type: multipart
-  delete_bucket_object: false
+  get_topic_info: true
+  endpoint: kafka
+  ack_type: none
+  security_type: SASL_PLAINTEXT
+  mechanism: PLAIN
+  put_get_bucket_notification: true

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_plaintext_plain_kafka_none_persistent.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_plaintext_plain_kafka_none_persistent.yaml
@@ -1,21 +1,26 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
  objects_count: 10
  objects_size_range:
-  min: 6M
-  max: 8M
- local_file_delete: true
+  min: 5
+  max: 15
  test_ops:
   create_bucket: true
   create_object: true
+  copy_object: true
+  delete_bucket_object: true
   enable_version: false
   create_topic: true
+  event_type:
+   - Copy
+   - Delete
   get_topic_info: true
   endpoint: kafka
-  persistent_flag: true
   ack_type: none
+  persistent_flag: true
+  security_type: SASL_PLAINTEXT
+  mechanism: PLAIN
   put_get_bucket_notification: true
-  event_type: Multipart
-  upload_type: multipart
-  delete_bucket_object: false
+  upload_type: normal

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_plaintext_plain_kafka_none_persistent_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_plaintext_plain_kafka_none_persistent_multipart.yaml
@@ -1,3 +1,4 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
@@ -5,17 +6,18 @@ config:
  objects_size_range:
   min: 6M
   max: 8M
- local_file_delete: true
  test_ops:
   create_bucket: true
   create_object: true
+  delete_bucket_object: false
   enable_version: false
   create_topic: true
-  get_topic_info: true
-  endpoint: kafka
-  persistent_flag: true
-  ack_type: none
-  put_get_bucket_notification: true
   event_type: Multipart
   upload_type: multipart
-  delete_bucket_object: false
+  get_topic_info: true
+  endpoint: kafka
+  ack_type: none
+  persistent_flag: true
+  security_type: SASL_PLAINTEXT
+  mechanism: PLAIN
+  put_get_bucket_notification: true

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_broker.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_broker.yaml
@@ -1,21 +1,25 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
  objects_count: 10
  objects_size_range:
-  min: 6M
-  max: 8M
- local_file_delete: true
+  min: 5
+  max: 15
  test_ops:
   create_bucket: true
   create_object: true
+  copy_object: true
+  delete_bucket_object: true
   enable_version: false
   create_topic: true
+  event_type:
+   - Copy
+   - Delete
   get_topic_info: true
   endpoint: kafka
-  persistent_flag: true
-  ack_type: none
+  ack_type: broker
+  security_type: SASL_PLAINTEXT
+  mechanism: SCRAM-SHA-256
   put_get_bucket_notification: true
-  event_type: Multipart
-  upload_type: multipart
-  delete_bucket_object: false
+  upload_type: normal

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_broker_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_broker_multipart.yaml
@@ -1,3 +1,4 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
@@ -5,17 +6,17 @@ config:
  objects_size_range:
   min: 6M
   max: 8M
- local_file_delete: true
  test_ops:
   create_bucket: true
   create_object: true
+  delete_bucket_object: false
   enable_version: false
   create_topic: true
-  get_topic_info: true
-  endpoint: kafka
-  persistent_flag: true
-  ack_type: none
-  put_get_bucket_notification: true
   event_type: Multipart
   upload_type: multipart
-  delete_bucket_object: false
+  get_topic_info: true
+  endpoint: kafka
+  ack_type: broker
+  security_type: SASL_PLAINTEXT
+  mechanism: SCRAM-SHA-256
+  put_get_bucket_notification: true

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_broker_persistent.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_broker_persistent.yaml
@@ -1,21 +1,26 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
  objects_count: 10
  objects_size_range:
-  min: 6M
-  max: 8M
- local_file_delete: true
+  min: 5
+  max: 15
  test_ops:
   create_bucket: true
   create_object: true
+  copy_object: true
+  delete_bucket_object: true
   enable_version: false
   create_topic: true
+  event_type:
+   - Copy
+   - Delete
   get_topic_info: true
   endpoint: kafka
+  ack_type: broker
   persistent_flag: true
-  ack_type: none
+  security_type: SASL_PLAINTEXT
+  mechanism: SCRAM-SHA-256
   put_get_bucket_notification: true
-  event_type: Multipart
-  upload_type: multipart
-  delete_bucket_object: false
+  upload_type: normal

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_broker_persistent_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_broker_persistent_multipart.yaml
@@ -1,3 +1,4 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
@@ -5,17 +6,18 @@ config:
  objects_size_range:
   min: 6M
   max: 8M
- local_file_delete: true
  test_ops:
   create_bucket: true
   create_object: true
+  delete_bucket_object: false
   enable_version: false
   create_topic: true
-  get_topic_info: true
-  endpoint: kafka
-  persistent_flag: true
-  ack_type: none
-  put_get_bucket_notification: true
   event_type: Multipart
   upload_type: multipart
-  delete_bucket_object: false
+  get_topic_info: true
+  endpoint: kafka
+  ack_type: broker
+  persistent_flag: true
+  security_type: SASL_PLAINTEXT
+  mechanism: SCRAM-SHA-256
+  put_get_bucket_notification: true

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_none.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_none.yaml
@@ -1,21 +1,25 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
  objects_count: 10
  objects_size_range:
-  min: 6M
-  max: 8M
- local_file_delete: true
+  min: 5
+  max: 15
  test_ops:
   create_bucket: true
   create_object: true
+  copy_object: true
+  delete_bucket_object: true
   enable_version: false
   create_topic: true
+  event_type:
+   - Copy
+   - Delete
   get_topic_info: true
   endpoint: kafka
-  persistent_flag: true
   ack_type: none
+  security_type: SASL_PLAINTEXT
+  mechanism: SCRAM-SHA-256
   put_get_bucket_notification: true
-  event_type: Multipart
-  upload_type: multipart
-  delete_bucket_object: false
+  upload_type: normal

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_none_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_none_multipart.yaml
@@ -1,3 +1,4 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
@@ -5,17 +6,17 @@ config:
  objects_size_range:
   min: 6M
   max: 8M
- local_file_delete: true
  test_ops:
   create_bucket: true
   create_object: true
+  delete_bucket_object: false
   enable_version: false
   create_topic: true
-  get_topic_info: true
-  endpoint: kafka
-  persistent_flag: true
-  ack_type: none
-  put_get_bucket_notification: true
   event_type: Multipart
   upload_type: multipart
-  delete_bucket_object: false
+  get_topic_info: true
+  endpoint: kafka
+  ack_type: none
+  security_type: SASL_PLAINTEXT
+  mechanism: SCRAM-SHA-256
+  put_get_bucket_notification: true

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_none_persistent.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_none_persistent.yaml
@@ -1,21 +1,26 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
  objects_count: 10
  objects_size_range:
-  min: 6M
-  max: 8M
- local_file_delete: true
+  min: 5
+  max: 15
  test_ops:
   create_bucket: true
   create_object: true
+  copy_object: true
+  delete_bucket_object: true
   enable_version: false
   create_topic: true
+  event_type:
+   - Copy
+   - Delete
   get_topic_info: true
   endpoint: kafka
-  persistent_flag: true
   ack_type: none
+  persistent_flag: true
+  security_type: SASL_PLAINTEXT
+  mechanism: SCRAM-SHA-256
   put_get_bucket_notification: true
-  event_type: Multipart
-  upload_type: multipart
-  delete_bucket_object: false
+  upload_type: normal

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_none_persistent_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_none_persistent_multipart.yaml
@@ -1,3 +1,4 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
@@ -5,17 +6,18 @@ config:
  objects_size_range:
   min: 6M
   max: 8M
- local_file_delete: true
  test_ops:
   create_bucket: true
   create_object: true
+  delete_bucket_object: false
   enable_version: false
   create_topic: true
-  get_topic_info: true
-  endpoint: kafka
-  persistent_flag: true
-  ack_type: none
-  put_get_bucket_notification: true
   event_type: Multipart
   upload_type: multipart
-  delete_bucket_object: false
+  get_topic_info: true
+  endpoint: kafka
+  ack_type: none
+  persistent_flag: true
+  security_type: SASL_PLAINTEXT
+  mechanism: SCRAM-SHA-256
+  put_get_bucket_notification: true

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_ssl_plain_kafka_broker.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_ssl_plain_kafka_broker.yaml
@@ -1,21 +1,25 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
  objects_count: 10
  objects_size_range:
-  min: 6M
-  max: 8M
- local_file_delete: true
+  min: 5
+  max: 15
  test_ops:
   create_bucket: true
   create_object: true
+  copy_object: true
+  delete_bucket_object: true
   enable_version: false
   create_topic: true
+  event_type:
+   - Copy
+   - Delete
   get_topic_info: true
   endpoint: kafka
-  persistent_flag: true
-  ack_type: none
+  ack_type: broker
+  security_type: SASL_SSL
+  mechanism: PLAIN
   put_get_bucket_notification: true
-  event_type: Multipart
-  upload_type: multipart
-  delete_bucket_object: false
+  upload_type: normal

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_ssl_plain_kafka_broker_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_ssl_plain_kafka_broker_multipart.yaml
@@ -1,3 +1,4 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
@@ -5,17 +6,17 @@ config:
  objects_size_range:
   min: 6M
   max: 8M
- local_file_delete: true
  test_ops:
   create_bucket: true
   create_object: true
+  delete_bucket_object: false
   enable_version: false
   create_topic: true
-  get_topic_info: true
-  endpoint: kafka
-  persistent_flag: true
-  ack_type: none
-  put_get_bucket_notification: true
   event_type: Multipart
   upload_type: multipart
-  delete_bucket_object: false
+  get_topic_info: true
+  endpoint: kafka
+  ack_type: broker
+  security_type: SASL_SSL
+  mechanism: PLAIN
+  put_get_bucket_notification: true

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_ssl_plain_kafka_broker_persistent.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_ssl_plain_kafka_broker_persistent.yaml
@@ -1,21 +1,26 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
  objects_count: 10
  objects_size_range:
-  min: 6M
-  max: 8M
- local_file_delete: true
+  min: 5
+  max: 15
  test_ops:
   create_bucket: true
   create_object: true
+  copy_object: true
+  delete_bucket_object: true
   enable_version: false
   create_topic: true
+  event_type:
+   - Copy
+   - Delete
   get_topic_info: true
   endpoint: kafka
+  ack_type: broker
   persistent_flag: true
-  ack_type: none
+  security_type: SASL_SSL
+  mechanism: PLAIN
   put_get_bucket_notification: true
-  event_type: Multipart
-  upload_type: multipart
-  delete_bucket_object: false
+  upload_type: normal

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_ssl_plain_kafka_broker_persistent_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_ssl_plain_kafka_broker_persistent_multipart.yaml
@@ -1,3 +1,4 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
@@ -5,17 +6,18 @@ config:
  objects_size_range:
   min: 6M
   max: 8M
- local_file_delete: true
  test_ops:
   create_bucket: true
   create_object: true
+  delete_bucket_object: false
   enable_version: false
   create_topic: true
-  get_topic_info: true
-  endpoint: kafka
-  persistent_flag: true
-  ack_type: none
-  put_get_bucket_notification: true
   event_type: Multipart
   upload_type: multipart
-  delete_bucket_object: false
+  get_topic_info: true
+  endpoint: kafka
+  ack_type: broker
+  persistent_flag: true
+  security_type: SASL_SSL
+  mechanism: PLAIN
+  put_get_bucket_notification: true

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_ssl_plain_kafka_none.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_ssl_plain_kafka_none.yaml
@@ -1,21 +1,25 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
  objects_count: 10
  objects_size_range:
-  min: 6M
-  max: 8M
- local_file_delete: true
+  min: 5
+  max: 15
  test_ops:
   create_bucket: true
   create_object: true
+  copy_object: true
+  delete_bucket_object: true
   enable_version: false
   create_topic: true
+  event_type:
+   - Copy
+   - Delete
   get_topic_info: true
   endpoint: kafka
-  persistent_flag: true
   ack_type: none
+  security_type: SASL_SSL
+  mechanism: PLAIN
   put_get_bucket_notification: true
-  event_type: Multipart
-  upload_type: multipart
-  delete_bucket_object: false
+  upload_type: normal

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_ssl_plain_kafka_none_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_ssl_plain_kafka_none_multipart.yaml
@@ -1,3 +1,4 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
@@ -5,17 +6,17 @@ config:
  objects_size_range:
   min: 6M
   max: 8M
- local_file_delete: true
  test_ops:
   create_bucket: true
   create_object: true
+  delete_bucket_object: false
   enable_version: false
   create_topic: true
-  get_topic_info: true
-  endpoint: kafka
-  persistent_flag: true
-  ack_type: none
-  put_get_bucket_notification: true
   event_type: Multipart
   upload_type: multipart
-  delete_bucket_object: false
+  get_topic_info: true
+  endpoint: kafka
+  ack_type: none
+  security_type: SASL_SSL
+  mechanism: PLAIN
+  put_get_bucket_notification: true

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_ssl_plain_kafka_none_persistent.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_ssl_plain_kafka_none_persistent.yaml
@@ -1,21 +1,26 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
  objects_count: 10
  objects_size_range:
-  min: 6M
-  max: 8M
- local_file_delete: true
+  min: 5
+  max: 15
  test_ops:
   create_bucket: true
   create_object: true
+  copy_object: true
+  delete_bucket_object: true
   enable_version: false
   create_topic: true
+  event_type:
+   - Copy
+   - Delete
   get_topic_info: true
   endpoint: kafka
-  persistent_flag: true
   ack_type: none
+  persistent_flag: true
+  security_type: SASL_SSL
+  mechanism: PLAIN
   put_get_bucket_notification: true
-  event_type: Multipart
-  upload_type: multipart
-  delete_bucket_object: false
+  upload_type: normal

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_ssl_plain_kafka_none_persistent_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_ssl_plain_kafka_none_persistent_multipart.yaml
@@ -1,3 +1,4 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
@@ -5,17 +6,18 @@ config:
  objects_size_range:
   min: 6M
   max: 8M
- local_file_delete: true
  test_ops:
   create_bucket: true
   create_object: true
+  delete_bucket_object: false
   enable_version: false
   create_topic: true
-  get_topic_info: true
-  endpoint: kafka
-  persistent_flag: true
-  ack_type: none
-  put_get_bucket_notification: true
   event_type: Multipart
   upload_type: multipart
-  delete_bucket_object: false
+  get_topic_info: true
+  endpoint: kafka
+  ack_type: none
+  persistent_flag: true
+  security_type: SASL_SSL
+  mechanism: PLAIN
+  put_get_bucket_notification: true

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_broker.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_broker.yaml
@@ -1,21 +1,25 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
  objects_count: 10
  objects_size_range:
-  min: 6M
-  max: 8M
- local_file_delete: true
+  min: 5
+  max: 15
  test_ops:
   create_bucket: true
   create_object: true
+  copy_object: true
+  delete_bucket_object: true
   enable_version: false
   create_topic: true
+  event_type:
+   - Copy
+   - Delete
   get_topic_info: true
   endpoint: kafka
-  persistent_flag: true
-  ack_type: none
+  ack_type: broker
+  security_type: SASL_SSL
+  mechanism: SCRAM-SHA-256
   put_get_bucket_notification: true
-  event_type: Multipart
-  upload_type: multipart
-  delete_bucket_object: false
+  upload_type: normal

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_broker_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_broker_multipart.yaml
@@ -1,3 +1,4 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
@@ -5,17 +6,17 @@ config:
  objects_size_range:
   min: 6M
   max: 8M
- local_file_delete: true
  test_ops:
   create_bucket: true
   create_object: true
+  delete_bucket_object: false
   enable_version: false
   create_topic: true
-  get_topic_info: true
-  endpoint: kafka
-  persistent_flag: true
-  ack_type: none
-  put_get_bucket_notification: true
   event_type: Multipart
   upload_type: multipart
-  delete_bucket_object: false
+  get_topic_info: true
+  endpoint: kafka
+  ack_type: broker
+  security_type: SASL_SSL
+  mechanism: SCRAM-SHA-256
+  put_get_bucket_notification: true

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_broker_persistent.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_broker_persistent.yaml
@@ -1,21 +1,26 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
  objects_count: 10
  objects_size_range:
-  min: 6M
-  max: 8M
- local_file_delete: true
+  min: 5
+  max: 15
  test_ops:
   create_bucket: true
   create_object: true
+  copy_object: true
+  delete_bucket_object: true
   enable_version: false
   create_topic: true
+  event_type:
+   - Copy
+   - Delete
   get_topic_info: true
   endpoint: kafka
+  ack_type: broker
   persistent_flag: true
-  ack_type: none
+  security_type: SASL_SSL
+  mechanism: SCRAM-SHA-256
   put_get_bucket_notification: true
-  event_type: Multipart
-  upload_type: multipart
-  delete_bucket_object: false
+  upload_type: normal

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_broker_persistent_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_broker_persistent_multipart.yaml
@@ -1,3 +1,4 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
@@ -5,17 +6,18 @@ config:
  objects_size_range:
   min: 6M
   max: 8M
- local_file_delete: true
  test_ops:
   create_bucket: true
   create_object: true
+  delete_bucket_object: false
   enable_version: false
   create_topic: true
-  get_topic_info: true
-  endpoint: kafka
-  persistent_flag: true
-  ack_type: none
-  put_get_bucket_notification: true
   event_type: Multipart
   upload_type: multipart
-  delete_bucket_object: false
+  get_topic_info: true
+  endpoint: kafka
+  ack_type: broker
+  persistent_flag: true
+  security_type: SASL_SSL
+  mechanism: SCRAM-SHA-256
+  put_get_bucket_notification: true

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_none.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_none.yaml
@@ -1,21 +1,25 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
  objects_count: 10
  objects_size_range:
-  min: 6M
-  max: 8M
- local_file_delete: true
+  min: 5
+  max: 15
  test_ops:
   create_bucket: true
   create_object: true
+  copy_object: true
+  delete_bucket_object: true
   enable_version: false
   create_topic: true
+  event_type:
+   - Copy
+   - Delete
   get_topic_info: true
   endpoint: kafka
-  persistent_flag: true
   ack_type: none
+  security_type: SASL_SSL
+  mechanism: SCRAM-SHA-256
   put_get_bucket_notification: true
-  event_type: Multipart
-  upload_type: multipart
-  delete_bucket_object: false
+  upload_type: normal

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_none_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_none_multipart.yaml
@@ -1,3 +1,4 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
@@ -5,17 +6,17 @@ config:
  objects_size_range:
   min: 6M
   max: 8M
- local_file_delete: true
  test_ops:
   create_bucket: true
   create_object: true
+  delete_bucket_object: false
   enable_version: false
   create_topic: true
-  get_topic_info: true
-  endpoint: kafka
-  persistent_flag: true
-  ack_type: none
-  put_get_bucket_notification: true
   event_type: Multipart
   upload_type: multipart
-  delete_bucket_object: false
+  get_topic_info: true
+  endpoint: kafka
+  ack_type: none
+  security_type: SASL_SSL
+  mechanism: SCRAM-SHA-256
+  put_get_bucket_notification: true

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_none_persistent.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_none_persistent.yaml
@@ -1,21 +1,26 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
  objects_count: 10
  objects_size_range:
-  min: 6M
-  max: 8M
- local_file_delete: true
+  min: 5
+  max: 15
  test_ops:
   create_bucket: true
   create_object: true
+  copy_object: true
+  delete_bucket_object: true
   enable_version: false
   create_topic: true
+  event_type:
+   - Copy
+   - Delete
   get_topic_info: true
   endpoint: kafka
-  persistent_flag: true
   ack_type: none
+  persistent_flag: true
+  security_type: SASL_SSL
+  mechanism: SCRAM-SHA-256
   put_get_bucket_notification: true
-  event_type: Multipart
-  upload_type: multipart
-  delete_bucket_object: false
+  upload_type: normal

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_none_persistent_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_none_persistent_multipart.yaml
@@ -1,3 +1,4 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
@@ -5,17 +6,18 @@ config:
  objects_size_range:
   min: 6M
   max: 8M
- local_file_delete: true
  test_ops:
   create_bucket: true
   create_object: true
+  delete_bucket_object: false
   enable_version: false
   create_topic: true
-  get_topic_info: true
-  endpoint: kafka
-  persistent_flag: true
-  ack_type: none
-  put_get_bucket_notification: true
   event_type: Multipart
   upload_type: multipart
-  delete_bucket_object: false
+  get_topic_info: true
+  endpoint: kafka
+  ack_type: none
+  persistent_flag: true
+  security_type: SASL_SSL
+  mechanism: SCRAM-SHA-256
+  put_get_bucket_notification: true

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_ssl_kafka_broker.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_ssl_kafka_broker.yaml
@@ -1,21 +1,24 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
  objects_count: 10
  objects_size_range:
-  min: 6M
-  max: 8M
- local_file_delete: true
+  min: 5
+  max: 15
  test_ops:
   create_bucket: true
   create_object: true
+  copy_object: true
+  delete_bucket_object: true
   enable_version: false
   create_topic: true
+  event_type:
+   - Copy
+   - Delete
   get_topic_info: true
   endpoint: kafka
-  persistent_flag: true
-  ack_type: none
+  ack_type: broker
+  security_type: SSL
   put_get_bucket_notification: true
-  event_type: Multipart
-  upload_type: multipart
-  delete_bucket_object: false
+  upload_type: normal

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_ssl_kafka_broker_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_ssl_kafka_broker_multipart.yaml
@@ -1,3 +1,4 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
@@ -5,17 +6,16 @@ config:
  objects_size_range:
   min: 6M
   max: 8M
- local_file_delete: true
  test_ops:
   create_bucket: true
   create_object: true
+  delete_bucket_object: false
   enable_version: false
   create_topic: true
-  get_topic_info: true
-  endpoint: kafka
-  persistent_flag: true
-  ack_type: none
-  put_get_bucket_notification: true
   event_type: Multipart
   upload_type: multipart
-  delete_bucket_object: false
+  get_topic_info: true
+  endpoint: kafka
+  ack_type: broker
+  security_type: SSL
+  put_get_bucket_notification: true

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_ssl_kafka_broker_persistent.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_ssl_kafka_broker_persistent.yaml
@@ -1,21 +1,25 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
  objects_count: 10
  objects_size_range:
-  min: 6M
-  max: 8M
- local_file_delete: true
+  min: 5
+  max: 15
  test_ops:
   create_bucket: true
   create_object: true
+  copy_object: true
+  delete_bucket_object: true
   enable_version: false
   create_topic: true
+  event_type:
+   - Copy
+   - Delete
   get_topic_info: true
   endpoint: kafka
+  ack_type: broker
   persistent_flag: true
-  ack_type: none
+  security_type: SSL
   put_get_bucket_notification: true
-  event_type: Multipart
-  upload_type: multipart
-  delete_bucket_object: false
+  upload_type: normal

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_ssl_kafka_broker_persistent_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_ssl_kafka_broker_persistent_multipart.yaml
@@ -1,3 +1,4 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
@@ -5,17 +6,17 @@ config:
  objects_size_range:
   min: 6M
   max: 8M
- local_file_delete: true
  test_ops:
   create_bucket: true
   create_object: true
+  delete_bucket_object: false
   enable_version: false
   create_topic: true
-  get_topic_info: true
-  endpoint: kafka
-  persistent_flag: true
-  ack_type: none
-  put_get_bucket_notification: true
   event_type: Multipart
   upload_type: multipart
-  delete_bucket_object: false
+  get_topic_info: true
+  endpoint: kafka
+  ack_type: broker
+  persistent_flag: true
+  security_type: SSL
+  put_get_bucket_notification: true

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_ssl_kafka_none.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_ssl_kafka_none.yaml
@@ -1,21 +1,24 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
  objects_count: 10
  objects_size_range:
-  min: 6M
-  max: 8M
- local_file_delete: true
+  min: 5
+  max: 15
  test_ops:
   create_bucket: true
   create_object: true
+  copy_object: true
+  delete_bucket_object: true
   enable_version: false
   create_topic: true
+  event_type:
+   - Copy
+   - Delete
   get_topic_info: true
   endpoint: kafka
-  persistent_flag: true
   ack_type: none
+  security_type: SSL
   put_get_bucket_notification: true
-  event_type: Multipart
-  upload_type: multipart
-  delete_bucket_object: false
+  upload_type: normal

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_ssl_kafka_none_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_ssl_kafka_none_multipart.yaml
@@ -1,3 +1,4 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
@@ -5,17 +6,16 @@ config:
  objects_size_range:
   min: 6M
   max: 8M
- local_file_delete: true
  test_ops:
   create_bucket: true
   create_object: true
+  delete_bucket_object: false
   enable_version: false
   create_topic: true
-  get_topic_info: true
-  endpoint: kafka
-  persistent_flag: true
-  ack_type: none
-  put_get_bucket_notification: true
   event_type: Multipart
   upload_type: multipart
-  delete_bucket_object: false
+  get_topic_info: true
+  endpoint: kafka
+  ack_type: none
+  security_type: SSL
+  put_get_bucket_notification: true

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_ssl_kafka_none_persistent.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_ssl_kafka_none_persistent.yaml
@@ -1,21 +1,25 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
  objects_count: 10
  objects_size_range:
-  min: 6M
-  max: 8M
- local_file_delete: true
+  min: 5
+  max: 15
  test_ops:
   create_bucket: true
   create_object: true
+  copy_object: true
+  delete_bucket_object: true
   enable_version: false
   create_topic: true
+  event_type:
+   - Copy
+   - Delete
   get_topic_info: true
   endpoint: kafka
-  persistent_flag: true
   ack_type: none
+  persistent_flag: true
+  security_type: SSL
   put_get_bucket_notification: true
-  event_type: Multipart
-  upload_type: multipart
-  delete_bucket_object: false
+  upload_type: normal

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_ssl_kafka_none_persistent_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_ssl_kafka_none_persistent_multipart.yaml
@@ -1,3 +1,4 @@
+# polarian:CEPH-83575407
 config:
  user_count: 1
  bucket_count: 2
@@ -5,17 +6,17 @@ config:
  objects_size_range:
   min: 6M
   max: 8M
- local_file_delete: true
  test_ops:
   create_bucket: true
   create_object: true
+  delete_bucket_object: false
   enable_version: false
   create_topic: true
-  get_topic_info: true
-  endpoint: kafka
-  persistent_flag: true
-  ack_type: none
-  put_get_bucket_notification: true
   event_type: Multipart
   upload_type: multipart
-  delete_bucket_object: false
+  get_topic_info: true
+  endpoint: kafka
+  ack_type: none
+  persistent_flag: true
+  security_type: SSL
+  put_get_bucket_notification: true


### PR DESCRIPTION
This PR is to automate kafka sasl scram testing.
installation and configuration of security types are present in the cephci PR: https://github.com/red-hat-storage/cephci/pull/2204
hotfix bz: [Bz 2160209](https://bugzilla.redhat.com/show_bug.cgi?id=2160209)
polarion id: [CEPH-83575407](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83575407)
reducing objects_count to 10 because the configs count is huge
pacific pass logs:

1. tier-2_rgw_test-bucket-notifications-kafka-ssl.yaml: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-t4ix2/
2. tier-2_rgw_test-bucket-notifications-kafka-sasl-sanity.yaml: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-byvu0/
3. tier-2_rgw_test-bucket-notifications-kafka-sasl-scheduled.yaml: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-o4cwm
4. tier-2_rgw_test-bucket-notifications.yaml: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-sucsk/

quincy pass logs: (failures are known issues for multipart events)

1. tier-2_rgw_test-bucket-notifications-kafka-ssl.yaml: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-vg727
2. tier-2_rgw_test-bucket-notifications-kafka-sasl-sanity.yaml: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-i90gk/
3. tier-2_rgw_test-bucket-notifications-kafka-sasl-scheduled.yaml: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-99e2z/
4. tier-2_rgw_test_bucket_notifications.yaml: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-pfktn/