### PR TITLE
support to check for large omap and cluster health

### DIFF
--- a/rgw/v2/lib/sync_status.py
+++ b/rgw/v2/lib/sync_status.py
@@ -62,3 +62,20 @@ def sync_status(retry=25, delay=60):
         log.info("data from archive zone does not sync to source zone as per design")
     else:
         raise SyncFailedError("sync is either slow or stuck")
+
+    # check for cluster health status and omap if any
+    ceph_status = check_ceph_status()
+
+
+def check_ceph_status():
+    """
+    get the ceph cluster status and health
+    """
+    log.info("get ceph status")
+    ceph_status = utils.exec_shell_cmd(cmd="sudo ceph status")
+    if "HEALTH_ERR" in ceph_status or "large omap objects" in ceph_status:
+        raise Exception(
+            "ceph status is either in HEALTH_ERR or we have large omap objects."
+        )
+    else:
+        log.info("ceph status - HEALTH_OK")


### PR DESCRIPTION
extend support to check large omap across all the tests.

Pass logs with health_ok - http://magna002.ceph.redhat.com/ceph-qe-logs/madhavi/PRs/large_omap/bucket_listing_health_ok_console.log 

with large omap - http://magna002.ceph.redhat.com/ceph-qe-logs/madhavi/PRs/large_omap/test_bucket_listing_large_omap.log 