### PR TITLE
TFA-Fix: AWSCommandExecError: List object versions on bucket failed

### DIFF
--- a/rgw/v2/tests/aws/test_delete_version_id_null.py
+++ b/rgw/v2/tests/aws/test_delete_version_id_null.py
@@ -88,6 +88,8 @@ def test_exec(config, ssh_con):
         aws_reusable.put_object(bucket_name, object_name, local_endpoint)
         time.sleep(30)
 
+        # waiting for sync to be caught up with other site
+        s3_reusable.check_sync_status()
         # Verifying object with version id null is created on both local and remote sites
         aws_reusable.verify_object_with_version_id_null(
             bucket_name, object_name, local_endpoint


### PR DESCRIPTION
Issue: AWSCommandExecError: List object versions on bucket failed for testbkt

is not reproduced here: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-VIN8BH/Delete_object_version_with_id_null_0.log

but issue seen inconsistently when testcase is combined with other testcases in testsuite.

Assuming it takes some time for the bkt/objects to sync to other site,

Pass log: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-OL64K8/