### PR TITLE
T2 automation-CEPH-11623-s3:GetBucketLocation with users in same tenant

### DIFF
--- a/rgw/v2/lib/s3/auth.py
+++ b/rgw/v2/lib/s3/auth.py
@@ -74,6 +74,7 @@ class Auth(object):
             use_ssl=self.ssl,
             verify=False,
             config=additional_config,
+            region_name="",
             aws_session_token=self.session_token if self.session_token else None,
         )
 
@@ -101,6 +102,7 @@ class Auth(object):
             endpoint_url=self.endpoint_url,
             config=additional_config,
             verify=False,
+            region_name="",
             aws_session_token=self.session_token if self.session_token else None,
         )
         return rgw

--- a/rgw/v2/tests/s3_swift/configs/test_bucketlocation_using_bucketpolicy_with_tenantuser.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucketlocation_using_bucketpolicy_with_tenantuser.yaml
@@ -1,0 +1,12 @@
+# Polarian id: CEPH-11623
+# Script: test_bucket_policy_with_tenant_user.py
+config:
+    bucket_count: 2
+    objects_count: 1
+    objects_size_range:
+      min: 5
+      max: 15
+    test_ops:
+      create_bucket: true
+      sub_user_count: 3
+      get_bucket_location: true

--- a/rgw/v2/tests/s3_swift/configs/test_list_all_multipart_uploads.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_list_all_multipart_uploads.yaml
@@ -1,5 +1,5 @@
 # Polarian id: CEPH-11116
-# Script: test_list_all_multipart_uploads.py
+# Script: test_bucket_policy_with_tenant_user.py
 config:
   bucket_count: 1
   objects_count: 1
@@ -10,3 +10,4 @@ config:
   test_ops:
     create_bucket: true
     upload_type: multipart
+    list_bucket_multipart_uploads: true

--- a/rgw/v2/tests/s3_swift/configs/test_listbucketversion_with_bucketpolicy_for_tenant_user.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_listbucketversion_with_bucketpolicy_for_tenant_user.yaml
@@ -1,5 +1,5 @@
-# Polarian id:
-# Script: test_list_all_multipart_uploads.py
+# Polarian id: CEPH-11574
+# Script: test_bucket_policy_with_tenant_user.py
 config:
     bucket_count: 2
     objects_count: 15

--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -33,20 +33,25 @@ rgw_service = RGWService()
 log = logging.getLogger()
 
 
-def create_bucket(bucket_name, rgw, user_info):
+def create_bucket(bucket_name, rgw, user_info, location=None):
     log.info("creating bucket with name: %s" % bucket_name)
     # bucket = s3_ops.resource_op(rgw_conn, 'Bucket', bucket_name_to_create)
     bucket = s3lib.resource_op(
         {"obj": rgw, "resource": "Bucket", "args": [bucket_name]}
     )
+    kw_args = None
+    if location is not None:
+        kw_args = dict(CreateBucketConfiguration={"LocationConstraint": location})
     created = s3lib.resource_op(
         {
             "obj": bucket,
             "resource": "create",
             "args": None,
+            "kwargs": kw_args,
             "extra_info": {"access_key": user_info["access_key"]},
         }
     )
+    log.info(f"bucket creation data: {created}")
     if created is False:
         raise TestExecError("Resource execution failed: bucket creation failed")
     if created is not None:


### PR DESCRIPTION
Tryed with location constraint "default" worked fine, here we rre mainly looking into s3:GetBucketLocation with users in same tenant
when location not given it will take default zone as bucket location

log: 
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_bucketlocation_using_bucketpolicy_with_tenantuser.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_list_all_multipart_uploads.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_listbucketversion_with_bucketpolicy_for_tenant_user.console.log