### PR TITLE
Fix TFA issue of "TypeError: the JSON object must be str, bytes or bytearray, not bool"

### DIFF
--- a/rgw/v2/tests/aws/reusable.py
+++ b/rgw/v2/tests/aws/reusable.py
@@ -40,10 +40,8 @@ def create_bucket(bucket_name, end_point, ssl=None):
     )
     try:
         create_response = utils.exec_shell_cmd(command)
-        if create_response:
-            raise Exception(
-                f"Create bucket failed for {bucket_name} with {create_response}"
-            )
+        if not create_response:
+            raise Exception(f"Create bucket failed for {bucket_name}")
     except Exception as e:
         raise AWSCommandExecError(message=str(e))
 
@@ -68,8 +66,10 @@ def list_object_versions(bucket_name, end_point, ssl=None):
         params=[f"--bucket {bucket_name} --endpoint-url {end_point}", ssl_param]
     )
     try:
-        create_response = utils.exec_shell_cmd(command)
-        return create_response
+        list_response = utils.exec_shell_cmd(command)
+        if not list_response:
+            raise Exception(f"List object versions on bucket failed for {bucket_name}")
+        return list_response
     except Exception as e:
         raise AWSCommandExecError(message=str(e))
 
@@ -99,6 +99,9 @@ def put_object(bucket_name, object_name, end_point, ssl=None):
     )
     try:
         create_response = utils.exec_shell_cmd(command)
+        log.info(create_response)
+        if not create_response:
+            raise Exception(f"Create object failed for {bucket_name}")
         return create_response
     except Exception as e:
         raise AWSCommandExecError(message=str(e))
@@ -138,8 +141,10 @@ def delete_object(bucket_name, object_name, end_point, ssl=None, versionid=None)
             ]
         )
     try:
-        create_response = utils.exec_shell_cmd(command)
-        return create_response
+        delete_response = utils.exec_shell_cmd(command)
+        if not delete_response:
+            raise Exception(f"delete object failed for {bucket_name}")
+        return delete_response
     except Exception as e:
         raise AWSCommandExecError(message=str(e))
 
@@ -166,10 +171,8 @@ def put_get_bucket_versioning(bucket_name, end_point, status="Enabled", ssl=None
     )
     try:
         put_response = utils.exec_shell_cmd(put_cmd)
-        if put_response:
-            raise Exception(
-                f"Version Enabling failed for {bucket_name} with {put_response}"
-            )
+        if not put_response:
+            raise Exception(f"Version Enabling failed for {bucket_name}")
         get_method = AWS(operation="get-bucket-versioning")
         get_cmd = get_method.command(
             params=[f"--bucket {bucket_name} --endpoint-url {end_point}", ssl_param]

--- a/rgw/v2/tests/s3_swift/test_bucket_listing.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_listing.py
@@ -9,7 +9,8 @@ Usage: test_bucket_listing.py -c <input_yaml>
 	test_bucket_listing_flat_ordered_benchmark.yaml
 	test_bucket_listing_pseudo_ordered_benchmark.yaml
 	test_bucket_listing_psuedo_only_ordered.yaml
-	test_bucket_listing_pseudo_ordered.yaml		
+	test_bucket_listing_pseudo_ordered.yaml	
+    test_bucket_listing_pseudo_ordered_dir_only.yaml	
 Operation:
     Create user 
 	create objects as per the object structure mentioned in the yaml
@@ -231,10 +232,14 @@ def test_exec(config, ssh_con):
                         max_aio = max_aio_output.rstrip("\n")
 
                     # bucket stats to get the num_objects of the bucket
+                    time.sleep(30)
                     bucket_stats = utils.exec_shell_cmd(
                         "radosgw-admin bucket stats --bucket  %s"
                         % bucket_name_to_create
                     )
+                    if not bucket_stats:
+                        raise TestExecError("Bucket stats command execution failed")
+
                     bucket_stats_json = json.loads(bucket_stats)
                     bkt_num_objects = bucket_stats_json["usage"]["rgw.main"][
                         "num_objects"


### PR DESCRIPTION
Error "TypeError: the JSON object must be str, bytes or bytearray, not bool" occurs due to the failures in exec_commnd execution failure

log: 
http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/test_bucket_listing_flat_ordered.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/test_bucket_listing_pseudo_ordered_dir_only.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/test_delete_version_id_null.console.log

issue seen in existing logs have ticket
https://issues.redhat.com/browse/RHCEPHQE-11284
https://issues.redhat.com/browse/RHCEPHQE-11984

