### PR TITLE
CEPH-83575283,CEPH-83575282 Verify ETag on transition and Multipart T…

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_cloud_transition_headobject_true.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_cloud_transition_headobject_true.yaml
@@ -4,6 +4,7 @@ config:
   user_count: 1
   bucket_count: 1
   objects_count: 100
+  etag_verification: true
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_cloud_transition_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_cloud_transition_multipart.yaml
@@ -1,15 +1,16 @@
 # script: test_cloud_transitions.py
-# Polarion ID : CEPH-83575278
+# Polarion ID : CEPH-83575283
 config:
   user_count: 1
   bucket_count: 1
-  objects_count: 100
-  etag_verification: true
+  objects_count: 10
+  split_size: 10
   objects_size_range:
-    min: 5
-    max: 15
+    min: 20M
+    max: 50M
   test_ops:
     create_bucket: true
     create_object: true
+    upload_type: multipart
     lc_id: cloud_transit
     retain_head_object: false

--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -1247,6 +1247,21 @@ def get_object_list(bucket_name, s3_conn_client, prefix=None):
     return object_list
 
 
+def get_object_list_etag(bucket_name, s3_conn_client):
+    """
+    Returns object Key,Etag for the given bucket
+    """
+    object_resp = s3_conn_client.list_objects(Bucket=bucket_name)
+    if "Contents" not in object_resp.keys():
+        log.info("Objects do not exist in the bucket")
+        return []
+    object_dict = {}
+    for di in object_resp["Contents"]:
+        object_dict.update({di["Key"]: di["ETag"]})
+    log.info(object_dict)
+    return object_dict
+
+
 def add_zonegroup_placement(
     storage_class=None,
     tier_type=None,


### PR DESCRIPTION
…ransition

Pass Logs:
http://magna002.ceph.redhat.com/ceph-qe-logs/tejas/cloud_transition_headobject_true_etag_verify.txt
http://magna002.ceph.redhat.com/ceph-qe-logs/tejas/cloud_transition_headobject_false_etag_verify.txt
http://magna002.ceph.redhat.com/ceph-qe-logs/tejas/cloud_transition_headobject_false_multipart.txt

Also based on the dicussion the ETag verification can only be used on non multipart object transition. Multipart Uploads result in changed ETag on remote site.