### PR TITLE
Fix json decoder failure

### DIFF
--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -1837,7 +1837,8 @@ def test_bucket_stats_across_sites(bucket_name_to_create):
             f"collect bucket stats for {bucket_name_to_create} at remote site {zone_name}"
         )
         stdin, stdout, stderr = remote_site_ssh_con.exec_command(cmd_bucket_stats)
-        stats_remote = json.loads(stdout.read().decode())
+        cmd_output = stdout.read().decode()
+        stats_remote = json.loads(cmd_output)
         log.info(
             f"bucket stats at remote site {zone_name} for {bucket_name_to_create} is {stats_remote}"
         )


### PR DESCRIPTION
Fix json decoder failure
With old approach: 
stats_remote = json.loads(stdout.read().decode())
Fail log: 
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-NGK3QT/test_sync_on_bucket_with_0_shards_0.log


With New approach:
 cmd_output = stdout.read().decode()
 stats_remote = json.loads(cmd_output)
 Pass log:
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-XFTUGC/test_sync_on_bucket_with_0_shards_0.log