### PR TITLE
testing lc with conflicting rules

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_lc_rule_conflict_btw_exp_transition.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_rule_conflict_btw_exp_transition.yaml
@@ -1,0 +1,34 @@
+#test_bucket_lifecycle_object_expiration_transition.py
+#polarion-id: CEPH-11184
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 25
+  parallel_lc: False
+  test_lc_transition: True
+  pool_name: data.cold
+  storage_class: cold
+  ec_pool_transition: False
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    create_bucket: true
+    create_object: true
+    enable_versioning: false
+    version_count: 1
+    conflict_btw_exp_transition: True
+  lifecycle_conf:
+    - ID: rule1
+      Filter:
+          Prefix: key1
+      Status: Enabled
+      Transitions:
+        - Days: 20
+          StorageClass: cold
+    - ID: rule2
+      Filter:
+          Prefix: key1
+      Status: Enabled
+      Expiration:
+        Days: 20

--- a/rgw/v2/tests/s3_swift/configs/test_lc_rule_conflict_exp_days.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_rule_conflict_exp_days.yaml
@@ -1,0 +1,25 @@
+#test_bucket_lifecycle_object_expiration_transition.py
+#polarion-id: CEPH-11184
+config:
+  objects_count: 25
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    enable_versioning: false
+    create_object: true
+    version_count: 1
+    conflict_exp_days: true
+  lifecycle_conf:
+    - ID: rule1
+      Filter:
+          Prefix: key1
+      Status: Enabled
+      Expiration:
+        Days: 20
+    - ID: rule2
+      Filter:
+          Prefix: key1
+      Status: Enabled
+      Expiration:
+        Days: 40

--- a/rgw/v2/tests/s3_swift/configs/test_lc_rule_conflict_transition_actions.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_rule_conflict_transition_actions.yaml
@@ -1,0 +1,46 @@
+#test_bucket_lifecycle_object_expiration_transition.py
+#polarion-id: CEPH-11184
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 10
+  parallel_lc: False
+  test_lc_transition: True
+  pool_name: data.cold
+  storage_class: cold
+  ec_pool_transition: False
+  multiple_transitions: True
+  two_pool_transition: True
+  second_pool_name: data.glacier
+  second_storage_class: glacier
+  conflict_transition_actions: True
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    create_bucket: true
+    create_object: true
+    enable_versioning: true
+    version_count: 3
+    delete_marker: false
+  lifecycle_conf:
+    - ID: LC_Rule_1
+      Filter:
+        Prefix: key1
+      Status: Enabled
+      Transitions:
+        - Days: 4
+          StorageClass: cold
+      NoncurrentVersionTransitions:
+        - NoncurrentDays: 4
+          StorageClass: cold
+    - ID: LC_Rule_2
+      Filter:
+        Prefix: key1
+      Status: Enabled
+      Transitions:
+        - Days: 4
+          StorageClass: glacier
+      NoncurrentVersionTransitions:
+        - NoncurrentDays: 4
+          StorageClass: glacier

--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -579,6 +579,19 @@ def put_get_bucket_lifecycle_test(
                     raise TestExecError("Objects expired before the expected days")
             time.sleep(time_diff + 60)
 
+            if config.test_ops.get("conflict_exp_days"):
+                bucket_stats_op = utils.exec_shell_cmd(
+                    "radosgw-admin bucket stats --bucket=%s" % bucket.name
+                )
+                json_doc1 = json.loads(bucket_stats_op)
+                obj_post_lc = json_doc1["usage"]["rgw.main"]["num_objects"]
+                if obj_post_lc == objs_total:
+                    raise TestExecError(
+                        "S3 Lifecycle should choose the path that is least expensive. "
+                        + "But lc expiration is takin more time than least expiration days "
+                        + "when conflict between expiration days exist"
+                    )
+
     log.info("testing if lc is applied via the radosgw-admin cli")
     op = utils.exec_shell_cmd("radosgw-admin lc list")
     json_doc = json.loads(op)

--- a/rgw/v2/tests/s3_swift/test_bucket_lifecycle_object_expiration_transition.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_lifecycle_object_expiration_transition.py
@@ -11,6 +11,8 @@ where : <input-yaml> are test_lc_date.yaml, test_rgw_enable_lc_threads.yaml, tes
  test_lc_rule_prefix_non_current_days_notifications.yaml
  test_lc_rule_expiration_dynamic_reshard.yaml, test_lc_rule_expiration_manual_reshard.yaml,
  test_lc_rule_expiration_manual_reshard_verify_attr.yaml
+ test_lc_rule_conflict_btw_exp_transition.yaml, test_lc_rule_conflict_exp_days.yaml,
+ test_lc_rule_conflict_transition_actions.yaml
 
 Operation:
 


### PR DESCRIPTION
This PR is to automate testing of lifecycle with conflicting rules
The following scenarios are covered:

- conflicting rules having same prefix but different exp days: the rule with least exp days takes effect
- conflict between expiration and transition for the same prefix and same days: expiration action takes effect
- conflicting rules having same prefix, same days but different transition storage class: in this case, storage class in the rule which is the last one among the conflicting rules in the list is taken effect

polarion id: [CEPH-11184](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-11184)

pass logs:
http://magna002.ceph.redhat.com/ceph-qe-logs/HemanthSai/lc_conflict_rules_PR/