### PR TITLE
Fix dynamic resharding issue in suite tier-1_rgw_ssl_multisite_test-…

### DIFF
--- a/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_dynamic_resharding_brownfield.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_dynamic_resharding_brownfield.yaml
@@ -1,3 +1,5 @@
+# script: test_Mbuckets_with_Nobjects.py
+# Polarian id: CEPH-83574736
 config:
   user_count: 1
   bucket_count: 1

--- a/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
+++ b/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
@@ -272,7 +272,9 @@ def test_exec(config, ssh_con):
                             )
                             json_doc = json.loads(op)
                             old_num_shards = json_doc["num_shards"]
-                            config.objects_count = old_num_shards + 10
+                            config.objects_count = (
+                                old_num_shards * config.max_objects_per_shard + 5
+                            )
                             config.mapped_sizes = utils.make_mapped_sizes(config)
 
                     for oc, size in list(config.mapped_sizes.items()):


### PR DESCRIPTION
…upgrade-5-to-latest

upgrade from 16.2.10-160.el8cp(5.3 z2(released)) to latest 5.3 build

Issue log: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-t5ytf/Create_bucket_for_Testing_dynamic_resharding_brownfield_scenario_after_upgrade_0.log

Issue : even though dynamic reshading is enabled, in bucket stats stats we can still observe num_shards as 11
            rgw_max_objs_per_shard set to 5, objects uploaded was 21(num_shards + 10)

log:
run1 :http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_multisite_dynamic_resharding_brownfield_0.console.log      num_shards = 97

run2: http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_multisite_dynamic_resharding_brownfield_1.console.log      num_shards = 787

run3: http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_multisite_dynamic_resharding_brownfield_1.console.log      num_shards = 1999


