### PR TITLE
 Automating mdlog and datalog trimming

### DIFF
--- a/rgw/v2/lib/resource_op.py
+++ b/rgw/v2/lib/resource_op.py
@@ -223,6 +223,10 @@ class Config(object):
         self.ec_storage_class = self.doc["config"].get("ec_storage_class")
         self.ec_pool_name = self.doc["config"].get("ec_pool_name")
         self.enable_resharding = self.doc["config"].get("enable_resharding")
+        self.log_trimming = self.doc["config"].get("log_trimming")
+        self.test_bilog_trim_on_non_existent_bucket = self.doc["config"].get(
+            "test_bilog_trim_on_non_existent_bucket"
+        )
         self.download_object = self.doc["config"].get("download_object")
         self.user_remove = self.doc["config"].get("user_remove", True)
         self.user_type = self.doc["config"].get("user_type")

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_datalog_trimming.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_datalog_trimming.yaml
@@ -1,9 +1,8 @@
 # upload type: non multipart
 # script: test_bilog_trimming.py
-# polarion_id: CEPH-83572658
+# polarion_id: CEPH-10540
 config:
-  log_trimming: bilog
-  test_bilog_trim_on_non_existent_bucket: true
+  log_trimming: datalog
   user_count: 1
   bucket_count: 2
   objects_count: 100

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_mdlog_trimming.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_mdlog_trimming.yaml
@@ -1,9 +1,8 @@
 # upload type: non multipart
 # script: test_bilog_trimming.py
-# polarion_id: CEPH-83572658
+# polarion_id: CEPH-10544
 config:
-  log_trimming: bilog
-  test_bilog_trim_on_non_existent_bucket: true
+  log_trimming: mdlog
   user_count: 1
   bucket_count: 2
   objects_count: 100

--- a/rgw/v2/tests/s3_swift/test_bilog_trimming.py
+++ b/rgw/v2/tests/s3_swift/test_bilog_trimming.py
@@ -41,7 +41,6 @@ TEST_DATA_PATH = None
 
 
 def test_exec(config, ssh_con):
-
     io_info_initialize = IOInfoInitialize()
     basic_io_structure = BasicIOInfoStructure()
     io_info_initialize.initialize(basic_io_structure.initial())
@@ -84,26 +83,8 @@ def test_exec(config, ssh_con):
                             each_user,
                         )
 
-                # Verify bilog list is not empty after creating objects
-                cmd = f"radosgw-admin bilog list --bucket {bucket_name_to_create}"
-                output1 = json.loads(utils.exec_shell_cmd(cmd))
-                if len(output1) > 0:
-                    log.info("Bucket index log is not empty")
-                else:
-                    raise TestExecError("Bucket index log is empty")
-
-                # Setting interval to default time of 20 minutes
-                time.sleep(1260)
-
-                # Verify bilog list is empty after the interval of creating objects
-                output2 = json.loads(utils.exec_shell_cmd(cmd))
-
-                if len(output2) == 0:
-                    log.info("Bucket index log is empty after the interval")
-                else:
-                    raise TestExecError(
-                        "Bucket index log is not empty after the interval"
-                    )
+                # test log trimming
+                reusable.test_log_trimming(bucket, config)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
 Automating mdlog and datalog trimming.

This PR would test log trimming (mdlog, datalog, and bilog) happens after the default interval of 20 minutes

The test covered : **CEPH-10540, and CEPH-10544.**

passed logs for mdlog and bilog : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-17PS0C

passed log for datalog : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-RHAN77

