### PR TITLE
[Close-loop-automation] Granualr sync policy : BZ2132554

### DIFF
--- a/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_sync_policy_extended.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_sync_policy_extended.yaml
@@ -1,0 +1,25 @@
+# Polarian TC : CEPH-83575138
+# script: test_multisite_sync_policy.py
+# bug 2132554
+config:
+    user_count: 1
+    bucket_count: 1
+    objects_count: 25
+    objects_size_range:
+        min: 5K
+        max: 2M
+    multisite_global_sync_policy: true
+    multisite_sync_policy: true
+    test_ops:
+        create_bucket: true
+        create_object: true
+        group_create: true
+        group_remove: true
+        flow_create: true
+        flow_remove: true
+        pipe_create: true
+        pipe_remove: true
+        group_status: enabled  # Enable , Allowed, Forbidden
+        bucket_group_status: enabled
+        flow_type: symmetrical # symmetrical , directional
+        new_bucket_and_group_state_change: true


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2132554

testing with symmetrical flow
1. zonegroup level allowed and bucket level enabled
2. zonegroup level enabled and bucket level allowed

log: 
http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/test_multisite_sync_policy_extended.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/test_multisite_syncpolicy_prefix_tag.console.log