### PR TITLE
TFA and archive zone workaround automation for BZ-2213138

### DIFF
--- a/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_multipart_haproxy.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_multipart_haproxy.yaml
@@ -1,6 +1,8 @@
 # upload type: non multipart
 # script: test_Mbuckets_with_Nobjects.py
 config:
+  remote_zone: archive
+  test_sync_consistency_bucket_stats: true
   haproxy: true
   user_count: 1
   bucket_count: 2

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_no_reshard_haproxy.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_no_reshard_haproxy.yaml
@@ -1,6 +1,8 @@
 # upload type: non multipart
 # script: test_Mbuckets_with_Nobjects.py
 config:
+  remote_zone: archive
+  test_sync_consistency_bucket_stats: true
   haproxy: true
   user_count: 1
   bucket_count: 2

--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -2031,7 +2031,7 @@ def create_container_using_swift(container_name, rgw, user_info):
         )
 
 
-def test_bucket_stats_across_sites(bucket_name_to_create):
+def test_bucket_stats_across_sites(bucket_name_to_create, config):
     """
     test bucket stats across all the sites is consistent for a bucket
     """
@@ -2045,6 +2045,8 @@ def test_bucket_stats_across_sites(bucket_name_to_create):
             zone_name = "secondary"
         else:
             zone_name = "primary"
+        if config.remote_zone == "archive":
+            zone_name = config.remote_zone
         cmd_bucket_stats = (
             f"radosgw-admin bucket stats --bucket {bucket_name_to_create}"
         )
@@ -2095,7 +2097,6 @@ def test_object_download_at_replicated_site(
         else:
             zone_name = "primary"
         log.info(f"remote zone is {zone_name}")
-
         # Download objects from remote site using boto3 rgw client
         remote_ip = utils.get_rgw_ip_zone(zone_name)
         remote_site_ssh_conn = utils.connect_remote(remote_ip)

--- a/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
+++ b/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
@@ -485,8 +485,9 @@ def test_exec(config, ssh_con):
                     if config.test_sync_consistency_bucket_stats:
                         log.info("Wait for sync lease period of 120 seconds")
                         time.sleep(150)
-                        reusable.test_bucket_stats_across_sites(bucket_name_to_create)
-
+                        reusable.test_bucket_stats_across_sites(
+                            bucket_name_to_create, config
+                        )
                     if config.bucket_sync_crash:
                         is_primary = utils.is_cluster_primary()
                         if is_primary is False:


### PR DESCRIPTION
This would fix the TFA issue https://issues.redhat.com/browse/RHCEPHQE-12411 and automate the archive zone sync issue workaround.  

We are first running the tests that might fail due to sync inconsistency at the archive zone **(bug-2213138**), but after updating the workaround which is to sync from only one zone to the archive zone), the same tests should pass and display a consistent behavior

cephci PR : https://github.com/red-hat-storage/cephci/pull/3263


LOGS: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-E9AGRS
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-SQ9OJ5