### PR TITLE
[Inditex]bug-1937618, retain bucket policies at archive site

### DIFF
--- a/rgw/v2/lib/resource_op.py
+++ b/rgw/v2/lib/resource_op.py
@@ -344,6 +344,7 @@ class Config(object):
             "testlc_with_obect_acl_set", False
         )
         self.test_sync_0_shards = self.doc["config"].get("test_sync_0_shards", False)
+        self.retain_bucket_pol = self.doc["config"].get("retain_bucket_pol", False)
         self.frontend = self.doc["config"].get("frontend")
         self.io_op_config = self.doc.get("config").get("io_op_config")
         self.radoslist_all = self.test_ops.get("radoslist_all", False)

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_bucket_pol_retain.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_bucket_pol_retain.yaml
@@ -1,0 +1,24 @@
+# upload type: non multipart
+# script: test_Mbuckets_with_Nobjects.py
+# bug 1937618: Bucket policies disappears in archive zone when an object is inserted in master zone bucket
+# CEPH-83575576
+config:
+  haproxy: true
+  retain_bucket_pol: true
+  user_count: 1
+  bucket_count: 2
+  objects_count: 40
+  objects_size_range:
+    min: 5K
+    max: 5M
+  test_ops:
+    create_bucket: true
+    create_object: true
+    download_object: false
+    delete_bucket_object: false
+    sharding:
+      enable: false
+      max_shards: 0
+    compression:
+      enable: false
+      type: zlib

--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -85,6 +85,19 @@ def set_get_object_acl(
         raise TestExecError("put object acl failed")
 
 
+def retain_bucket_policy(rgw_conn2, bucket_name_to_create, config):
+    """
+    put bucket policy and retain it at archive site
+    """
+    log.info(f"Set bucket policy on {bucket_name_to_create}")
+    put_bucket_pol = rgw_conn2.put_bucket_policy(
+        Bucket=bucket_name_to_create,
+        Policy='{"Version": "2012-10-17", "Statement": [{ "Sid": "id-1","Effect": "Allow","Principal": {"AWS": "arn:aws:iam::123456789012:root"}, "Action": [ "s3:PutObject","s3:PutObjectAcl"], "Resource": ["arn:aws:s3:::acl3/*" ] } ]}',
+    )
+    if not put_bucket_pol:
+        raise TestExecError("put bucket pol failed")
+
+
 def upload_object(
     s3_object_name,
     bucket,

--- a/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
+++ b/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
@@ -100,6 +100,7 @@ def test_exec(config, ssh_con):
             rgw_conn = auth.do_auth(**{"signature_version": "s3v4"})
         else:
             rgw_conn = auth.do_auth()
+        rgw_conn2 = auth.do_auth_using_client()
         # Test multisite sync with 0 shards bugs 2188022, 2180549 Hot Fix for Square eCommerce
         if config.test_sync_0_shards:
             reusable.sync_test_0_shards(config)
@@ -239,6 +240,14 @@ def test_exec(config, ssh_con):
                     if config.user_type == "tenanted"
                     else bucket.name
                 )
+                if config.retain_bucket_pol:
+                    log.info(
+                        "Test bucket policy retained at archive site after writing IOs bug-1937618"
+                    )
+                    reusable.retain_bucket_policy(
+                        rgw_conn2, bucket_name_to_create, config
+                    )
+
                 if config.dynamic_resharding is True:
                     if config.test_ops.get("enable_version", False):
                         log.info("Enable bucket versioning")


### PR DESCRIPTION
Automate bug-1937618, Retain bucket policies at the archive site

Bucket policies disappears in archive zone when an object is inserted in master zone bucket

https://bugzilla.redhat.com/show_bug.cgi?id=1937618

https://polarion.engineering.redhat.com/polarion/#/project/https://polarion.engineering.redhat.com/polarion/redirect/project/CEPH/workitem?id=CEPH-83575576

logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-D764QV