### PR TITLE
decreasing number of multipart objects to be updated in vm cluster

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_bucket_lc_object_exp_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_lc_object_exp_multipart.yaml
@@ -2,7 +2,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 1000
+  objects_count: 100
   rgw_lc_debug_interval: 1
   objects_size_range:
     min: 16M


### PR DESCRIPTION
As multipart objects taking longer time to upload : http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/18.2.0-6/Weekly/rgw/4/tier-2_rgw_singlesite_to_multisite/RGW_multipart_object_expiration_through_lc_on_Secondary_0.log

decreasing number of objects to be uploaded for vm cluster, while testing in bare metal we will include, larger number objects to be uploaded..