### PR TITLE
Import lc multipart object expiration config from single site to multisite

### DIFF
--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_lc_object_exp_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_lc_object_exp_multipart.yaml
@@ -1,0 +1,1 @@
+../configs/test_bucket_lc_object_exp_multipart.yaml


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCEPHQE-10041

 Suite: tier-1-extn_rgw_multisite-secondary-to-primary

Test Cases: RGW multipart object expiration through lc on Secondary

2023-07-09 15:57:10,558 (cephci.sanity_rgw_multisite) [DEBUG] - cephci.Regression.rgw.5.cephci.ceph.ceph.py:1523 - b' File "/home/cephuser/rgw-ms-tests/ceph-qe-scripts/rgw/v2/tests/s3_swift/test_bucket_lc_object_exp_multipart.py", line 215, in <module>' 2023-07-09 15:57:10,558 (cephci.sanity_rgw_multisite) [DEBUG] - cephci.Regression.rgw.5.cephci.ceph.ceph.py:1523 - b' config = Config(yaml_file)' 2023-07-09 15:57:10,559 (cephci.sanity_rgw_multisite) [DEBUG] - cephci.Regression.rgw.5.cephci.ceph.ceph.py:1523 - b' File "/home/cephuser/rgw-ms-tests/ceph-qe-scripts/rgw/v2/lib/resource_op.py", line 219, in _init_' 2023-07-09 15:57:10,559 (cephci.sanity_rgw_multisite) [DEBUG] - cephci.Regression.rgw.5.cephci.ceph.ceph.py:1523 - b' raise ConfigError("config file not given")' 2023-07-09 15:57:10,560 (cephci.sanity_rgw_multisite) [DEBUG] - cephci.Regression.rgw.5.cephci.ceph.ceph.py:1523 - b'v2.lib.exceptions.ConfigError: config file not give