### PR TITLE
[T2-Automation][RGW]: CEPH-10647

### DIFF
--- a/rgw/v2/lib/resource_op.py
+++ b/rgw/v2/lib/resource_op.py
@@ -247,6 +247,9 @@ class Config(object):
         self.container_count = self.doc["config"].get("container_count")
         self.version_count = self.doc["config"].get("version_count")
         self.version_enable = self.doc["config"].get("version_enable", False)
+        self.delete_object_current_versions = self.doc["config"].get(
+            "delete_object_current_versions", False
+        )
         self.delete_using_different_user = self.doc["config"].get(
             "delete_using_different_user", False
         )

--- a/rgw/v2/tests/s3_swift/configs/test_delete_current_version_object.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_delete_current_version_object.yaml
@@ -1,0 +1,16 @@
+# CEPH-10647
+config:
+     user_count: 1
+     bucket_count: 2
+     objects_count: 2
+     version_count: 4
+     objects_size_range:
+          min: 5
+          max: 15
+     delete_object_current_versions: true
+     test_ops:
+          enable_version: true
+          suspend_version: false
+          copy_to_version: false
+          delete_object_versions: false
+          upload_after_suspend: false

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_delete_current_version_object.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_delete_current_version_object.yaml
@@ -1,0 +1,1 @@
+../configs/test_delete_current_version_object.yaml


### PR DESCRIPTION
[T2-Automation][RGW]: CEPH-10647
Delete the current version of the object

Current PR includes logic:
1. Deleting current version of uploaded objects on a version enabled bucket
2. verify current version id deleted
3. new version become the current version id
4. all the existing versions except deleted version is still available

Log: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/CEPH-10647/