### PR TITLE
[TC:CEPH-83575469]:deleting lifecycle rule should not throw any error

### DIFF
--- a/rgw/v2/lib/resource_op.py
+++ b/rgw/v2/lib/resource_op.py
@@ -285,6 +285,7 @@ class Config(object):
         self.container_count = self.doc["config"].get("container_count")
         self.version_count = self.doc["config"].get("version_count")
         self.version_enable = self.doc["config"].get("version_enable", False)
+        self.deletelc = self.doc["config"].get("deletelc", False)
         self.disable_dynamic_shard = self.doc["config"].get(
             "disable_dynamic_shard", False
         )

--- a/rgw/v2/tests/s3cmd/configs/test_deletelifecycle.yaml
+++ b/rgw/v2/tests/s3cmd/configs/test_deletelifecycle.yaml
@@ -1,0 +1,14 @@
+#Polarian:CEPH-83575469
+#BZ: 2183223
+#Script: test_s3cmd.py
+
+config:
+  deletelc: true
+  objects_size_range:
+  lifecycle_conf:
+    - ID: LC_Rule_1
+      Filter:
+        Prefix: single-obj
+      Status: Enabled
+      Expiration:
+        Days: 1


### PR DESCRIPTION
[TC:CEPH-83575469]:deleting lifecycle rule should not throw any error
s3cmd dellifecycle s3://<bucket> should success without any error.

Log: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/PR-511/pass-log