### PR TITLE
Add support to verify notification on versioned buckets

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_kafka_none_version_copy_del.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_kafka_none_version_copy_del.yaml
@@ -1,0 +1,25 @@
+# version enabled + none type + persistent = false - CEPH-83574074
+config:
+ user_count: 1
+ bucket_count: 2
+ objects_count: 2
+ version_count: 5
+ objects_size_range:
+  min: 5
+  max: 15
+ test_ops:
+  create_bucket: true
+  create_object: true
+  enable_version: true
+  create_topic: true
+  copy_object: true
+  get_topic_info: true
+  persistent_flag: false
+  endpoint: kafka
+  ack_type: broker
+  put_get_bucket_notification: true
+  event_type:
+    - Copy
+    - Delete
+  upload_type: normal
+  delete_bucket_object: true

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_kafka_persist_broker_version_copy_del.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_kafka_persist_broker_version_copy_del.yaml
@@ -1,0 +1,25 @@
+# version enabled + broker type + persistent = true - CEPH-83574087
+config:
+ user_count: 1
+ bucket_count: 2
+ objects_count: 2
+ version_count: 5
+ objects_size_range:
+  min: 5
+  max: 15
+ test_ops:
+  create_bucket: true
+  create_object: true
+  enable_version: true
+  create_topic: true
+  copy_object: true
+  get_topic_info: true
+  persistent_flag: true
+  endpoint: kafka
+  ack_type: broker
+  put_get_bucket_notification: true
+  event_type:
+    - Copy
+    - Delete
+  upload_type: normal
+  delete_bucket_object: true

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_broker_version_copy_del.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_broker_version_copy_del.yaml
@@ -1,0 +1,25 @@
+# version enabled + broker type + persistent=false - CEPH-83574073
+config:
+ user_count: 1
+ bucket_count: 2
+ objects_count: 2
+ version_count: 5
+ objects_size_range:
+  min: 5
+  max: 15
+ test_ops:
+  create_bucket: true
+  create_object: true
+  enable_version: true
+  create_topic: true
+  copy_object: true
+  get_topic_info: true
+  persistent_flag: false
+  endpoint: kafka
+  ack_type: broker
+  put_get_bucket_notification: true
+  event_type:
+    - Copy
+    - Delete
+  upload_type: normal
+  delete_bucket_object: false

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_persist_none_version_copy_del.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_persist_none_version_copy_del.yaml
@@ -1,0 +1,26 @@
+# version enabled + none type + persistent = true - CEPH-83574086
+config:
+ user_count: 1
+ bucket_count: 2
+ objects_count: 2
+ version_count: 5
+ objects_size_range:
+  min: 5
+  max: 15
+ user_remove: false
+ test_ops:
+  create_bucket: true
+  create_object: true
+  enable_version: true
+  create_topic: true
+  copy_object: true
+  get_topic_info: true
+  endpoint: kafka
+  ack_type: none
+  persistent_flag: true
+  put_get_bucket_notification: true
+  event_type:
+    - Copy
+    - Delete
+  upload_type: normal
+  delete_bucket_object: false

--- a/rgw/v2/tests/s3_swift/reusables/bucket_notification.py
+++ b/rgw/v2/tests/s3_swift/reusables/bucket_notification.py
@@ -194,7 +194,9 @@ def get_bucket_notification(rgw_s3_client, bucketname, empty=False):
     )
 
 
-def verify_event_record(event_type, bucket, event_record_path, ceph_version):
+def verify_event_record(
+    event_type, bucket, event_record_path, ceph_version, versioning=False
+):
     """
     verify event records
     """
@@ -204,13 +206,17 @@ def verify_event_record(event_type, bucket, event_record_path, ceph_version):
     # verify event record for a particular event type
     notifications_received = False
     events = []
+    if "Put" in event_type:
+        events = ["ObjectCreated:Put"]
     if "Delete" in event_type:
         events = [
             "ObjectRemoved:Delete",
             "ObjectRemoved:DeleteMarkerCreated",
         ]
     if "Copy" in event_type:
-        events = ["ObjectCreated:Copy"]
+        events = [
+            "ObjectCreated:Copy",
+        ]
     if "Multipart" in event_type:
         events = [
             "ObjectCreated:Post",
@@ -226,6 +232,18 @@ def verify_event_record(event_type, bucket, event_record_path, ceph_version):
         ]
     log.info(f"verifying event record for event type {event_type}")
     log.info(f"valid event names are :{events}")
+
+    # get object list of a bucket
+    cmd = f"radosgw-admin bucket list --bucket {bucket}"
+    bucket_list = utils.exec_shell_cmd(cmd)
+
+    # get zonegroup details
+    zonegroup_get = utils.exec_shell_cmd("radosgw-admin zonegroup get")
+    zonegroup_get_json = json.loads(zonegroup_get)
+
+    # get bucket stats of bucket
+    bucket_stats = utils.exec_shell_cmd(f"radosgw-admin bucket stats --bucket {bucket}")
+    bucket_stats_json = json.loads(bucket_stats)
 
     # read the file event_record
     with open(event_record_path, "r") as records:
@@ -262,10 +280,6 @@ def verify_event_record(event_type, bucket, event_record_path, ceph_version):
                 raise EventRecordDataError("eventTime: Incorrect timestamp format")
 
             # fetch bucket details and verify bucket attributes in event record
-            bucket_stats = utils.exec_shell_cmd(
-                "radosgw-admin bucket stats --bucket %s" % bucket
-            )
-            bucket_stats_json = json.loads(bucket_stats)
             log.info("verify bucket attributes in event record")
             # verify bucket name in event record
             bucket_name = event_record_json["Records"][0]["s3"]["bucket"]["name"]
@@ -311,8 +325,6 @@ def verify_event_record(event_type, bucket, event_record_path, ceph_version):
             log.info(f"size: {size}")
 
             # verify the zonegroup in event record
-            zonegroup_get = utils.exec_shell_cmd("radosgw-admin zonegroup get")
-            zonegroup_get_json = json.loads(zonegroup_get)
             zonegroup_name = zonegroup_get_json["name"]
             awsRegion = event_record_json["Records"][0]["awsRegion"]
             # verify awsRegion in event record is the zonegroup ref BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2004171
@@ -320,6 +332,18 @@ def verify_event_record(event_type, bucket, event_record_path, ceph_version):
                 log.info(f"awsRegion: {awsRegion}")
             else:
                 raise EventRecordDataError("awsRegion not in event record")
+
+            # verify object version in case versioning is enabled
+            if versioning:
+                # get object version id using radosgw-admin cli
+                object_key = event_record_json["Records"][0]["s3"]["object"]["key"]
+                event_version_id = event_record_json["Records"][0]["s3"]["object"][
+                    "versionId"
+                ]
+                if event_version_id in bucket_list:
+                    log.info(f"object version: {event_version_id} in event record")
+                else:
+                    raise EventRecordDataError("Object version_id not in event record")
 
     if notifications_received is False:
         raise EventRecordDataError(

--- a/rgw/v2/tests/s3_swift/test_bucket_notifications.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_notifications.py
@@ -23,6 +23,11 @@ Usage: test_bucket_notification.py -c <input_yaml>
     test_bucket_notification_with_tenant_user.yaml
     test_bucket_notification_kafka_broker_persistent_dynamic_reshard.yaml
     test_bucket_notification_kafka_broker_persistent_manual_reshard.yaml
+    test_bucket_notification_kafka_none_version_copy_del.yaml
+    test_bucket_notification_kafka_persist_broker_version_copy_del.yaml
+    test_bucket_notification_kafka_persist_none_version_copy_del.yaml
+    test_bucket_notification_kafka_broker_version_copy_del.yaml
+
 Operation:
     create user (tenant/non-tenant)
     Create topic and get topic
@@ -64,7 +69,6 @@ TEST_DATA_PATH = None
 
 
 def test_exec(config, ssh_con):
-
     io_info_initialize = IOInfoInitialize()
     basic_io_structure = BasicIOInfoStructure()
     write_bucket_io_info = BucketIoInfo()
@@ -125,15 +129,18 @@ def test_exec(config, ssh_con):
                 bucket = reusable.create_bucket(
                     bucket_name_to_create, rgw_conn, each_user
                 )
-                if config.test_ops.get("enable_version", False):
+                versioning = config.test_ops.get("enable_version", False)
+                if versioning:
                     log.info("enable bucket version")
                     reusable.enable_versioning(
                         bucket, rgw_conn, each_user, write_bucket_io_info
                     )
 
                 event_types = config.test_ops.get("event_type")
+                # Adding event_type Put as default
+                event_types = ["Put"]
                 if type(event_types) == str:
-                    event_types = [event_types]
+                    event_types += [event_types]
                 security_type = config.test_ops.get("security_type", "PLAINTEXT")
                 mechanism = config.test_ops.get("mechanism", None)
                 # create topic with endpoint
@@ -213,6 +220,16 @@ def test_exec(config, ssh_con):
                                 config,
                                 each_user,
                             )
+                        elif config.test_ops.get("enable_version", False):
+                            reusable.upload_version_object(
+                                config,
+                                each_user,
+                                rgw_conn,
+                                s3_object_name,
+                                config.obj_size,
+                                bucket,
+                                TEST_DATA_PATH,
+                            )
                         else:
                             log.info("upload type: normal")
                             reusable.upload_object(
@@ -276,6 +293,7 @@ def test_exec(config, ssh_con):
                         bucket_name_to_create,
                         event_record_path,
                         ceph_version_name,
+                        versioning,
                     )
                     if verify is False:
                         raise EventRecordDataError(
@@ -308,7 +326,6 @@ def test_exec(config, ssh_con):
 
 
 if __name__ == "__main__":
-
     test_info = AddTestInfo("test bucket notification")
     test_info.started_info()
 


### PR DESCRIPTION
This PR is to add support to verify notification on versioned buckets
CEPH-83574074 - Kafka: Topic creation with kafka-ack-level=none and persistent flag false
CEPH-83574087 - MS: verify notification with kafka-ack-level=broker + persistent =true +versioned bucket
CEPH-83574073 - Kafka: Topic creation with kafka-ack-level=broker and persistent flag false
CEPH-83574086 - MS: Verify notification with kafka-ack-level=broker + persistent =true

Passlogs: http://magna002.ceph.redhat.com/ceph-qe-logs/madhavi/PRs/notification/versioned_bkt/ 

updated pass logs - http://magna002.ceph.redhat.com/ceph-qe-logs/madhavi/PRs/notification/versioned_bkt/new_logs/