### PR TITLE
testing bucket notifications with metadata filter 

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_kafka_broker_persistent_filter.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_kafka_broker_persistent_filter.yaml
@@ -1,0 +1,31 @@
+# polarian:CEPH-83574420
+config:
+ user_count: 1
+ bucket_count: 2
+ objects_count: 25
+ objects_size_range:
+  min: 5
+  max: 15
+ test_ops:
+  create_bucket: true
+  create_object: true
+  copy_object: true
+  delete_bucket_object: true
+  enable_version: false
+  create_topic: true
+  event_type:
+   - Copy
+   - Delete
+  get_topic_info: true
+  endpoint: kafka
+  ack_type: broker
+  persistent_flag: true
+  put_get_bucket_notification: true
+  upload_type: normal
+  Filter:
+   Key:
+    FilterRules:
+     - Name: 'prefix'
+       Value: 'images_'
+     - Name: 'suffix'
+       Value: '_jpg'


### PR DESCRIPTION
This PR is to verify notifications are seen on a bucket configured with metadata filter
add config for filter with prefix or suffix of object name while performing put_bucket_notification_configuration() in topic configuration itself , refer [put_bucket_notification_configuration](https://boto3.amazonaws.com/v1/documentation/api/1.9.42/reference/services/s3.html#S3.Client.put_bucket_notification_configuration)
Polarion id: [CEPH-83574420](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574420)

pass logs: http://magna002.ceph.redhat.com/ceph-qe-logs/HemanthSai/notif_metadata_filter/
 (failures are known issues for multipart events on rhcs6.0 , refer [Bz2153533](https://bugzilla.redhat.com/show_bug.cgi?id=2153533)