### PR TITLE
[Granular] bucket sync policy combination of zonegroup and bucket level policy

### DIFF
--- a/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucketsync_allowed_forbidden.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucketsync_allowed_forbidden.yaml
@@ -1,0 +1,28 @@
+# Polarian TC : CEPH-83575137
+# script: test_multisite_bucket_granular_sync_policy.py
+config:
+    user_count: 1
+    bucket_count: 2
+    objects_count: 100
+    objects_size_range:
+        min: 5K
+        max: 2M
+    test_ops:
+        zonegroup_group: true
+        zonegroup_status: allowed
+        zonegroup_flow: true
+        zonegroup_flow_type: directional
+        zonegroup_source_zone: primary
+        zonegroup_dest_zone: secondary
+        zonegroup_source_zones: primary
+        zonegroup_dest_zones: secondary
+        zonegroup_pipe: true
+        bucket_group: true
+        bucket_status: forbidden
+        bucket_flow: false
+        bucket_pipe: true
+        bucket_source_zones: primary
+        bucket_dest_zones: secondary
+        create_object: true
+        create_bucket: true
+        zonegroup_group_remove: true

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucketsync_enable_enable.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucketsync_enable_enable.yaml
@@ -1,0 +1,29 @@
+# Polarian TC : CEPH-83575137
+# script: test_multisite_bucket_granular_sync_policy.py
+config:
+    user_count: 1
+    bucket_count: 2
+    objects_count: 100
+    objects_size_range:
+        min: 5K
+        max: 2M
+    test_ops:
+        zonegroup_group: true
+        zonegroup_status: enable
+        zonegroup_flow: true
+        zonegroup_flow_type: directional
+        zonegroup_source_zone: primary
+        zonegroup_dest_zone: secondary
+        zonegroup_source_zones: primary
+        zonegroup_dest_zones: secondary
+        zonegroup_pipe: true
+        bucket_group: true
+        bucket_status: enable
+        bucket_flow: false
+        bucket_pipe: true
+        bucket_source_zones: primary
+        bucket_dest_zones: secondary
+        create_object: true
+        create_bucket: true
+        should_sync: true
+        zonegroup_group_remove: true

--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -1845,6 +1845,8 @@ def verify_object_sync_on_other_site(rgw_ssh_con, bucket, config):
             raise TestExecError(
                 f"object count mismatch found in another site for bucket {bucket.name} : {bucket_objects} expected {bkt_objects}"
             )
+        cmd_output = command_output
+    log.info(f"object synced on anothe site for bucket {bucket.name} : {cmd_output}")
 
 
 def flow_operation(

--- a/rgw/v2/tests/s3_swift/test_multisite_bucket_granular_sync_policy.py
+++ b/rgw/v2/tests/s3_swift/test_multisite_bucket_granular_sync_policy.py
@@ -4,6 +4,7 @@ Usage: test_multisite_bucket_granular_sync_policy.py
 <input_yaml>
 	Note: Any one of these yamls can be used
     multisite_configs/test_multisite_granular_bucket_sync_policy.yaml
+    multisite_configs/test_multisite_granular_bucketsync_allowed_forbidden.yaml
 
 Operation:
 	Creates delete sync policy group bucket , zonegroupl level
@@ -223,8 +224,12 @@ def test_exec(config, ssh_con):
                                 raise TestExecError(
                                     f"object should not sync to another site for bucket {bucket.name}, but synced"
                                 )
+                            log.info(
+                                f"object did not sync to another site for bucket {bucket.name} as expected"
+                            )
 
                             if config.test_ops.get("bucket_sync", False):
+                                bucket_group = "bgroup-" + bkt.name
                                 reusable.group_operation(
                                     bucket_group,
                                     "modify",


### PR DESCRIPTION
Directional flow with zonegroup level allowed and bucket level forbidden
log: http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/test_multisite_granular_bucketsync_allowed_forbidden.console.log

Directional flow with zonegroup level enabled and bucket level enabled
log: http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/test_multisite_granular_bucketsync_enable_enable.console.log