### PR TITLE
[T2-Automation]: CEPH-83575816 - Radosgw bucket list should not be tr…

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_bucket_list_not_truncated.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_list_not_truncated.yaml
@@ -1,0 +1,14 @@
+#script - test_bucket_listing.py
+# Polarion ID : CEPH-83575816
+config:
+   user_count: 1
+   bucket_count: 1200
+   objects_count: 1
+   objects_size_range:
+        min: 4
+        max: 5
+   test_ops:
+        create_bucket: true
+        modify_user: true
+        list_bucket_with_uid: true
+        user_remove: true

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_list_not_truncated.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_list_not_truncated.yaml
@@ -1,0 +1,14 @@
+#script - test_bucket_listing.py
+# Polarion ID : CEPH-83575816
+config:
+   user_count: 1
+   bucket_count: 1200
+   objects_count: 1
+   objects_size_range:
+        min: 4
+        max: 5
+   test_ops:
+        create_bucket: true
+        modify_user: true
+        list_bucket_with_uid: true
+        user_remove: true


### PR DESCRIPTION
…uncated to 1000 entries

CEPH-83575816 - Radosgw bucket list should not be truncated to 1000 entries
Modify user with max_bucket quota set to 5000
and create 5000 buckets for a user.

Ensure with default value rgw_list_buckets_max_chunk:1000, all the 5000 buckets are listing via radosgw-admin bucket list

Pass log: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/CEPH-83575816/test_bucket_list.console.log

other old config logs:
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/CEPH-83575816/
failure not related to current changes