### PR TITLE
testing bucket notifications for multisite replication events 

### DIFF
--- a/rgw/v2/lib/s3/auth.py
+++ b/rgw/v2/lib/s3/auth.py
@@ -31,10 +31,14 @@ class Auth(object):
             stdin, stdout, stderr = ssh_con.exec_command("hostname")
             self.hostname = stdout.readline().strip()
             self.port = utils.get_radosgw_port_no(ssh_con)
+            stdin, stdout, stderr = ssh_con.exec_command(
+                "hostname -I | awk '{print $1}'"
+            )
+            self.ip = stdout.readline().strip()
         else:
             self.hostname = socket.gethostname()
             self.port = utils.get_radosgw_port_no()
-        self.ip = socket.gethostbyname(self.hostname)
+            self.ip = socket.gethostbyname(self.hostname)
         self.ssl = extra_kwargs.get("ssl", False)
         self.haproxy = extra_kwargs.get("haproxy", False)
         if self.haproxy:

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_kafka_broker_ms_replication_from_pri.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_kafka_broker_ms_replication_from_pri.yaml
@@ -1,0 +1,21 @@
+config:
+ user_count: 1
+ bucket_count: 1
+ objects_count: 25
+ objects_size_range:
+  min: 5
+  max: 15
+ test_ops:
+  create_bucket: true
+  create_object: true
+  enable_version: false
+  create_topic: true
+  get_topic_info: true
+  endpoint: kafka
+  ack_type: broker
+  put_get_bucket_notification: true
+  event_type:
+    - MultisiteReplication
+  upload_type: normal
+  delete_bucket_object: false
+  sync_source_zone_master: True

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_kafka_broker_ms_replication_from_sec.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_kafka_broker_ms_replication_from_sec.yaml
@@ -1,0 +1,21 @@
+config:
+ user_count: 1
+ bucket_count: 1
+ objects_count: 25
+ objects_size_range:
+  min: 5
+  max: 15
+ test_ops:
+  create_bucket: true
+  create_object: true
+  enable_version: false
+  create_topic: true
+  get_topic_info: true
+  endpoint: kafka
+  ack_type: broker
+  put_get_bucket_notification: true
+  event_type:
+    - MultisiteReplication
+  upload_type: normal
+  delete_bucket_object: false
+  sync_source_zone_master: False

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_broker_copy.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_broker_copy.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_kafka_broker_copy.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_broker_delete.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_broker_delete.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_kafka_broker_delete.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_broker_ms_replication_from_pri.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_broker_ms_replication_from_pri.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_kafka_broker_ms_replication_from_pri.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_broker_ms_replication_from_sec.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_broker_ms_replication_from_sec.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_kafka_broker_ms_replication_from_sec.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_broker_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_broker_multipart.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_kafka_broker_multipart.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_broker_persistent_copy.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_broker_persistent_copy.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_kafka_broker_persistent_copy.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_broker_persistent_delete.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_broker_persistent_delete.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_kafka_broker_persistent_delete.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_broker_persistent_dynamic_reshard.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_broker_persistent_dynamic_reshard.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_kafka_broker_persistent_dynamic_reshard.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_broker_persistent_filter.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_broker_persistent_filter.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_kafka_broker_persistent_filter.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_broker_persistent_manual_reshard.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_broker_persistent_manual_reshard.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_kafka_broker_persistent_manual_reshard.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_broker_persistent_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_broker_persistent_multipart.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_kafka_broker_persistent_multipart.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_down_broker_persistent.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_down_broker_persistent.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_kafka_down_broker_persistent.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_down_broker_persistent_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_down_broker_persistent_multipart.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_kafka_down_broker_persistent_multipart.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_down_none_persistent.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_down_none_persistent.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_kafka_down_none_persistent.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_down_none_persistent_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_down_none_persistent_multipart.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_kafka_down_none_persistent_multipart.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_none_copy.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_none_copy.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_kafka_none_copy.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_none_delete.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_none_delete.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_kafka_none_delete.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_none_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_none_multipart.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_kafka_none_multipart.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_none_persistent_copy.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_none_persistent_copy.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_kafka_none_persistent_copy.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_none_persistent_delete.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_none_persistent_delete.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_kafka_none_persistent_delete.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_none_persistent_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_none_persistent_multipart.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_kafka_none_persistent_multipart.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_plaintext_plain_kafka_broker.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_plaintext_plain_kafka_broker.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_sasl_plaintext_plain_kafka_broker.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_plaintext_plain_kafka_broker_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_plaintext_plain_kafka_broker_multipart.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_sasl_plaintext_plain_kafka_broker_multipart.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_plaintext_plain_kafka_broker_persistent.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_plaintext_plain_kafka_broker_persistent.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_sasl_plaintext_plain_kafka_broker_persistent.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_plaintext_plain_kafka_broker_persistent_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_plaintext_plain_kafka_broker_persistent_multipart.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_sasl_plaintext_plain_kafka_broker_persistent_multipart.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_plaintext_plain_kafka_none.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_plaintext_plain_kafka_none.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_sasl_plaintext_plain_kafka_none.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_plaintext_plain_kafka_none_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_plaintext_plain_kafka_none_multipart.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_sasl_plaintext_plain_kafka_none_multipart.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_plaintext_plain_kafka_none_persistent.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_plaintext_plain_kafka_none_persistent.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_sasl_plaintext_plain_kafka_none_persistent.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_plaintext_plain_kafka_none_persistent_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_plaintext_plain_kafka_none_persistent_multipart.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_sasl_plaintext_plain_kafka_none_persistent_multipart.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_broker.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_broker.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_broker.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_broker_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_broker_multipart.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_broker_multipart.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_broker_persistent.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_broker_persistent.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_broker_persistent.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_broker_persistent_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_broker_persistent_multipart.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_broker_persistent_multipart.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_none.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_none.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_none.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_none_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_none_multipart.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_none_multipart.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_none_persistent.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_none_persistent.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_none_persistent.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_none_persistent_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_none_persistent_multipart.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_none_persistent_multipart.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_ssl_plain_kafka_broker.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_ssl_plain_kafka_broker.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_sasl_ssl_plain_kafka_broker.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_ssl_plain_kafka_broker_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_ssl_plain_kafka_broker_multipart.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_sasl_ssl_plain_kafka_broker_multipart.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_ssl_plain_kafka_broker_persistent.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_ssl_plain_kafka_broker_persistent.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_sasl_ssl_plain_kafka_broker_persistent.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_ssl_plain_kafka_broker_persistent_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_ssl_plain_kafka_broker_persistent_multipart.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_sasl_ssl_plain_kafka_broker_persistent_multipart.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_ssl_plain_kafka_none.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_ssl_plain_kafka_none.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_sasl_ssl_plain_kafka_none.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_ssl_plain_kafka_none_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_ssl_plain_kafka_none_multipart.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_sasl_ssl_plain_kafka_none_multipart.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_ssl_plain_kafka_none_persistent.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_ssl_plain_kafka_none_persistent.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_sasl_ssl_plain_kafka_none_persistent.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_ssl_plain_kafka_none_persistent_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_ssl_plain_kafka_none_persistent_multipart.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_sasl_ssl_plain_kafka_none_persistent_multipart.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_broker.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_broker.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_broker.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_broker_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_broker_multipart.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_broker_multipart.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_broker_persistent.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_broker_persistent.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_broker_persistent.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_broker_persistent_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_broker_persistent_multipart.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_broker_persistent_multipart.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_none.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_none.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_none.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_none_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_none_multipart.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_none_multipart.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_none_persistent.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_none_persistent.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_none_persistent.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_none_persistent_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_none_persistent_multipart.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_sasl_ssl_scram_sha_256_kafka_none_persistent_multipart.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_ssl_kafka_broker.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_ssl_kafka_broker.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_ssl_kafka_broker.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_ssl_kafka_broker_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_ssl_kafka_broker_multipart.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_ssl_kafka_broker_multipart.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_ssl_kafka_broker_persistent.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_ssl_kafka_broker_persistent.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_ssl_kafka_broker_persistent.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_ssl_kafka_broker_persistent_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_ssl_kafka_broker_persistent_multipart.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_ssl_kafka_broker_persistent_multipart.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_ssl_kafka_none.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_ssl_kafka_none.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_ssl_kafka_none.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_ssl_kafka_none_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_ssl_kafka_none_multipart.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_ssl_kafka_none_multipart.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_ssl_kafka_none_persistent.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_ssl_kafka_none_persistent.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_ssl_kafka_none_persistent.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_ssl_kafka_none_persistent_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_ssl_kafka_none_persistent_multipart.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_notification_ssl_kafka_none_persistent_multipart.yaml

--- a/rgw/v2/tests/s3_swift/reusables/bucket_notification.py
+++ b/rgw/v2/tests/s3_swift/reusables/bucket_notification.py
@@ -264,6 +264,8 @@ def verify_event_record(event_type, bucket, event_record_path, ceph_version):
             "ObjectLifecycle:Expiration:DeleteMarker",
             "ObjectLifecycle:Expiration:AbortMultipartUpload",
         ]
+    if "MultisiteReplication" in event_type:
+        events = ["ObjectSynced:Create"]
     log.info(f"verifying event record for event type {event_type}")
     log.info(f"valid event names are :{events}")
 


### PR DESCRIPTION
This PR is to test bucket notifications for Multisite Replication events
under "s3:ObjectSynced*" event type, currently only "s3:ObjectSynced:Create" works with ceph extension
refer [bz2053347](https://bugzilla.redhat.com/show_bug.cgi?id=2053347) for more details
polarion id: [CEPH-83575571](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83575571)

pass logs: http://magna002.ceph.redhat.com/ceph-qe-logs/HemanthSai/notif_ms_repication_PR/
(for failures regd ms replication events (of obj size 0 and bucket owner not in event record), raised new [bz2189308](https://bugzilla.redhat.com/show_bug.cgi?id=2189308)