### PR TITLE
TFA: LC expiration and  test sync with 0 shards.

### DIFF
--- a/rgw/v2/tests/s3_swift/multisite_configs/test_lc_rule_prefix_non_current_days_haproxy.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_lc_rule_prefix_non_current_days_haproxy.yaml
@@ -1,0 +1,19 @@
+# script: test_bucket_lifecycle_object_expiration_transition.py
+config:
+  haproxy: true
+  objects_count: 100
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    enable_versioning: true
+    create_object: true
+    version_count: 3
+    delete_marker: false
+  lifecycle_conf:
+    - ID: LC_Rule_2
+      Filter:
+        Prefix: key1
+      Status: Enabled
+      NoncurrentVersionExpiration:
+        NoncurrentDays: 20

--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -98,6 +98,16 @@ def retain_bucket_policy(rgw_conn2, bucket_name_to_create, config):
         raise TestExecError("put bucket pol failed")
 
 
+def sync_test_0_shards(config):
+    """
+    This function sets the bucket_index_max_shards to 0 at the zonegroup
+    """
+    log.info("Test multisite replication with 0 shards")
+    utils.exec_shell_cmd(f"radosgw-admin zonegroup modify --bucket_index_max_shards 0")
+    utils.exec_shell_cmd(f"radosgw-admin period update --commit")
+    utils.exec_shell_cmd(f"radosgw-admin period get")
+
+
 def upload_object(
     s3_object_name,
     bucket,


### PR DESCRIPTION
TFA ticket : https://issues.redhat.com/browse/RHCEPHQE-9364

Adding the sync_test_0_shards() that was removed from reusable.py
logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-YZTTFM/test_sync_on_bucket_with_0_shards_0.log

Also adding the config file for LC expiration to test from primary to secondary.

logs for http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-XT4MC1/test_LC_from_primary_to_secondary_0.log