### PR TITLE
testing the buckets are accessible if the num_objects quota exceeds on a dynamically resharded bucket

### DIFF
--- a/rgw/v2/tests/s3_swift/multisite_configs/test_dynamic_resharding_quota_exceed.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_dynamic_resharding_quota_exceed.yaml
@@ -1,0 +1,13 @@
+# script: test_dynamic_bucket_resharding.py
+# polarion id: CEPH-83574669
+config:
+  objects_count: 50
+  objects_size_range:
+    min: 15
+    max: 20
+  sharding_type: dynamic
+  max_objects_per_shard: 5
+  rgw_reshard_thread_interval: 60
+  test_ops:
+    exceed_quota_access_bucket_sec: true
+    delete_bucket_object: true


### PR DESCRIPTION
This PR covers the following scenario:

- enable dynamic resharing with max_obj_per_shard set to 5
- set bucket quota max objects(config.object_count *2) and enable quota on the bucket
- upload config.object_count  objects to see QuotaExceeded error
- verify bucket is resharded
- upload config.object_count objects again and wait until dynamic reshard triggers
- verify on secondary site: bucket stats, list and metadata executes fine and bucket is accessible

polarion id:[CEPH-83574669](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574669)

pass log: http://magna002.ceph.redhat.com/ceph-qe-logs/HemanthSai/quota_dynamic_reshrding/cephci-run-B5QCPC/

updated pass log after adding code for testing multiple reshards:
http://magna002.ceph.redhat.com/ceph-qe-logs/HemanthSai/quota_dynamic_reshrding/test_dynamic_resharding_quota_exceed.console.log