### PR TITLE
CEPH-9749: delete container with different tenant swift user with sam…

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_delete_container_from_user_of_diff_tenant.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_delete_container_from_user_of_diff_tenant.yaml
@@ -1,6 +1,6 @@
-# test case id: CEPH-9744
+# test case id: CEPH-9749
 config:
-    objects_count: 20
+    objects_count: 100
     container_count: 2
     objects_size_range:
         min: 5
@@ -9,4 +9,4 @@ config:
         create_container: true
         fill_container: true
         new_tenant: true
-        get_object_with_same_swift_tenant_user_under_diff_tenant: true
+        delete_container_with_same_swift_tenant_user_under_diff_tenant: true


### PR DESCRIPTION
…e name

[automate][t2]:CEPH-9749-Createcontainer with a tenant$user$subuser. Test if the user with the same name but belonging to a different tenant is able to delete the container. It should fail.

log: http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_delete_container_from_user_of_diff_tenant.console.log

does not effect existing tc execution:
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_swift_basic_ops.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_swift_large_upload.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_swift_version_copy_op.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_swift_versioning.console.log