### PR TITLE
[TFA issue Fix] swift Container DELETE failed: There was a conflict w…

### DIFF
--- a/rgw/v2/tests/s3_swift/test_swift_basic_ops.py
+++ b/rgw/v2/tests/s3_swift/test_swift_basic_ops.py
@@ -590,7 +590,7 @@ def test_exec(config, ssh_con):
                 log.info(f"Delete container {container_name} with container owner")
                 rgw.delete_container(container_name)
 
-        if config.test_ops.get("enable_version_by_s3", False):
+        elif config.test_ops.get("enable_version_by_s3", False):
             log.info("making changes to ceph.conf")
             ceph_conf.set_to_ceph_conf(
                 "global", ConfigOpts.rgw_swift_versioning_enabled, "True", ssh_con
@@ -666,7 +666,8 @@ def test_exec(config, ssh_con):
                 raise TestExecError(
                     f"enable versioning on bucket {bucket_name} with swift user failed"
                 )
-        if config.test_ops.get("check_user_permission", False):
+
+        elif config.test_ops.get("check_user_permission", False):
             log.info("making changes to ceph.conf")
             ceph_conf.set_to_ceph_conf(
                 "global", ConfigOpts.rgw_swift_versioning_enabled, "True", ssh_con
@@ -790,6 +791,7 @@ def test_exec(config, ssh_con):
                     raise AssertionError(
                         "Should not fail to write content since permission is readwrite"
                     )
+
         else:
             container_name = utils.gen_bucket_name_from_userid(
                 user_info["user_id"], rand_no=cc


### PR DESCRIPTION
…hen trying to complete your request

TFA issue: https://issues.redhat.com/browse/RHCEPHQE-12627
failure log: http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/17.2.6-180/Weekly/rgw/20/tier-2_rgw_regression/swift_download_large_object_tests_0.log

Since user who create container is removed all data removed, and we are trying to perform operation with deleted container tc was failing

pass log: 
http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/swift/test_delete_container_from_user_of_diff_tenant.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/swift/test_get_objects_from_tenant_swift_user.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/swift/test_s3_and_swift_versioning.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/swift/test_swift_basic_ops.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/swift/test_swift_enable_version_with_different_user.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/swift/test_swift_large_download.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/swift/test_swift_large_upload.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/swift/test_swift_object_expire_op.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/swift/test_swift_user_access_read.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/swift/test_swift_user_access_readwrite.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/swift/test_swift_user_access_write.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/swift/test_swift_version_copy_op.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/swift/test_swift_versioning.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/swift/test_upload_large_obj_with_same_obj_name.console.log