### PR TITLE
[TFA] link single site config file to multisite config

### DIFF
--- a/rgw/v2/tests/s3_swift/multisite_configs/test_sse_kms_per_object.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_sse_kms_per_object.yaml
@@ -1,0 +1,1 @@
+../configs/test_sse_kms_per_object.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_sse_s3_per_bucket_encryption_multipart_object_upload.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_sse_s3_per_bucket_encryption_multipart_object_upload.yaml
@@ -1,0 +1,1 @@
+../configs/test_sse_s3_per_bucket_encryption_multipart_object_upload.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_sse_s3_per_object.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_sse_s3_per_object.yaml
@@ -1,0 +1,1 @@
+../configs/test_sse_s3_per_object.yaml


### PR DESCRIPTION
Bellow tsetcases failed to config file not found in multisite, adding file to Multisiteconfig

http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/18.2.0-95/Weekly/rgw/11/tier-2_rgw_ms_async_data_notification/sse-s3_per_object_encryption_test_0.log

http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/18.2.0-95/Weekly/rgw/11/tier-2_rgw_ms_async_data_notification/sse_s3_per_bucket_enc_multipart_upload_0.log

http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/18.2.0-95/Weekly/rgw/11/tier-2_rgw_ms_async_data_notification/test_sse_kms_per_object_0.log