### PR TITLE
Fix nonetype objects while performing manual resharding

### DIFF
--- a/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
+++ b/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
@@ -272,9 +272,10 @@ def test_exec(config, ssh_con):
                             )
                             json_doc = json.loads(op)
                             old_num_shards = json_doc["num_shards"]
-                            config.objects_count = (
-                                old_num_shards * config.max_objects_per_shard + 5
-                            )
+                            if config.dynamic_resharding is True:
+                                config.objects_count = (
+                                    old_num_shards * config.max_objects_per_shard + 5
+                                )
                             config.mapped_sizes = utils.make_mapped_sizes(config)
 
                     for oc, size in list(config.mapped_sizes.items()):


### PR DESCRIPTION
 Log:
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_multisite_dynamic_resharding_brownfield_0.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_multisite_dynamic_resharding_brownfield_1.console.log

http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_multisite_manual_resharding_brownfield_0.console.log
https://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/test_multisite_manual_resharding_brownfield_1.console.log