### PR TITLE
Add support for Object Lock Compliance mode TC CEPH-83574057

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_object_lock_compliance.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_object_lock_compliance.yaml
@@ -11,3 +11,4 @@ config:
   test_ops:
     create_bucket: true
     create_object: true
+    compliance_mode: true

--- a/rgw/v2/tests/s3_swift/configs/test_object_lock_governance.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_object_lock_governance.yaml
@@ -1,0 +1,15 @@
+# upload type: non multipart
+# Polarion ID : CEPH-83574057
+# Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1890843
+# script: test_object_lock.py - Test object lock configuration for bucket
+config:
+  user_count: 1
+  bucket_count: 2
+  objects_count: 100
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    create_bucket: true
+    create_object: true
+    compliance_mode: false

--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -1599,3 +1599,20 @@ def pipe_operation(group_id, pipe_op, zone_names=None, bucket_name=None):
     utils.exec_shell_cmd(cmd)
     update_commit()
     return pipe_id
+
+
+def object_put_hold(client, body, bucket, key, LegalHold):
+    # boto3 put object with object legal hold ON or OFF
+    client.put_object(
+        Body=body,
+        Bucket=bucket,
+        Key=key,
+        ObjectLockLegalHoldStatus=LegalHold,
+    )
+
+
+def object_lock_put(client, bucket, lock_configuration):
+    # boto3 put object lock configuration on bucket
+    client.put_object_lock_configuration(
+        Bucket=bucket, ObjectLockConfiguration=lock_configuration
+    )

--- a/rgw/v2/tests/s3_swift/test_multisite_sync_policy.py
+++ b/rgw/v2/tests/s3_swift/test_multisite_sync_policy.py
@@ -83,7 +83,7 @@ def test_exec(config, ssh_con):
                 if config.test_ops["group_remove"]:
                     group_status = config.test_ops["group_status"]
                     reusable.group_operation(group_id, "remove", group_status)
-                    if config.test_ops["group_transition"]:
+                    if config.test_ops.get("group_transition", False):
                         reusable.group_operation(group_id2, "remove", group_status)
 
     for each_user in all_users_info:


### PR DESCRIPTION
Steps performed:
- Add support for Governance mode in bucket level lock
- Add Legal Hold for all object uploads

Imp : Change in multisite_sync_policy.py is a missed line in last PR . It will be tested when Sync policy tests are added to cephCI

Pass log:
http://magna002.ceph.redhat.com/ceph-qe-logs/tejas/object_lock_governance.txt