### PR TITLE
[Tier-2] CEPH-83575139 - Ensure a bucket only sync to specific zone

### DIFF
--- a/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucketsync_enabled_forbidden.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucketsync_enabled_forbidden.yaml
@@ -1,4 +1,4 @@
-# Polarian TC : CEPH-83575137
+# Polarian TC : CEPH-83575139
 # script: test_multisite_bucket_granular_sync_policy.py
 config:
     user_count: 1
@@ -11,21 +11,20 @@ config:
         zonegroup_group: true
         zonegroup_status: enabled
         zonegroup_flow: true
-        zonegroup_flow_type: directional
-        zonegroup_source_zone: primary
-        zonegroup_dest_zone: secondary
-        zonegroup_source_zones: primary
-        zonegroup_dest_zones: secondary
+        zonegroup_flow_type: symmetrical
         zonegroup_pipe: true
         bucket_group: true
-        bucket_status: enabled
-        bucket_flow: false
+        bucket_status: forbidden
+        bucket_flow: true
+        bucket_flow_type: directional
+        bucket_source_zone: primary
+        bucket_dest_zone: secondary
         bucket_pipe: true
         bucket_source_zones: primary
         bucket_dest_zones: secondary
         create_object: true
         create_bucket: true
-        should_sync: true
+        should_sync: false
         write_io_verify_another_site: true
-        write_io_verify_should_sync: false
+        write_io_verify_should_sync: true
         zonegroup_group_remove: true

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucketsync_forbidden_allowed.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucketsync_forbidden_allowed.yaml
@@ -1,4 +1,4 @@
-# Polarian TC : CEPH-83575137
+# Polarian TC : CEPH-83575139
 # script: test_multisite_bucket_granular_sync_policy.py
 config:
     user_count: 1
@@ -9,23 +9,22 @@ config:
         max: 2M
     test_ops:
         zonegroup_group: true
-        zonegroup_status: enabled
+        zonegroup_status: forbidden
         zonegroup_flow: true
-        zonegroup_flow_type: directional
-        zonegroup_source_zone: primary
-        zonegroup_dest_zone: secondary
-        zonegroup_source_zones: primary
-        zonegroup_dest_zones: secondary
+        zonegroup_flow_type: symmetrical
         zonegroup_pipe: true
         bucket_group: true
-        bucket_status: enabled
-        bucket_flow: false
+        bucket_status: allowed
+        bucket_flow: true
+        bucket_flow_type: directional
+        bucket_source_zone: primary
+        bucket_dest_zone: secondary
         bucket_pipe: true
         bucket_source_zones: primary
         bucket_dest_zones: secondary
         create_object: true
         create_bucket: true
-        should_sync: true
+        should_sync: false
         write_io_verify_another_site: true
         write_io_verify_should_sync: false
         zonegroup_group_remove: true

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucketsync_forbidden_enabled.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucketsync_forbidden_enabled.yaml
@@ -1,5 +1,6 @@
-# Polarian TC : CEPH-83575137
+# Polarian TC : CEPH-83575139
 # script: test_multisite_bucket_granular_sync_policy.py
+# sync will not happen both side as zonegroup level status is forbidden
 config:
     user_count: 1
     bucket_count: 1
@@ -9,7 +10,7 @@ config:
         max: 2M
     test_ops:
         zonegroup_group: true
-        zonegroup_status: enabled
+        zonegroup_status: forbidden
         zonegroup_flow: true
         zonegroup_flow_type: directional
         zonegroup_source_zone: primary
@@ -19,13 +20,12 @@ config:
         zonegroup_pipe: true
         bucket_group: true
         bucket_status: enabled
-        bucket_flow: false
+        bucket_flow: true
+        bucket_flow_type: symmetrical
         bucket_pipe: true
-        bucket_source_zones: primary
-        bucket_dest_zones: secondary
         create_object: true
         create_bucket: true
-        should_sync: true
+        should_sync: false
         write_io_verify_another_site: true
         write_io_verify_should_sync: false
         zonegroup_group_remove: true

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucketsync_forbidden_forbidden.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucketsync_forbidden_forbidden.yaml
@@ -1,4 +1,4 @@
-# Polarian TC : CEPH-83575137
+# Polarian TC : CEPH-83575139
 # script: test_multisite_bucket_granular_sync_policy.py
 config:
     user_count: 1
@@ -9,7 +9,7 @@ config:
         max: 2M
     test_ops:
         zonegroup_group: true
-        zonegroup_status: enabled
+        zonegroup_status: forbidden
         zonegroup_flow: true
         zonegroup_flow_type: directional
         zonegroup_source_zone: primary
@@ -19,13 +19,16 @@ config:
         zonegroup_pipe: true
         bucket_group: true
         bucket_status: enabled
-        bucket_flow: false
+        bucket_flow: true
+        bucket_flow_type: directional
+        bucket_source_zone: secondary
+        bucket_dest_zone: primary
         bucket_pipe: true
-        bucket_source_zones: primary
-        bucket_dest_zones: secondary
+        bucket_source_zones: secondary
+        bucket_dest_zones: primary
         create_object: true
         create_bucket: true
-        should_sync: true
+        should_sync: false
         write_io_verify_another_site: true
         write_io_verify_should_sync: false
         zonegroup_group_remove: true


### PR DESCRIPTION
[Tier-2] CEPH-83575139 - Ensure a bucket only sync to specific zone

automated remaining semantic in : https://docs.google.com/spreadsheets/d/1-ZW8YF9CMQQdjTv3aobCAiqQa_-lYtb3WjbdoYEH7Ms/edit?usp=sharing

log: 
http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/test_multisite_granular_bucketsync_enable_enable.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/test_multisite_granular_bucketsync_enabled_forbidden.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/test_multisite_granular_bucketsync_forbidden_allowed.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/test_multisite_granular_bucketsync_forbidden_enabled.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/test_multisite_granular_bucketsync_forbidden_forbidden.console.log
