### PR TITLE
small change in capitalization in the event type ObjectLifecycle:Expiration:Noncurrent

### DIFF
--- a/rgw/v2/tests/s3_swift/reusables/bucket_notification.py
+++ b/rgw/v2/tests/s3_swift/reusables/bucket_notification.py
@@ -260,7 +260,7 @@ def verify_event_record(event_type, bucket, event_record_path, ceph_version):
     if "LifecycleExpiration" in event_type:
         events = [
             "ObjectLifecycle:Expiration:Current",
-            "ObjectLifecycle:Expiration:NonCurrent",
+            "ObjectLifecycle:Expiration:Noncurrent",
             "ObjectLifecycle:Expiration:DeleteMarker",
             "ObjectLifecycle:Expiration:AbortMultipartUpload",
         ]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2187982 is closed as not a bug. dev decided to have the event type capitalization based on aws doc i.e., ObjectLifecycle:Expiration:Noncurrent