### PR TITLE
CEPH-9749: delete container with different tenant swift user with same name

### DIFF
--- a/rgw/v2/lib/swift/auth.py
+++ b/rgw/v2/lib/swift/auth.py
@@ -56,3 +56,23 @@ class Auth(object):
             authurl=f"{proto}://{self.hostname}:{self.port}/auth",
         )
         return rgw
+
+    def do_auth_using_client(self):
+        """
+        This function is to perform authentication using client module
+
+        Parameters:
+
+        Returns:
+            rgw: Connection status
+        """
+        log.info("performing authentication using client module")
+        proto = "https" if self.is_secure else "http"
+
+        rgw = swiftclient.client.Connection(
+            user=self.user_id,
+            key=self.secret_key,
+            insecure=True,
+            authurl=f"{proto}://{self.hostname}:{self.port}/auth",
+        )
+        return rgw

--- a/rgw/v2/tests/s3_swift/configs/test_delete_container_from_user_of_diff_tenant.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_delete_container_from_user_of_diff_tenant.yaml
@@ -1,0 +1,12 @@
+# test case id: CEPH-9749
+config:
+    objects_count: 100
+    container_count: 2
+    objects_size_range:
+        min: 5
+        max: 15
+    test_ops:
+        create_container: true
+        fill_container: true
+        new_tenant: true
+        delete_container_same_user: true

--- a/rgw/v2/tests/s3_swift/test_swift_basic_ops.py
+++ b/rgw/v2/tests/s3_swift/test_swift_basic_ops.py
@@ -20,6 +20,7 @@ Operation:
     Download uploaded objects from container
     Modify downloaded objects and re-upload it to the container
     Delete objects from container
+    Get object from container
     Delete container
     Copy versioned object
     Multipart upload

--- a/rgw/v2/tests/s3_swift/test_swift_basic_ops.py
+++ b/rgw/v2/tests/s3_swift/test_swift_basic_ops.py
@@ -9,6 +9,8 @@ Usage: test_swift_basic_ops.py -c <input_yaml>
     test_swift_versioning.yaml
     test_swift_version_copy_op.yaml
     test_swift_large_upload.yaml
+    test_get_objects_from_tenant_swift_user.yaml
+    test_delete_container_from_user_of_diff_tenant.yaml
 
 Operation:
     Create swift user
@@ -42,6 +44,7 @@ import names
 import v2.lib.manage_data as manage_data
 import v2.lib.resource_op as swiftlib
 import v2.utils.utils as utils
+from swiftclient import ClientException
 from v2.lib.admin import UserMgmt
 from v2.lib.exceptions import RGWBaseException, TestExecError
 from v2.lib.resource_op import Config
@@ -127,14 +130,26 @@ def test_exec(config, ssh_con):
     log.info(type(ceph_conf))
     rgw_service = RGWService()
     # preparing data
+    tenants_user_info = []
     user_name = names.get_first_name() + random.choice(string.ascii_letters)
     tenant = "tenant"
     tenant_user_info = umgmt.create_tenant_user(
         tenant_name=tenant, user_id=user_name, displayname=user_name
     )
+    tenants_user_info.append(tenant_user_info)
     user_info = umgmt.create_subuser(tenant_name=tenant, user_id=user_name)
     auth = Auth(user_info, ssh_con, config.ssl)
     rgw = auth.do_auth()
+
+    if config.test_ops.get("new_tenant", False):
+        new_tenant = "tenant" + random.choice(string.ascii_letters)
+        new_tenant_info = umgmt.create_tenant_user(
+            tenant_name=new_tenant, user_id=user_name, displayname=user_name
+        )
+        tenants_user_info.append(new_tenant_info)
+        new_user_info = umgmt.create_subuser(tenant_name=new_tenant, user_id=user_name)
+        new_auth = Auth(new_user_info, ssh_con, config.ssl)
+        rgw_client = new_auth.do_auth_using_client()
 
     for cc in range(config.container_count):
         if config.version_enable is True:
@@ -348,6 +363,52 @@ def test_exec(config, ssh_con):
                     else:
                         raise TestExecError("md5 mismatch")
 
+        if config.test_ops.get("create_container", False):
+            container_name = utils.gen_bucket_name_from_userid(
+                user_info["user_id"], rand_no=cc
+            )
+            container = swiftlib.resource_op(
+                {"obj": rgw, "resource": "put_container", "args": [container_name]}
+            )
+            if container is False:
+                raise TestExecError(
+                    "Resource execution failed: container creation failed"
+                )
+            if config.test_ops.get("fill_container", False):
+                for oc, size in list(config.mapped_sizes.items()):
+                    swift_object_name = fill_container(
+                        rgw,
+                        container_name,
+                        user_name,
+                        oc,
+                        cc,
+                        size,
+                    )
+
+            if config.test_ops.get("delete_container_same_user", False):
+
+                if config.test_ops.get("fill_container", False):
+                    headers, items = rgw.get_container(container_name)
+                    for i in items:
+                        rgw.delete_object(container_name, i["name"])
+
+                log.info(
+                    f"Delete container {container_name} with different tenant having same user name {new_user_info}"
+                )
+                # Verify same user in different tenant not having permission for deleting of container
+                try:
+                    rgw_client.delete_container(container_name)
+                    raise Exception(
+                        f"{new_user_info['user_id']} user should not be able to delete container: {container_name}"
+                    )
+                except ClientException as e:
+                    log.error(
+                        f"Delete container with different tenant tenant having same user name failed as expected: {e}"
+                    )
+
+                log.info(f"Delete container {container_name} with container owner")
+                rgw.delete_container(container_name)
+
         else:
             container_name = utils.gen_bucket_name_from_userid(
                 user_info["user_id"], rand_no=cc
@@ -395,11 +456,13 @@ def test_exec(config, ssh_con):
             log.info("deleting swift container")
             rgw.delete_container(container_name)
 
+    for tuser in tenants_user_info:
+        reusable.remove_user(tuser, tenant=tuser["tenant"])
+
     # check for any crashes during the execution
     crash_info = reusable.check_for_crash()
     if crash_info:
         raise TestExecError("ceph daemon crash found!")
-    reusable.remove_user(tenant_user_info, tenant=tenant)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
[automate][t2]:CEPH-9749-Createcontainer with a tenant$user$subuser. Test if the user with the same name but belonging to a different tenant is able to delete the container. It should fail.

log: http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_delete_container_from_user_of_diff_tenant.console.log

does not effect existing tc execution:
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_swift_basic_ops.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_swift_large_upload.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_swift_version_copy_op.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_swift_versioning.console.log