### PR TITLE
change max_objs_per_shard to 5(as default)

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_dbr_with_custom_objs_per_shard_and_max_dynamic_shard.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dbr_with_custom_objs_per_shard_and_max_dynamic_shard.yaml
@@ -5,7 +5,7 @@ config:
     min: 5
     max: 10
   sharding_type: dynamic
-  max_objects_per_shard: 1
+  max_objects_per_shard: 5
   max_rgw_dynamic_shards: 200
   test_ops:
     delete_bucket_object: true

--- a/rgw/v2/tests/s3_swift/configs/test_dbr_with_custom_objs_per_shard_max_dynamic_shard_and_reshard_thread_interval.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dbr_with_custom_objs_per_shard_max_dynamic_shard_and_reshard_thread_interval.yaml
@@ -5,7 +5,7 @@ config:
     min: 5
     max: 10
   sharding_type: dynamic
-  max_objects_per_shard: 1
+  max_objects_per_shard: 5
   max_rgw_dynamic_shards: 200
   rgw_reshard_thread_interval: 180
   test_ops:

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_dynamic_resharding_brownfield.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_dynamic_resharding_brownfield.yaml
@@ -7,7 +7,7 @@ config:
     min: 15K
     max: 500K
   dbr_scenario: brownfield
-  max_objects_per_shard: 1
+  max_objects_per_shard: 5
   local_file_delete: true
   test_ops:
     create_bucket: true

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_dynamic_resharding_greenfield.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_dynamic_resharding_greenfield.yaml
@@ -7,7 +7,7 @@ config:
     min: 15K
     max: 5M
   dbr_scenario: greenfield
-  max_objects_per_shard: 1
+  max_objects_per_shard: 5
   local_file_delete: true
   test_ops:
     create_bucket: true


### PR DESCRIPTION
This PR is to have uniform value for max_objs_per_shard across all dynamic resharding tests. 

Pass logs:
http://magna002.ceph.redhat.com/ceph-qe-logs/madhavi/PRs/max_shards/ 