### PR TITLE
rgw_override_bucket_index_max_shards takes string value

### DIFF
--- a/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
+++ b/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
@@ -836,7 +836,7 @@ def test_exec(config, ssh_con):
 
     if config.test_ops["sharding"]["enable"] is True:
         ceph_conf.set_to_ceph_conf(
-            "global", ConfigOpts.rgw_override_bucket_index_max_shards, 0, ssh_con
+            "global", ConfigOpts.rgw_override_bucket_index_max_shards, str(0), ssh_con
         )
         srv_restarted = rgw_service.restart(ssh_con)
 


### PR DESCRIPTION
rgw_override_bucket_index_max_shards takes string value not integer

issue: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-9gte9/test_sharding_enabled_pre_upgrade_0.log

log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-u6clr/test_sharding_enabled_pre_upgrade_0.log

