### PR TITLE
[TFA]Fix failure seen in create bucket with aws

### DIFF
--- a/rgw/v2/tests/aws/reusable.py
+++ b/rgw/v2/tests/aws/reusable.py
@@ -40,7 +40,8 @@ def create_bucket(bucket_name, end_point, ssl=None):
     )
     try:
         create_response = utils.exec_shell_cmd(command)
-        if not create_response:
+        log.info(f"bucket creation response is {create_response}")
+        if create_response:
             raise Exception(f"Create bucket failed for {bucket_name}")
     except Exception as e:
         raise AWSCommandExecError(message=str(e))
@@ -171,7 +172,8 @@ def put_get_bucket_versioning(bucket_name, end_point, status="Enabled", ssl=None
     )
     try:
         put_response = utils.exec_shell_cmd(put_cmd)
-        if not put_response:
+        log.info(f"response of put versioning:{put_response}")
+        if put_response:
             raise Exception(f"Version Enabling failed for {bucket_name}")
         get_method = AWS(operation="get-bucket-versioning")
         get_cmd = get_method.command(


### PR DESCRIPTION
Failure logs:
http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/17.2.6-161/Regression/rgw/19/tier-2_rgw_test_5-3_specific_fixes/

Failure was due to below reason:
With aws while creating bucket and while enabling versioning on a bucket we do not get any response back when the operation is successfully completed.
Hence script was failing at the condition check:
"create_response = utils.exec_shell_cmd(command)
        if not create_response:
            raise Exception(f"Create bucket failed for {bucket_name}")"
            
 Hence changing the condition check to resolve this issue.

Pass logs:
[test_s3copyObj_admin_user]: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/aws-tfa/test_s3copyObj_admin_user
[test_sts_rename_large_object]: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/aws-tfa/test_sts_rename_large_object
[test_delete_version_id_null]: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/aws-tfa/test_delete_version_id_null
(Failure: known BZ:1967576)