### PR TITLE
testing sts assume role with web identity using keycloak server

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_sts_aswi.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_aswi.yaml
@@ -1,0 +1,31 @@
+# polarion test case id: CEPH-83575817
+# test scripts : test_sts_aswi.py
+config:
+     bucket_count: 2
+     objects_count: 50
+     objects_size_range:
+          min: 5
+          max: 15
+     test_ops:
+          create_bucket: true
+          create_object: true
+     sts:
+          policy_document:
+                "Version": "2012-10-17"
+                "Statement": [
+                    {
+                         "Effect": "Allow",
+                         "Principal": {
+                           "Federated": ["arn:aws:iam:::oidc-provider/ip_addr:8180/realms/master"]
+                         },
+                         "Action": ["sts:AssumeRoleWithWebIdentity"],
+                    }
+                ]
+          role_policy:
+               "Version": "2012-10-17"
+               "Statement":
+                    {
+                         "Effect": "Allow",
+                         "Action": "s3:*",
+                         "Resource": "arn:aws:s3:::*",
+                    }

--- a/rgw/v2/tests/s3_swift/configs/test_sts_aswi_azp_claim.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_aswi_azp_claim.yaml
@@ -1,0 +1,37 @@
+# polarion test case id: CEPH-83574501
+# test scripts : test_sts_aswi.py
+# azp - Authorized party - the party to which the ID Token was issued
+config:
+     bucket_count: 2
+     objects_count: 50
+     objects_size_range:
+          min: 5
+          max: 15
+     test_ops:
+          create_bucket: true
+          create_object: true
+     sts:
+          policy_document:
+                "Version": "2012-10-17"
+                "Statement": [
+                    {
+                         "Effect": "Allow",
+                         "Principal": {
+                           "Federated": ["arn:aws:iam:::oidc-provider/ip_addr:8180/realms/master"]
+                         },
+                         "Action": ["sts:AssumeRoleWithWebIdentity"],
+                         "Condition": {
+                           "StringEquals": {
+                             "ip_addr:8180/realms/master:azp": "azp_claim"
+                           }
+                         }
+                    }
+                ]
+          role_policy:
+               "Version": "2012-10-17"
+               "Statement":
+                    {
+                         "Effect": "Allow",
+                         "Action": "s3:*",
+                         "Resource": "arn:aws:s3:::*",
+                    }

--- a/rgw/v2/tests/s3_swift/configs/test_sts_aswi_sub_claim.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_aswi_sub_claim.yaml
@@ -1,0 +1,37 @@
+# polarion test case id: CEPH-83574500
+# test scripts : test_sts_aswi.py
+# sub - subject claim is a string that identifies the principal that is the subject of the JWT
+config:
+     bucket_count: 2
+     objects_count: 50
+     objects_size_range:
+          min: 5
+          max: 15
+     test_ops:
+          create_bucket: true
+          create_object: true
+     sts:
+          policy_document:
+                "Version": "2012-10-17"
+                "Statement": [
+                    {
+                         "Effect": "Allow",
+                         "Principal": {
+                           "Federated": ["arn:aws:iam:::oidc-provider/ip_addr:8180/realms/master"]
+                         },
+                         "Action": ["sts:AssumeRoleWithWebIdentity"],
+                         "Condition": {
+                           "StringEquals": {
+                             "ip_addr:8180/realms/master:sub": "sub_claim"
+                           }
+                         }
+                    }
+                ]
+          role_policy:
+               "Version": "2012-10-17"
+               "Statement":
+                    {
+                         "Effect": "Allow",
+                         "Action": "s3:*",
+                         "Resource": "arn:aws:s3:::*",
+                    }

--- a/rgw/v2/tests/s3_swift/test_sts_aswi.py
+++ b/rgw/v2/tests/s3_swift/test_sts_aswi.py
@@ -1,0 +1,323 @@
+"""
+test_sts_aswi.py - Test STS Assume role with web identity
+
+Usage: test_sts_aswi.py -c <input_yaml>
+<input_yaml>
+    test_sts_aswi.yaml
+    test_sts_aswi_azp_claim.yaml
+    test_sts_aswi_sub_claim.yaml
+
+Operation:
+    s1: Create 2 Users.
+        user1 will be the owner and will give permisison to create bucket to user2
+    s2: keycloak deployment and administration
+    s3: create openid connect provider
+    s4: add caps to user1 for create role and oidc-provider - use radosgw-admin
+    s5: create iam_client object using user1 credentials
+    s6: gen a policy_doc added with user2 uid added in it.
+    s7: create role
+    s8: put role
+    s9: get sts client object
+    s10: assume role with web identity, this will return credentials and token
+    s11: with above credentials create s3 object and start the io
+        create bucket
+        upload object
+
+
+"""
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(__file__, "../../../..")))
+import argparse
+import json
+import logging
+import random
+import time
+import traceback
+
+import boto3
+import v2.lib.resource_op as s3lib
+import v2.utils.utils as utils
+from botocore.exceptions import ClientError
+from v2.lib.exceptions import RGWBaseException, TestExecError
+from v2.lib.resource_op import Config
+from v2.lib.rgw_config_opts import CephConfOp, ConfigOpts
+from v2.lib.s3.auth import Auth
+from v2.lib.s3.write_io_info import AddUserInfo, BasicIOInfoStructure, IOInfoInitialize
+from v2.tests.s3_swift import reusable
+from v2.tests.s3_swift.reusables.sts import Keycloak
+from v2.utils.log import configure_logging
+from v2.utils.test_desc import AddTestInfo
+from v2.utils.utils import RGWService
+
+log = logging.getLogger()
+TEST_DATA_PATH = None
+
+
+def test_exec(config, ssh_con):
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+    ceph_config_set = CephConfOp(ssh_con)
+    rgw_service = RGWService()
+    local_ip_addr = utils.get_localhost_ip_address()
+    keycloak = Keycloak(
+        client_id="sts_client", client_secret="client_secret1", ip_addr=local_ip_addr
+    )
+
+    if config.sts is None:
+        raise TestExecError("sts policies are missing in yaml config")
+
+    # create users
+    config.user_count = 2
+    users_info = s3lib.create_users(config.user_count)
+    # user1 is the owner
+    user1, user2 = users_info[0], users_info[1]
+    log.info("adding sts config to ceph.conf")
+    sesison_encryption_token = "abcdefghijklmnoq"
+    ceph_config_set.set_to_ceph_conf(
+        "global", ConfigOpts.rgw_sts_key, sesison_encryption_token, ssh_con
+    )
+    ceph_config_set.set_to_ceph_conf(
+        "global", ConfigOpts.rgw_s3_auth_use_sts, "True", ssh_con
+    )
+    srv_restarted = rgw_service.restart(ssh_con)
+    time.sleep(30)
+    if srv_restarted is False:
+        raise TestExecError("RGW service restart failed")
+    else:
+        log.info("RGW service restarted")
+
+    auth = Auth(user1, ssh_con, ssl=config.ssl)
+    iam_client = auth.do_auth_iam_client()
+    user1_client = auth.do_auth_using_client()
+
+    auth2 = Auth(user2, ssh_con, ssl=config.ssl)
+    iam_client2 = auth2.do_auth_iam_client()
+    sts_client = auth2.do_auth_sts_client()
+    log.info(f"sts client: {sts_client}")
+
+    web_token = keycloak.get_web_acccess_token()
+    log.info(f"web token: {web_token}")
+    jwt = keycloak.introspect_token(web_token)
+    policy_document = json.dumps(config.sts["policy_document"]).replace(" ", "")
+    policy_document = policy_document.replace("ip_addr", local_ip_addr)
+    policy_document = policy_document.replace("azp_claim", jwt["azp"])
+    policy_document = policy_document.replace("sub_claim", jwt["sub"])
+    log.info(policy_document)
+
+    role_policy = json.dumps(config.sts["role_policy"]).replace(" ", "")
+
+    add_caps_cmd = (
+        'sudo radosgw-admin caps add --uid="{user_id}" --caps="roles=*"'.format(
+            user_id=user1["user_id"]
+        )
+    )
+    utils.exec_shell_cmd(add_caps_cmd)
+
+    add_caps_cmd = (
+        'radosgw-admin caps add --uid="{user_id}" --caps="oidc-provider=*"'.format(
+            user_id=user1["user_id"]
+        )
+    )
+    utils.exec_shell_cmd(add_caps_cmd)
+
+    add_caps_cmd = (
+        'sudo radosgw-admin caps add --uid="{user_id}" --caps="roles=*"'.format(
+            user_id=user2["user_id"]
+        )
+    )
+    utils.exec_shell_cmd(add_caps_cmd)
+
+    add_caps_cmd = (
+        'radosgw-admin caps add --uid="{user_id}" --caps="oidc-provider=*"'.format(
+            user_id=user2["user_id"]
+        )
+    )
+    utils.exec_shell_cmd(add_caps_cmd)
+
+    keycloak.delete_open_id_connect_provider(iam_client)
+    keycloak.create_open_id_connect_provider(iam_client)
+    keycloak.list_open_id_connect_provider(iam_client)
+
+    role_name = f"S3RoleOf.{user1['user_id']}"
+    log.info(f"role_name: {role_name}")
+    tags_list = [{"Key": "project", "Value": "ceph"}]
+    log.info("creating role")
+    if config.test_ops.get("create_role_tagging"):
+        create_role_response = iam_client.create_role(
+            AssumeRolePolicyDocument=policy_document,
+            Path="/",
+            RoleName=role_name,
+            Tags=tags_list,
+        )
+    else:
+        create_role_response = iam_client.create_role(
+            AssumeRolePolicyDocument=policy_document, Path="/", RoleName=role_name
+        )
+    log.info(f"create_role_response: {create_role_response}")
+
+    if config.test_ops.get("iam_resource_tag"):
+        print("Adding tags to role\n")
+        response = iam_client.tag_role(RoleName=role_name, Tags=tags_list)
+        log.info("tag_role_response")
+        log.info(response)
+
+    policy_name = f"policy.{user1['user_id']}"
+    log.info(f"policy_name: {policy_name}")
+
+    log.info("putting role policy")
+    put_policy_response = iam_client.put_role_policy(
+        RoleName=role_name, PolicyName=policy_name, PolicyDocument=role_policy
+    )
+    log.info("put_policy_response")
+    log.info(put_policy_response)
+
+    web_token = keycloak.get_web_acccess_token()
+    log.info(f"web token: {web_token}")
+    keycloak.introspect_token(web_token)
+    assume_role_response = sts_client.assume_role_with_web_identity(
+        RoleArn=create_role_response["Role"]["Arn"],
+        RoleSessionName=user1["user_id"],
+        DurationSeconds=3600,
+        WebIdentityToken=web_token,
+    )
+    log.info(f"assume role with web identity response: {assume_role_response}")
+
+    assumed_role_user_info = {
+        "access_key": assume_role_response["Credentials"]["AccessKeyId"],
+        "secret_key": assume_role_response["Credentials"]["SecretAccessKey"],
+        "session_token": assume_role_response["Credentials"]["SessionToken"],
+        "user_id": user2["user_id"],
+    }
+    s3_auth = Auth(assumed_role_user_info, ssh_con, ssl=config.ssl)
+    s3_client_rgw = s3_auth.do_auth()
+
+    io_info_initialize.initialize(basic_io_structure.initial())
+    write_user_info = AddUserInfo()
+    basic_io_structure = BasicIOInfoStructure()
+    user_info = basic_io_structure.user(
+        **{
+            "user_id": assumed_role_user_info["user_id"],
+            "access_key": assumed_role_user_info["access_key"],
+            "secret_key": assumed_role_user_info["secret_key"],
+        }
+    )
+    write_user_info.add_user_info(user_info)
+
+    if config.test_ops["create_bucket"]:
+        log.info(f"Number of buckets to create {config.bucket_count}")
+        for bc in range(config.bucket_count):
+            bucket_name_to_create = utils.gen_bucket_name_from_userid(
+                assumed_role_user_info["user_id"], rand_no=bc
+            )
+            log.info("creating bucket with name: %s" % bucket_name_to_create)
+            bucket = reusable.create_bucket(
+                bucket_name_to_create, s3_client_rgw, assumed_role_user_info
+            )
+            if config.test_ops.get("bucket_tagging"):
+                response = user1_client.put_bucket_tagging(
+                    Bucket=bucket_name_to_create,
+                    Tagging={
+                        "TagSet": [
+                            {
+                                "Key": "project",
+                                "Value": "ceph",
+                            }
+                        ],
+                    },
+                )
+                log.info(f"put bucket tagging response: {response}")
+            if config.test_ops["create_object"]:
+                # uploading data
+                log.info("s3 objects to create: %s" % config.objects_count)
+                for oc, size in list(config.mapped_sizes.items()):
+                    config.obj_size = size
+                    s3_object_name = utils.gen_s3_object_name(bucket_name_to_create, oc)
+                    log.info("s3 object name: %s" % s3_object_name)
+                    s3_object_path = os.path.join(TEST_DATA_PATH, s3_object_name)
+                    log.info("s3 object path: %s" % s3_object_path)
+                    if config.test_ops.get("upload_type") == "multipart":
+                        log.info("upload type: multipart")
+                        reusable.upload_mutipart_object(
+                            s3_object_name,
+                            bucket,
+                            TEST_DATA_PATH,
+                            config,
+                            assumed_role_user_info,
+                        )
+                    else:
+                        log.info("upload type: normal")
+                        if config.test_ops.get("object_tagging"):
+                            tags = "project=ceph"
+                            reusable.upload_object_with_tagging(
+                                s3_object_name,
+                                bucket,
+                                TEST_DATA_PATH,
+                                config,
+                                assumed_role_user_info,
+                                tags,
+                            )
+                        else:
+                            reusable.upload_object(
+                                s3_object_name,
+                                bucket,
+                                TEST_DATA_PATH,
+                                config,
+                                assumed_role_user_info,
+                            )
+
+    # check for any crashes during the execution
+    crash_info = reusable.check_for_crash()
+    if crash_info:
+        raise TestExecError("ceph daemon crash found!")
+
+
+if __name__ == "__main__":
+    test_info = AddTestInfo(
+        "Starting STS test for assume-role with web identity operation"
+    )
+    test_info.started_info()
+
+    try:
+        project_dir = os.path.abspath(os.path.join(__file__, "../../.."))
+        test_data_dir = "test_data"
+        TEST_DATA_PATH = os.path.join(project_dir, test_data_dir)
+        log.info("TEST_DATA_PATH: %s" % TEST_DATA_PATH)
+        if not os.path.exists(TEST_DATA_PATH):
+            log.info("test data dir not exists, creating.. ")
+            os.makedirs(TEST_DATA_PATH)
+        parser = argparse.ArgumentParser(description="RGW S3 STS aswi automation")
+        parser.add_argument("-c", dest="config", help="RGW Test yaml configuration")
+        parser.add_argument(
+            "-log_level",
+            dest="log_level",
+            help="Set Log Level [DEBUG, INFO, WARNING, ERROR, CRITICAL]",
+            default="info",
+        )
+        parser.add_argument(
+            "--rgw-node", dest="rgw_node", help="RGW Node", default="127.0.0.1"
+        )
+        args = parser.parse_args()
+        yaml_file = args.config
+        rgw_node = args.rgw_node
+        ssh_con = None
+        if rgw_node != "127.0.0.1":
+            ssh_con = utils.connect_remote(rgw_node)
+        log_f_name = os.path.basename(os.path.splitext(yaml_file)[0])
+        configure_logging(f_name=log_f_name, set_level=args.log_level.upper())
+        config = Config(yaml_file)
+        config.read(ssh_con)
+        if config.mapped_sizes is None:
+            config.mapped_sizes = utils.make_mapped_sizes(config)
+
+        test_exec(config, ssh_con)
+        test_info.success_status("test passed")
+        sys.exit(0)
+
+    except (RGWBaseException, Exception) as e:
+        log.error(e)
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        sys.exit(1)

--- a/rgw/v2/utils/utils.py
+++ b/rgw/v2/utils/utils.py
@@ -841,3 +841,12 @@ def get_rgw_ip_zone(zone_name):
             rgw_endpoint_url = zone["endpoints"][0]
             parse_result = urlparse(rgw_endpoint_url)
             return parse_result.hostname
+
+
+def get_localhost_ip_address():
+    """
+    returns the public ip address of local host
+    """
+    out = exec_shell_cmd("ip -o -f inet addr show | awk '/scope global/ {print $4}'")
+    ip_addr = out.strip().split("/")[0]
+    return ip_addr


### PR DESCRIPTION
adding code for keycloak deployment and administration and testing assume role with web identity
in this PR, added basic aswi config, azp and sub claim testing configs
seeing issue while testing aud claim, aswi call failed, will investigate more into it.
there is an issue with aswi call with keycloak certificates. added a workaround of updating encryption realm key with less priority and 1024 key size. refer https://tracker.ceph.com/issues/54562
will take up session tags testing automation and other improvisations in the next PR
polarion testcases:

- https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83575817
- https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574501
- https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574500

pass logs for pacific and quincy:
http://magna002.ceph.redhat.com/ceph-qe-logs/HemanthSai/sts_aswi/