### PR TITLE
fixing lc transition conflict tc failure because of verification at lc processing time

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_lc_rule_conflict_transition_actions.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_rule_conflict_transition_actions.yaml
@@ -14,6 +14,7 @@ config:
   second_pool_name: data.glacier
   second_storage_class: glacier
   conflict_transition_actions: True
+  rgw_lc_debug_interval: 80
   objects_size_range:
     min: 5
     max: 15
@@ -23,6 +24,7 @@ config:
     enable_versioning: true
     version_count: 3
     delete_marker: false
+    actual_lc_days: 4
   lifecycle_conf:
     - ID: LC_Rule_1
       Filter:

--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -639,7 +639,9 @@ def put_get_bucket_lifecycle_test(
     if not upload_end_time:
         upload_end_time = time.time()
     time_diff = math.ceil(upload_end_time - upload_start_time)
-    time_limit = upload_start_time + (config.rgw_lc_debug_interval * 20)
+    time_limit = upload_start_time + (
+        config.rgw_lc_debug_interval * config.test_ops.get("actual_lc_days", 20)
+    )
     for rule in config.lifecycle_conf:
         if rule.get("Expiration", {}).get("Date", False):
             # todo: need to get the interval value from yaml file

--- a/rgw/v2/tests/s3_swift/test_bucket_lifecycle_object_expiration_transition.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_lifecycle_object_expiration_transition.py
@@ -312,7 +312,7 @@ def test_exec(config, ssh_con):
                         )
                         log.info(f"lc lists is {lc_list_before}")
                         for data in lc_list_before:
-                            if data["bucket"] == bucket.name:
+                            if bucket.name in data["bucket"]:
                                 if data["status"] != "UNINITIAL":
                                     raise TestExecError(
                                         f"Since rgw_enable_lc_threads set to false for bucket {bucket.name}, lc status should be 'UNINITIAL'"


### PR DESCRIPTION
This PR fixes the issue seen with lc conflict transition testcase.
lc validation failed because of bucket list is executed at lc processing time and that time storage class of all objects is not transitioned to target class.
the fix is to wait for the point of time which is in the middle of two lc process, so that lc process completes and bucket list will be settled with target storage class

TFA fail log:  http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/17.2.6-174/Regression/null/26/tier-4-rgw/test_bucket_lc_rule_conflict_between_transition_actions_0.log


also dynamically taken the number of days to wait for lc expiration with the config "actual_lc_days" instead of default value 20

a small change to check for bucket name in lc list for rgw_enable_lc_thread test case
pass log for the same: http://magna002.ceph.redhat.com/ceph-qe-logs/Hemanth_Sai/PR_fix_lc_conflict_transition/quincy_test_lc_rule_conflict_transition_actions.console.log

pass logs on pacific, quincy and reef: http://magna002.ceph.redhat.com/ceph-qe-logs/Hemanth_Sai/PR_fix_lc_conflict_transition/

sample pass log for changing default 20 days: http://magna002.ceph.redhat.com/ceph-qe-logs/Hemanth_Sai/PR_fix_lc_conflict_transition/quincy_test_lc_rule_prefix_non_current_days.console.log