### PR TITLE
CEPH-83575917: Test archive site on/off on an upload of 5K objects

### DIFF
--- a/rgw/v2/lib/resource_op.py
+++ b/rgw/v2/lib/resource_op.py
@@ -414,6 +414,9 @@ class Config(object):
         self.put_empty_bucket_notification = self.test_ops.get(
             "put_empty_bucket_notification", False
         )
+        self.full_sync_test = self.doc["config"].get("full_sync_test", False)
+        self.remote_zone = self.doc["config"].get("remote_zone")
+        self.local_zone = self.doc["config"].get("local_zone")
         self.bucket_max_read_ops = self.doc["config"].get("bucket_max_read_ops")
         self.bucket_max_read_bytes = self.doc["config"].get("bucket_max_read_bytes")
         self.bucket_max_write_ops = self.doc["config"].get("bucket_max_write_ops")

--- a/rgw/v2/tests/s3cmd/multisite_configs/test_s3cmd.yaml
+++ b/rgw/v2/tests/s3cmd/multisite_configs/test_s3cmd.yaml
@@ -1,0 +1,11 @@
+# test case id: CEPH-83575917
+config:
+  haproxy: true
+  full_sync_test: true
+  remote_zone: archive
+  local_zone: primary
+  container_count: 1
+  objects_count: 5000
+  objects_size_range:
+    min: 5
+    max: 15


### PR DESCRIPTION
Automate a full sync of an RGW bucket to the archive zone having at least 5000 objects.

- https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83575917
- https://issues.redhat.com/browse/RHCEPHQE-12010
- dependent cephci PR is https://github.com/red-hat-storage/cephci/pull/3158

logs: 
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-UOTHQW

latest passed logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-OL8YPW
