### PR TITLE
Fix for kwarg being none in s3 create bucket

### DIFF
--- a/rgw/v2/lib/resource_op.py
+++ b/rgw/v2/lib/resource_op.py
@@ -53,9 +53,10 @@ def resource_op(exec_info):
                 else:
                     result = getattr(obj, resource)()
             if "kwargs" in exec_info:
-                log.info("in kwargs")
-                log.info("kwargs value: %s" % exec_info["kwargs"])
-                result = getattr(obj, resource)(**dict(exec_info["kwargs"]))
+                if exec_info["kwargs"] is not None:
+                    log.info("in kwargs")
+                    log.info("kwargs value: %s" % exec_info["kwargs"])
+                    result = getattr(obj, resource)(**dict(exec_info["kwargs"]))
         else:
             log.info(" type is: %s" % type(getattr(obj, resource)))
             result = getattr(obj, resource)


### PR DESCRIPTION
Fix for kwarg being none in s3 create bucket

this was missed in pr: https://github.com/red-hat-storage/ceph-qe-scripts/pull/437
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_listbucketversion_with_bucketpolicy_for_tenant_user.console.log