### PR TITLE
Fix s3cmd issue of UTF-8 ASCII

### DIFF
--- a/rgw/v2/tests/s3cmd/test_header_size.py
+++ b/rgw/v2/tests/s3cmd/test_header_size.py
@@ -65,7 +65,7 @@ def test_exec(config, ssh_con):
             bucket_name = utils.gen_bucket_name_from_userid(user_name, rand_no=bc)
             s3cmd_reusable.create_bucket(bucket_name)
             log.info(f"Bucket {bucket_name} created")
-            utils.exec_shell_cmd(f"fallocate -l 2m obj25m")
+            utils.exec_shell_cmd(f"fallocate -l 25m obj25m")
             header = "".join(
                 random.choices(ascii_uppercase + digits + ascii_lowercase, k=8192)
             )

--- a/rgw/v2/utils/utils.py
+++ b/rgw/v2/utils/utils.py
@@ -62,10 +62,12 @@ def exec_shell_cmd(cmd, debug_info=False):
             cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            universal_newlines=True,
+            universal_newlines=False,
             shell=True,
         )
         out, err = pr.communicate()
+        out = out.decode("utf-8", errors="ignore")
+        err = err.decode("utf-8", errors="ignore")
         if pr.returncode == 0:
             log.info("cmd excuted")
             if out is not None:


### PR DESCRIPTION
Fix s3cmd issue of UTF-8 ASCII in command
log: 
1: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-r2510
2: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-zb6mb
