### PR TITLE
[Fix TFA] Symmetrical run has pipe creation as directional, so updated pipe as symmetrical only

### DIFF
--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -1714,7 +1714,7 @@ def pipe_operation(
     pipe_id = group_id + "pipe"
     if zone_names is not None:
         zone_name = zone_names.split(",")
-        zn = f" --source-zones={zone_name[0]} --dest-zones={zone_name[1]}"
+        zn = f" --source-zones='{zone_name[0]}','{zone_name[1]}' --dest-zones='{zone_name[0]}','{zone_name[1]}'"
     else:
         zn = " --source-zones='*' --dest-zones='*'"
     if bucket_name is not None:


### PR DESCRIPTION
Since pipe creation as directional for Symmetrical flow, sync to secondary zone was disable.  So observed sync stuck or in progress issue

failed logs: 
http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/18.2.0-95/Weekly/rgw/11/sanity_rgw_multisite/Bucket_Granular_Sync_policy_tests_0.log
http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/18.2.0-95/Weekly/rgw/11/sanity_rgw_multisite/user_operations_using_REST_0.log
http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/18.2.0-95/Weekly/rgw/11/tier-2_rgw_ms_granular_sync_policy/Bucket_Granular_Sync_policy_tests_0.log