### PR TITLE
[T2-Automation]: CEPH-11195:Set lifecycle rule to abort incomplete mu…

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_bucket_lc_incomplete_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_lc_incomplete_multipart.yaml
@@ -1,0 +1,24 @@
+# script: ceph-qe-scripts/rgw/v2/tests/s3_swift/test_bucket_lifecycle_config_ops.py
+# Polarian-ID: CEPH-11195
+
+config:
+  user_count: 1
+  bucket_count: 2
+  objects_count: 5
+  abort_multipart: true
+  objects_size_range:
+    min: 10M
+    max: 20M
+  test_ops:
+    create_bucket: true
+    create_object: true
+    enable_versioning: false
+    version_count: 0
+    upload_type: multipart
+    rgw_lc_debug: true
+  lifecycle_conf:
+    - ID: LC_Rule_1
+      Status: Enabled
+      Prefix: ""
+      AbortIncompleteMultipartUpload:
+        DaysAfterInitiation: 1

--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -2038,3 +2038,32 @@ def test_object_download_at_replicated_site(
             raise TestExecError(
                 "md5sum signature mismatch, detected corruption on download"
             )
+
+
+def validate_incomplete_multipart(bucket_name, rgw_conn):
+    """
+    Validating incomplete multipart objects in a bucket
+    returns True if incomplete multipart found otherwise returns False
+
+    Parameters:
+    bucket_name(str): Name of the bucket
+
+    Returns:
+        True: If incomplete multipart found
+        False: If incomplete multipart not found
+    """
+    incomplete_multipart = False
+    bkt_stat_output = json.loads(
+        utils.exec_shell_cmd(f"radosgw-admin bucket stats --bucket {bucket_name}")
+    )
+    if bkt_stat_output["usage"]["rgw.multimeta"]["num_objects"] != 0:
+        log.info(f"Incomplete multipart found!")
+        incomplete_multipart = True
+
+    multipart_objects = rgw_conn.list_multipart_uploads(Bucket=bucket_name)
+    log.info(f"multipart objects {multipart_objects}")
+    if "Uploads" in multipart_objects.keys():
+        log.info(f"Incomplete multipart found!")
+        incomplete_multipart = True
+
+    return incomplete_multipart


### PR DESCRIPTION
…ltipart uploads

[T2-Automation]: CEPH-11195:Set lifecycle rule to abort incomplete multipart uploads
1. Added support for validation of incomplete multipart
2. Added automation support for LC expiration rule for aborted multipart upload

Pass log: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/CEPH-11195/test_bucket_lc_incomplete_multipart.log

Pass log for existing config which uses currently updated script:
test_bucket_lc_disable_object_exp:
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/CEPH-11195/test_bucket_lc_disable_object_exp.log
