### PR TITLE
Function and yaml to check for failed object upload

### DIFF
--- a/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_failed.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_failed.yaml
@@ -1,0 +1,21 @@
+# upload type: Upload expected to fail from a AP read-only site
+# script: test_Mbuckets_with_Nobjects.py
+config:
+  user_count: 1
+  bucket_count: 2
+  objects_count: 100
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    create_bucket: true
+    create_object: false
+    upload_type: read_only_upload
+    download_object: false
+    delete_bucket_object: false
+    sharding:
+      enable: false
+      max_shards: 0
+    compression:
+      enable: false
+      type: zlib

--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -66,6 +66,28 @@ def create_bucket(bucket_name, rgw, user_info, location=None):
     return bucket
 
 
+def create_bucket_readonly(bucket_name, rgw, user_info):
+    log.info("creating bucket with name: %s" % bucket_name)
+    bucket = s3lib.resource_op(
+        {"obj": rgw, "resource": "Bucket", "args": [bucket_name]}
+    )
+    kw_args = None
+    created = s3lib.resource_op(
+        {
+            "obj": bucket,
+            "resource": "create",
+            "args": None,
+            "kwargs": kw_args,
+            "extra_info": {"access_key": user_info["access_key"]},
+        }
+    )
+    log.info(f"bucket creation data: {created}")
+    if created is not False:
+        raise TestExecError("Resource execution failed: bucket creation worked")
+    else:
+        log.info("Bucket creation failed as expected")
+
+
 def set_get_object_acl(
     s3_object_name,
     bucket_name,

--- a/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
+++ b/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
@@ -230,7 +230,11 @@ def test_exec(config, ssh_con):
                         if config.dynamic_resharding
                         else "brownfield-manual-bkt"
                     )
-
+                if config.test_ops.get("upload_type") == "read_only_upload":
+                    reusable.create_bucket_readonly(
+                        bucket_name_to_create, rgw_conn, each_user
+                    )
+                    return
                 log.info("creating bucket with name: %s" % bucket_name_to_create)
                 bucket = reusable.create_bucket(
                     bucket_name_to_create, rgw_conn, each_user


### PR DESCRIPTION
As part of Active passive Multisite functionality, the writes to read only secondary will fail.
Adding a function which will fail if writes happen on  cluster.

Fail log: http://magna002.ceph.redhat.com/ceph-qe-logs/tejas/Mbuckets_Nobjects_failed.txt