### PR TITLE
Changes to use resource_op for object tagging

### DIFF
--- a/rgw/v2/lib/s3/write_io_info.py
+++ b/rgw/v2/lib/s3/write_io_info.py
@@ -466,7 +466,7 @@ def logioinfo(func):
 
         if "s3.Object" == type(obj).__name__:
             log.info("in s3.Object logging")
-            resource_names = ["upload_file", "initiate_multipart_upload"]
+            resource_names = ["upload_file", "initiate_multipart_upload", "put"]
             if resource_name in resource_names:
                 log.info(
                     "writing log for upload_type: %s"

--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -327,7 +327,29 @@ def upload_object_with_tagging(
     if data_info is False:
         TestExecError("data creation failed")
     log.info("uploading s3 object with object tagging enabled: %s" % s3_object_path)
-    bucket.put_object(Key=s3_object_name, Body=s3_object_path, Tagging=obj_tag)
+    upload_info = dict({"access_key": user_info["access_key"]}, **data_info)
+
+    s3_obj = s3lib.resource_op(
+        {
+            "obj": bucket,
+            "resource": "Object",
+            "args": [s3_object_name],
+        }
+    )
+    with open(s3_object_path, "rb") as fptr:
+        object_uploaded_status = s3lib.resource_op(
+            {
+                "obj": s3_obj,
+                "resource": "put",
+                "kwargs": dict(Body=fptr, Tagging=obj_tag),
+                "extra_info": upload_info,
+            }
+        )
+
+    if object_uploaded_status is False:
+        raise TestExecError("Resource execution failed: object upload failed")
+    if object_uploaded_status is None:
+        log.info("object uploaded")
 
 
 def upload_mutipart_object(

--- a/rgw/v2/tests/s3_swift/test_multisite_syncpolicy_prefix_tag.py
+++ b/rgw/v2/tests/s3_swift/test_multisite_syncpolicy_prefix_tag.py
@@ -62,7 +62,7 @@ def test_exec(config, ssh_con):
             bucket = reusable.create_bucket(bucket_name, rgw_conn, user)
             log.info(f"Bucket {bucket_name} created")
             prefix = "foo"
-            obj_tag = '{"TagSet":[{"Key":"colour", "Value":"red"}]}'
+            tag = "colour=red"
             # Create bucket sync policy
             group_id1 = "group-" + bucket_name
             reusable.group_operation(
@@ -75,7 +75,7 @@ def test_exec(config, ssh_con):
             if config.test_ops["has_prefix"]:
                 detail = f"{detail} --prefix={prefix}"
             if config.test_ops["has_tag"]:
-                detail = f"{detail} --tags-add={obj_tag}"
+                detail = f"{detail} --tags-add={tag}"
             log.info("Creating bucket policy with details")
             pipe_id = reusable.pipe_operation(
                 group_id1,
@@ -83,7 +83,7 @@ def test_exec(config, ssh_con):
                 bucket_name=bucket_name,
                 policy_detail=detail,
             )
-            time.sleep(60)
+            time.sleep(30)
 
             log.info(f"Creating objects on bucket: {bucket_name}")
             log.info("s3 objects to create: %s" % config.objects_count)
@@ -99,7 +99,6 @@ def test_exec(config, ssh_con):
                 log.info("s3 object path: %s" % s3_object_path)
 
                 if config.test_ops["has_tag"]:
-                    obj_tag = ""
                     log.info("upload type: tagged")
                     reusable.upload_object_with_tagging(
                         s3_object_name,
@@ -107,7 +106,7 @@ def test_exec(config, ssh_con):
                         TEST_DATA_PATH,
                         config,
                         user,
-                        obj_tag,
+                        tag,
                     )
                 else:
                     log.info("upload type: normal")


### PR DESCRIPTION
1. Changes in upload_object_with_tagging() to use resource_op , for files to be populated on upload.
2. There were few changes needed in test_syncpolicy_prefix_tag.py  on the tag format.

Pass log:
http://magna002.ceph.redhat.com/ceph-qe-logs/tejas/syncpolicy_prefix_tag_changes.txt