### PR TITLE
Test lifecycle with multiple rules where ruid is same but rule config is different

### DIFF
--- a/rgw/v2/tests/s3_swift/multisite_configs/test_lc_multiple_rule_with_diff_config_for_same_ruleid.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_lc_multiple_rule_with_diff_config_for_same_ruleid.yaml
@@ -1,0 +1,27 @@
+# script: test_bucket_lifecycle_object_expiration_transition.py
+# polarion ID: CEPH-11183
+config:
+  user_count: 1
+  bucket_count: 2
+  objects_count: 100
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    enable_versioning: false
+    create_object: true
+    create_bucket: true
+    lc_config_with_diff_rules: true
+  lifecycle_conf:
+    - ID: LC_Rule_1
+      Filter:
+        Prefix: key1
+      Status: Enabled
+      Expiration:
+        Days: 1
+    - ID: LC_Rule_1
+      Filter:
+        Prefix: key2
+      Status: Enabled
+      Expiration:
+        Date: "2023-02-19"

--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -633,7 +633,12 @@ def put_get_bucket_lifecycle_test(
             raise TestExecError("bucket lifecycle config retrieval failed")
     else:
         raise TestExecError("bucket life cycle retrieved")
-    objs_total = (config.test_ops["version_count"]) * (config.objects_count)
+    version_count = (
+        config.test_ops["version_count"]
+        if config.test_ops.get("version_count", False)
+        else 1
+    )
+    objs_total = (version_count) * (config.objects_count)
     if not upload_start_time:
         upload_start_time = time.time()
     if not upload_end_time:


### PR DESCRIPTION
Test lifecycle with multiple rules where ruid is same but rule config is different : lc should fail

log: http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/test_lc_multiple_rule_with_diff_config_for_same_ruleid.console.log