### PR TITLE
[Tier-2]CEPH-11204-BucketNotification with users in same tenant and diff tenant

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_put_get_bucket_notification_with_tenant_same_and_different_user.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_put_get_bucket_notification_with_tenant_same_and_different_user.yaml
@@ -1,0 +1,25 @@
+# Ploarion ID : CEPH-11204 - BucketNotification with users in same tenant and diff tenant
+# script: test_bucket_policy_with_tenant_user.py
+# BZ : https://bugzilla.redhat.com/show_bug.cgi?id=2180415
+config:
+    user_count: 2
+    bucket_count: 2
+    objects_count: 100
+    user_type: tenanted
+    objects_size_range:
+        min: 5
+        max: 15
+    test_ops:
+        create_bucket: true
+        create_object: true
+        enable_version: false
+        create_topic: true
+        get_topic_info: true
+        endpoint: kafka
+        ack_type: broker
+        new_tenant_user: true
+        users_count: 3
+        put_get_bucket_notification: true
+        event_type: Copy
+        upload_type: normal
+        copy_object: true

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_put_get_bucket_notification_with_tenant_same_and_different_user.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_put_get_bucket_notification_with_tenant_same_and_different_user.yaml
@@ -1,0 +1,1 @@
+../configs/test_put_get_bucket_notification_with_tenant_same_and_different_user.yaml


### PR DESCRIPTION
This user story is to automate - CEPH-11204-BucketNotification with users in same tenant

Using policy s3:PutBucketNotification and s3:GetBucketNotification  users under same and different tenants,should be able put and get notifications.User boto3 module to configure.

log: http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/test_put_get_bucket_notification_with_tenant_same_and_different_user.console.log

Automation of BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2180415