### PR TITLE
close-loop-bug-2137596: Test bucket versioning is never suspended at archive site

### DIFF
--- a/rgw/v2/lib/resource_op.py
+++ b/rgw/v2/lib/resource_op.py
@@ -347,6 +347,9 @@ class Config(object):
             "testlc_with_obect_acl_set", False
         )
         self.test_sync_0_shards = self.doc["config"].get("test_sync_0_shards", False)
+        self.test_versioning_archive = self.doc["config"].get(
+            "test_versioning_archive", False
+        )
         self.retain_bucket_pol = self.doc["config"].get("retain_bucket_pol", False)
         self.frontend = self.doc["config"].get("frontend")
         self.io_op_config = self.doc.get("config").get("io_op_config")

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_versioning_objects_suspend_archive_haproxy.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_versioning_objects_suspend_archive_haproxy.yaml
@@ -1,0 +1,20 @@
+# upload type: non multipart
+# script: test_versioning_with_objects.py
+# polarian CEPH-83575578
+# bugzilla: 2137596
+config:
+     haproxy: true
+     test_versioning_archive: true
+     user_count: 1
+     bucket_count: 2
+     objects_count: 3
+     version_count: 2
+     objects_size_range:
+          min: 5
+          max: 15
+     test_ops:
+          enable_version: true
+          suspend_version: true
+          copy_to_version: false
+          delete_object_versions: false
+          upload_after_suspend: false


### PR DESCRIPTION
close-loop : Automate bug-2137596 at archive site

https://polarion.engineering.redhat.com/polarion/#/project/https://polarion.engineering.redhat.com/polarion/redirect/project/CEPH/workitem?id=CEPH-83575578

https://bugzilla.redhat.com/show_bug.cgi?id=2137596

log: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-7HFZ5Y

