### PR TITLE
Increase sleep time post rgw service restart

### DIFF
--- a/rgw/v2/tests/s3cmd/test_ratelimit_global.py
+++ b/rgw/v2/tests/s3cmd/test_ratelimit_global.py
@@ -95,7 +95,7 @@ def test_exec(config, ssh_con):
 
     log.info("Restarting for global rate limit to take effect")
     restart_service = rgw_service.restart(ssh_con)
-    sleep(5)
+    sleep(60)
     if restart_service is False:
         raise TestExecError("RGW service restart failed")
     limget = utils.exec_shell_cmd(
@@ -138,7 +138,7 @@ def test_exec(config, ssh_con):
 
     log.info("Restarting for global rate limit to take effect")
     restart_service = rgw_service.restart(ssh_con)
-    sleep(5)
+    sleep(60)
     if restart_service is False:
         raise TestExecError("RGW service restart failed")
 
@@ -166,7 +166,7 @@ def test_exec(config, ssh_con):
         f"radosgw-admin global ratelimit disable --ratelimit-scope=user"
     )
     restart_service = rgw_service.restart(ssh_con)
-    sleep(5)
+    sleep(60)
     if restart_service is False:
         raise TestExecError("RGW service restart failed")
 


### PR DESCRIPTION
Increase sleep time post rgw service restart,
since we have observed ERROR: Could not connect to server: [Errno 111] Connection refused occasionally.

log: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-JCP57M/