### PR TITLE
testing persistent notifications when kafka server is down

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_kafka_down_broker_persistent.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_kafka_down_broker_persistent.yaml
@@ -1,0 +1,24 @@
+config:
+ user_count: 1
+ bucket_count: 2
+ objects_count: 25
+ objects_size_range:
+  min: 5
+  max: 15
+ test_ops:
+  create_bucket: true
+  create_object: true
+  copy_object: true
+  enable_version: false
+  create_topic: true
+  get_topic_info: true
+  endpoint: kafka
+  persistent_flag: true
+  ack_type: broker
+  put_get_bucket_notification: true
+  event_type:
+   - Copy
+   - Delete
+  upload_type: normal
+  delete_bucket_object: true
+  verify_persistence_with_kafka_stop: true

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_kafka_down_broker_persistent_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_kafka_down_broker_persistent_multipart.yaml
@@ -1,0 +1,22 @@
+config:
+ user_count: 1
+ bucket_count: 2
+ objects_count: 25
+ local_file_delete: true
+ objects_size_range:
+  min: 6M
+  max: 8M
+ test_ops:
+  create_bucket: true
+  create_object: true
+  enable_version: false
+  create_topic: true
+  get_topic_info: true
+  endpoint: kafka
+  persistent_flag: true
+  ack_type: broker
+  put_get_bucket_notification: true
+  event_type: Multipart
+  upload_type: multipart
+  delete_bucket_object: false
+  verify_persistence_with_kafka_stop: true

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_kafka_down_none_persistent.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_kafka_down_none_persistent.yaml
@@ -1,0 +1,24 @@
+config:
+ user_count: 1
+ bucket_count: 2
+ objects_count: 25
+ objects_size_range:
+  min: 5
+  max: 15
+ test_ops:
+  create_bucket: true
+  create_object: true
+  enable_version: false
+  create_topic: true
+  get_topic_info: true
+  endpoint: kafka
+  persistent_flag: true
+  ack_type: none
+  put_get_bucket_notification: true
+  event_type:
+   - Copy
+   - Delete
+  upload_type: normal
+  delete_bucket_object: true
+  copy_object: true
+  verify_persistence_with_kafka_stop: true

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_kafka_down_none_persistent_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_kafka_down_none_persistent_multipart.yaml
@@ -1,0 +1,22 @@
+config:
+ user_count: 1
+ bucket_count: 2
+ objects_count: 25
+ objects_size_range:
+  min: 6M
+  max: 8M
+ local_file_delete: true
+ test_ops:
+  create_bucket: true
+  create_object: true
+  enable_version: false
+  create_topic: true
+  get_topic_info: true
+  endpoint: kafka
+  persistent_flag: true
+  ack_type: none
+  put_get_bucket_notification: true
+  event_type: Multipart
+  upload_type: multipart
+  delete_bucket_object: false
+  verify_persistence_with_kafka_stop: true

--- a/rgw/v2/tests/s3_swift/test_bucket_notifications.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_notifications.py
@@ -1,5 +1,5 @@
 """
-test_bucket_notification - Test bucket notifcations 
+test_bucket_notification - Test bucket notifcations
 Usage: test_bucket_notification.py -c <input_yaml>
 <input_yaml>
     Note: any one of these yamls can be used
@@ -9,7 +9,7 @@ Usage: test_bucket_notification.py -c <input_yaml>
     test_bucket_notification_kafka_none_persistent_delete.yaml
     test_bucket_notification_kafka_none_persistent_copy.yaml
     test_bucket_notification_kafka_none_persistent_multipart.yaml
-    test_bucket_notification_kafka_broker_delete.yaml		
+    test_bucket_notification_kafka_broker_delete.yaml
     test_bucket_notification_kafka_broker_copy.yaml
     test_bucket_notification_kafka_broker_multipart.yaml
     test_bucket_notification_kafka_none_delete.yaml
@@ -214,6 +214,10 @@ def test_exec(config, ssh_con):
                             "radosgw-admin topic get failed for bucket notification topic"
                         )
 
+                # stop kafka server
+                if config.test_ops.get("verify_persistence_with_kafka_stop", False):
+                    notification.start_stop_kafka_server("stop")
+
                 # create objects
                 if config.test_ops.get("create_object", False):
                     # uploading data
@@ -282,6 +286,10 @@ def test_exec(config, ssh_con):
                             )
                     else:
                         reusable.delete_objects(bucket)
+
+                # start kafka server
+                if config.test_ops.get("verify_persistence_with_kafka_stop", False):
+                    notification.start_stop_kafka_server("start")
 
                 # start kafka broker and consumer
                 event_record_path = "/tmp/event_record"


### PR DESCRIPTION
this PR is to test persistent bucket notifications while kafka is down.
test steps:
- create a topic with persistent flag true
- stop the kafka server
- upload objects
- start the kafka server and verify the notifications are received

polarion id's: [CEPH-83574417](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574417) , [CEPH-83574078](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574078)

pacific pass logs: http://magna002.ceph.redhat.com/ceph-qe-logs/HemanthSai/persist_notif_kafka_down/

bz raised for quincy failures: [bz2184268](https://bugzilla.redhat.com/show_bug.cgi?id=2184268)