### PR TITLE
CEPH-9744: Get object with different tenant swift user with same name

### DIFF
--- a/rgw/v2/lib/swift/auth.py
+++ b/rgw/v2/lib/swift/auth.py
@@ -56,3 +56,23 @@ class Auth(object):
             authurl=f"{proto}://{self.hostname}:{self.port}/auth",
         )
         return rgw
+
+    def do_auth_using_client(self):
+        """
+        This function is to perform authentication using client module
+
+        Parameters:
+
+        Returns:
+            rgw: Connection status
+        """
+        log.info("performing authentication using client module")
+        proto = "https" if self.is_secure else "http"
+
+        rgw = swiftclient.client.Connection(
+            user=self.user_id,
+            key=self.secret_key,
+            insecure=True,
+            authurl=f"{proto}://{self.hostname}:{self.port}/auth",
+        )
+        return rgw

--- a/rgw/v2/tests/s3_swift/configs/test_get_objects_from_tenant_swift_user.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_get_objects_from_tenant_swift_user.yaml
@@ -1,0 +1,12 @@
+# test case id: CEPH-9744
+config:
+    objects_count: 20
+    container_count: 2
+    objects_size_range:
+        min: 5
+        max: 15
+    test_ops:
+        create_container: true
+        fill_container: true
+        new_tenant: true
+        create_same_swift_tenant_user_under_diff_tenant: true


### PR DESCRIPTION
[automate][t2]:CEPH-9749-Createcontainer with a tenant$user. Test if the user with the same name but belonging to a different tenant is able to delete the container. It should fail.

log: http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_get_objects_from_tenant_swift_user.console.log

does not effect existing tc execution:
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_swift_basic_ops.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_swift_large_upload.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_swift_version_copy_op.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_swift_versioning.console.log