### PR TITLE
TFA: for conflicting LC transition actions

### DIFF
--- a/rgw/v2/lib/s3/lifecycle_validation.py
+++ b/rgw/v2/lib/s3/lifecycle_validation.py
@@ -4,6 +4,7 @@ import sys
 sys.path.append(os.path.abspath(os.path.join(__file__, "../../../")))
 import json
 import logging
+import time
 
 import v2.utils.utils as utils
 
@@ -26,6 +27,13 @@ def validate_prefix_rule(bucket, config):
     )
     objs_diff = objs_total - objs_ncurr
     op = utils.exec_shell_cmd("radosgw-admin bucket stats --bucket=%s" % bucket.name)
+    if config.conflict_transition_actions:
+        log.info(
+            "Transition to latest storage class in lc config taken place"
+            + " when there is a conflict between transition rules having same days and same prefix"
+            + " but different storage class"
+        )
+        time.sleep(60)
     op2 = utils.exec_shell_cmd("radosgw-admin bucket list --bucket=%s" % bucket.name)
     json_doc = json.loads(op)
     json_doc2 = json.loads(op2)
@@ -64,12 +72,6 @@ def validate_prefix_rule(bucket, config):
             )
         else:
             raise AssertionError("lc validation for object transition failed")
-        if config.test_ops.get("conflict_transition_actions"):
-            log.info(
-                "Transition to latest storage class in lc config taken place"
-                + " when there is a conflict between transition rules having same days and same prefix"
-                + " but different storage class"
-            )
     else:
         log.info("Start the validation of LC expiration.")
 


### PR DESCRIPTION
This issue was seen due to conflicting LC transition actions where objects with the same prefixes are transitioned to two different storage classes, the result is that we observed an automation failure with objects in the bucket list in both storage classes.

As discussed, we have increased the time between the bucket listing and LC process in such a case.
TFA ticket in Jira : https://issues.redhat.com/browse/RHCEPHQE-12419


passed log http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ZBW6AJ