### PR TITLE
[CEPH-83575880]Automation of user modify with --placement-id

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_user_modify_with_placementid.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_user_modify_with_placementid.yaml
@@ -1,0 +1,9 @@
+# script: user_create.py
+# Polarian: CEPH-83575880
+config:
+    user_count: 1
+    user_type: non-tenanted
+    test_ops:
+        create_bucket: false
+        swift_user: false
+        user_modify_with_placementid: true

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_user_modify_with_placementid.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_user_modify_with_placementid.yaml
@@ -1,0 +1,9 @@
+# script: user_create.py
+# Polarian: CEPH-83575880
+config:
+    user_count: 1
+    user_type: non-tenanted
+    test_ops:
+        create_bucket: false
+        swift_user: false
+        user_modify_with_placementid: true

--- a/rgw/v2/tests/s3_swift/user_create.py
+++ b/rgw/v2/tests/s3_swift/user_create.py
@@ -81,6 +81,13 @@ def test_exec(config, ssh_con):
                         test_info.success_status(
                             f"Tenanted Swift user modification completed for {user_name}:swift"
                         )
+        for user in all_users_info:
+            if config.test_ops.get("user_modify_with_placementid", False):
+                cmd = f'radosgw-admin user modify --uid={user["user_id"]} --placement-id "test"'
+                out = utils.exec_shell_cmd(cmd, return_err=True)
+                log.info(f"user modify with placement id out put is {out}")
+                if "*** Caught signal (Aborted) **" in out:
+                    raise AssertionError("user modify with placementid caused crash!!")
 
         test_info.success_status("test passed")
         sys.exit(0)

--- a/rgw/v2/utils/utils.py
+++ b/rgw/v2/utils/utils.py
@@ -55,7 +55,7 @@ def exec_long_running_shell_cmd(cmd):
         return False
 
 
-def exec_shell_cmd(cmd, debug_info=False):
+def exec_shell_cmd(cmd, debug_info=False, return_err=False):
     try:
         log.info("executing cmd: %s" % cmd)
         pr = subprocess.Popen(
@@ -78,6 +78,8 @@ def exec_shell_cmd(cmd, debug_info=False):
                 else:
                     return out
         else:
+            if return_err == True:
+                return err
             raise Exception("error: %s \nreturncode: %s" % (err, pr.returncode))
     except Exception as e:
         log.error("cmd execution failed")


### PR DESCRIPTION
[CEPH-83575880]Automation of user modify with --placement-id

radosgw-admin user modify --uid <uid> --placement-id <placement_id> should not cause any crash
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2228157

Logs: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/ceph83575880/


Pass-log for existing script where exec_shell_command method in use:
https://github.com/red-hat-storage/ceph-qe-scripts/blob/master/rgw/v2/tests/s3_swift/test_bucket_listing.py#L85
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/ceph83575880/test_bucket_list_not_truncated.console.log


https://github.com/red-hat-storage/ceph-qe-scripts/blob/master/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py#L611
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/ceph83575880/test_datalog_trim_command.console.log