### PR TITLE
T2 CEPH-83574042: Get LC rule map via radosgw-admin lc get on the bucket

### DIFF
--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -575,6 +575,13 @@ def put_get_bucket_lifecycle_test(
             log.info("LC is applied on the bucket")
         else:
             raise TestExecError("LC is not applied")
+    op_lc_get = utils.exec_shell_cmd(f"radosgw-admin lc get --bucket {bucket.name}")
+    json_doc = json.loads(op_lc_get)
+    rule_map = json_doc["rule_map"][0]["rule"]
+    if not rule_map:
+        raise TestExecError(
+            f"radosgw-admin lc get is not applied on bucket {bucket.name}"
+        )
 
 
 def remove_user(user_info, cluster_name="ceph", tenant=False):


### PR DESCRIPTION
Tier-2 CEPH-83574042:  Test radosgw-admin lc get on the bucket to get the LC rule map.

Logs: http://magna002.ceph.redhat.com/ceph-qe-logs/vidushi/automation_logs/pr-404/logs_1

[Test if LC policy is applied via lc list and lc get.](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574042)