### PR TITLE
[TFA-Fix]: Fix the issue of name error 'true' not found with timeinit…

### DIFF
--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -1140,6 +1140,18 @@ def check_for_crash():
         return ceph_crash
 
 
+def time_taken_to_execute_command(cmd):
+    """
+    Time taken to list via radosgw-admin command.
+    :param cmd: cmd
+    """
+    output = json.loads(utils.exec_shell_cmd(cmd))
+    for op in output:
+        op.update({"exists": str(op["exists"])})
+        op["meta"].update({"appendable": str(op["meta"]["appendable"])})
+    return str(output)
+
+
 def time_to_list_via_radosgw(bucket_name, listing):
     """
     Time taken to list via radosgw-admin command.
@@ -1151,7 +1163,9 @@ def time_to_list_via_radosgw(bucket_name, listing):
         cmd = "radosgw-admin bucket list --max-entries=100000 --bucket=%s " % (
             bucket_name
         )
-        time_taken = timeit.timeit(utils.exec_shell_cmd(cmd), globals=globals())
+        time_taken = timeit.timeit(
+            stmt=time_taken_to_execute_command(cmd), globals=globals()
+        )
         return time_taken
 
     if listing == "unordered":
@@ -1162,7 +1176,9 @@ def time_to_list_via_radosgw(bucket_name, listing):
             "radosgw-admin bucket list --max-entries=100000 --bucket=%s --allow-unordered"
             % (bucket_name)
         )
-        time_taken = timeit.timeit(utils.exec_shell_cmd(cmd), globals=globals())
+        time_taken = timeit.timeit(
+            stmt=time_taken_to_execute_command(cmd), globals=globals()
+        )
         return time_taken
 
 


### PR DESCRIPTION
… module

**Problem statement:** 
Listing test cases were failing with timeit module with bellow error:
"File "/usr/lib64/python3.9/timeit.py", line 177, in timeit'
timing = self.inner(it, self.timer)'
File "<timeit-src>", line 15, in inner'
b"NameError: name 'true' is not defined""
Fail log: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-EQ5UC5/listing_flat_unordered_buckets_on_secondary_0.log

**Debug findings:**
Problem with timeit is because of format of the output we are recieving,

In older version i.e for example: pacific:
Output for the command: radosgw-admin bucket list --max-entries=100000 --bucket=kevine.640-bucky-2548-0 --allow-unordered' was containing double quotes for the values(true, false)
"exists": "true",
"appendable": "false"

But with ceph-7.0:
out put doesnot contain quotes,
"exists": true,
"appendable": false
This is the reason we are getting error: NameError: name 'true' is not defined

**Pass logs:**
**Verifying changes with pacific cluster:**
[root@ceph-rgw5-3-2y1xyi-node5 ~]# ceph --version
ceph version 16.2.10-94.el9cp (48ce8ed67474ea50f10c019b9445be7f49749d23) pacific (stable)
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/name_error/pacific.log
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/name_error/pacific2.log


**Verifying changes with quincy cluster:**
(dec13-venv) [root@ceph-ck-7x-e1mf6o-node5 s3_swift]# ceph --version
ceph version 17.2.6-167.el9cp (5ef1496ea3e9daaa9788809a172bd5a1c3192cf7) quincy (stable)
Pass log: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/name_error/quincy.log


**Verifying changes with reef cluster:**
[cephuser@ceph-ck-6xnew-k6tq17-node6 ~]$ ceph --version
ceph version 18.2.0-128.el9cp (d38df712b9120eae50f448fe0847719d3567c2d1) reef (stable)
bucket_listing_flat_unordered: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/name_error/reef.log
bucket_listing_flat_ordered: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/name_error/reef2.log