### PR TITLE
Upload large object with same name using tenant swift user

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_upload_large_obj_with_same_obj_name.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_upload_large_obj_with_same_obj_name.yaml
@@ -1,0 +1,15 @@
+# test case id: CEPH-9814
+config:
+    objects_count: 1
+    container_count: 2
+    split_size: 100
+    objects_size_range:
+        min: 300M
+        max: 500M
+    test_ops:
+        create_container: true
+        upload_type: multipart
+        fill_container: true
+        new_tenant: true
+        upload_another_large_object_with_same_name_with_diff_tenants: true
+    local_file_delete: true


### PR DESCRIPTION
T2 automation-CEPH-9814-Upload another large object with the same name - with multi tenant

log: http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_upload_large_obj_with_same_name_container.console.log


does not effect existing execution: 
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_swift_large_download.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_swift_large_upload.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_get_objects_from_tenant_swift_user.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_delete_container_from_user_of_diff_tenant.console.log