### PR TITLE
Fix corner case related to issue RHCEPHQE-8808

### DIFF
--- a/rgw/v2/tests/s3_swift/test_manual_lc_process_single_bucket.py
+++ b/rgw/v2/tests/s3_swift/test_manual_lc_process_single_bucket.py
@@ -95,10 +95,10 @@ def test_exec(config, ssh_con):
         completed_bucket = 0
         completed_bkt_name = ""
         for data in lc_list_op_after:
-            if data["status"] == "COMPLETE":
+            if data["status"] == "COMPLETE" and buckets[0] in data["bucket"]:
                 completed_bucket += 1
                 completed_bkt_name = data["bucket"]
-
+        log.info(f"Manual LC process completed bucket is {completed_bkt_name}")
         bucket_details = json.loads(
             utils.exec_shell_cmd(f"radosgw-admin bucket stats --bucket={buckets[0]}")
         )


### PR DESCRIPTION
Fix the corner case observed in issue: https://issues.redhat.com/browse/RHCEPHQE-8808
when cluster has multiple buckets for which lc is in completed state and some other bucket(other than one for which manual LC process is done) is at the top of the lc list, need to filter out only that bucket for which manual LC process is performed.

Log: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/RHCEPHQE-8808/