### PR TITLE
Fix bucket generation workflow

### DIFF
--- a/rgw/v2/tests/s3_swift/test_dynamic_bucket_resharding.py
+++ b/rgw/v2/tests/s3_swift/test_dynamic_bucket_resharding.py
@@ -153,26 +153,18 @@ def test_exec(config, ssh_con):
             log.info("checking for any sync error")
             utils.exec_shell_cmd("sudo radosgw-admin sync error list")
             raise AssertionError("sync status is in failed or errored state!")
-        if "behind" in bkt_sync_status:
-            log.info(
-                f"sync is in progress!, perform resharding of an bucket {bucket.name}"
-            )
-            bkt_stat_cmd = f"radosgw-admin bucket stats --bucket {bucket.name}"
-            old_shard_value = json.loads(utils.exec_shell_cmd(bkt_stat_cmd))[
-                "num_shards"
-            ]
-            manual_shard_no = old_shard_value + 5
-            cmd_exec = utils.exec_shell_cmd(
-                f"radosgw-admin bucket reshard --bucket={bucket.name} "
-                f"--num-shards={manual_shard_no}"
-            )
-            if not cmd_exec:
-                raise TestExecError("manual resharding command execution failed")
-            new_shard_value = json.loads(utils.exec_shell_cmd(bkt_stat_cmd))[
-                "num_shards"
-            ]
-            if new_shard_value == manual_shard_no:
-                log.info("manual reshard succeeded!")
+        bkt_stat_cmd = f"radosgw-admin bucket stats --bucket {bucket.name}"
+        old_shard_value = json.loads(utils.exec_shell_cmd(bkt_stat_cmd))["num_shards"]
+        manual_shard_no = old_shard_value + 5
+        cmd_exec = utils.exec_shell_cmd(
+            f"radosgw-admin bucket reshard --bucket={bucket.name} "
+            f"--num-shards={manual_shard_no}"
+        )
+        if not cmd_exec:
+            raise TestExecError("manual resharding command execution failed")
+        new_shard_value = json.loads(utils.exec_shell_cmd(bkt_stat_cmd))["num_shards"]
+        if new_shard_value == manual_shard_no:
+            log.info("manual reshard succeeded!")
         bucket_gen_after = reusable.fetch_bucket_gen(bucket.name)
         log.info(f"Latest generation of a bucket {bucket.name} is :{bucket_gen_after}")
         if bucket_gen_after > bucket_gen_before:


### PR DESCRIPTION
Changing the workflow:
going ahead with resharding of bucket and verifying bucket gen has changed irrespective of sync status.
once reshard completes and bucket gen verified we are verifying sync is caught up between the sites!

initially we were looking into sync status if sync is behind then only we were going ahead with re-sharding and verifying bucket gen which is not necessary, sync status is not necessary for bucket gen.

fail-log: http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/RHCEPH-5.3-RHEL-8-20230627.0/Weekly/rgw/3/tier-2_rgw_ms-dbr-disable/

pass log: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/bucket-gen-fix/ 