### PR TITLE
BZ-2174235:[SERPRO]: No metadata loss post a bucket is resharded.

### DIFF
--- a/rgw/v2/lib/resource_op.py
+++ b/rgw/v2/lib/resource_op.py
@@ -222,6 +222,9 @@ class Config(object):
         self.two_pool_transition = self.doc["config"].get("two_pool_transition")
         self.ec_storage_class = self.doc["config"].get("ec_storage_class")
         self.ec_pool_name = self.doc["config"].get("ec_pool_name")
+        self.test_with_bucket_index_shards = self.doc["config"].get(
+            "test_with_bucket_index_shards"
+        )
         self.enable_resharding = self.doc["config"].get("enable_resharding")
         self.log_trimming = self.doc["config"].get("log_trimming")
         self.test_bilog_trim_on_non_existent_bucket = self.doc["config"].get(

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_index_shards.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_index_shards.yaml
@@ -1,0 +1,11 @@
+# CEPH-83575472, bug-2174235
+config:
+  test_with_bucket_index_shards: true
+  objects_count: 100
+  objects_size_range:
+    min: 15
+    max: 20
+  sharding_type: manual
+  shards: 97
+  test_ops:
+    delete_bucket_object: false


### PR DESCRIPTION
CEPH-83575472, bug 2174235



<br class="Apple-interchange-newline">[Test if "bucket_index_max_shards" = 0, resharding a bucket will not remove bucket metadata](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83575472)


1. Failed logs without the fix: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-9GYSV0
2. Pass logs with the fix: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-57Q9PD