### PR TITLE
Bugs 2247742/2236643 , test inconsistency in size for compression enabled

### DIFF
--- a/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_no_reshard_haproxy.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_no_reshard_haproxy.yaml
@@ -14,6 +14,7 @@ config:
     create_bucket: true
     create_object: true
     download_object: false
+    download_object_at_remote_site: false
     delete_bucket_object: false
     sharding:
       enable: false

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_sse_s3_bucket_enc_multipart_download_archive_site.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_sse_s3_bucket_enc_multipart_download_archive_site.yaml
@@ -2,6 +2,7 @@
 # test_script : test_sse_s3_kms_with_vault.py
 config:
  user_count: 1
+ test_sync_consistency_bucket_stats: true
  remote_zone: archive
  encryption_keys: s3
  bucket_count: 1

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_sse_s3_bucket_enc_multipart_download_remote_site.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_sse_s3_bucket_enc_multipart_download_remote_site.yaml
@@ -2,6 +2,7 @@
 #script- test_sse_s3_kms_with_vault.py
 config:
  user_count: 1
+ test_sync_consistency_bucket_stats: true
  encryption_keys: s3
  bucket_count: 1
  objects_count: 30

--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -2107,8 +2107,11 @@ def test_bucket_stats_across_sites(bucket_name_to_create, config):
         log.info(
             f"collect bucket stats for {bucket_name_to_create} at remote site {zone_name}"
         )
-        log.info("Wait for the sync lease period of 1200 seconds")
-        time.sleep(1200)
+        if config.test_ops["download_object_at_remote_site"] is True:
+            log.info("We have already waited for the sync lease period")
+        else:
+            log.info("We have to wait for sync lease period")
+            time.sleep(1200)
         stdin, stdout, stderr = remote_site_ssh_con.exec_command(cmd_bucket_stats)
         cmd_output = stdout.read().decode()
         stats_remote = json.loads(cmd_output)
@@ -2124,7 +2127,7 @@ def test_bucket_stats_across_sites(bucket_name_to_create, config):
             log.info(f"Data is consistent for bucket {bucket_name_to_create}")
         else:
             raise TestExecError(
-                "Data is inconsistent for {bucket_name_to_create} across sites"
+                f"Data is inconsistent for {bucket_name_to_create} across sites"
             )
 
 

--- a/rgw/v2/tests/s3_swift/test_sse_s3_kms_with_vault.py
+++ b/rgw/v2/tests/s3_swift/test_sse_s3_kms_with_vault.py
@@ -221,6 +221,12 @@ def test_exec(config, ssh_con):
                                 rgw_conn,
                                 each_user,
                             )
+                    if config.test_sync_consistency_bucket_stats:
+                        ##Verify the bugs 2236643 and 2247742
+                        log.info("Test consistency in size(via bucket stats).")
+                        reusable.test_bucket_stats_across_sites(
+                            bucket_name_to_create, config
+                        )
     # check sync status if a multisite cluster
     reusable.check_sync_status()
 


### PR DESCRIPTION
[rgw-ms][compression-encryption][usage]: Encrypted multipart uploads cause an inconsistency in size obtained via bucket stats.

bugs for 6.1z4 : https://bugzilla.redhat.com/show_bug.cgi?id=2247742
bugs for 7.0: https://bugzilla.redhat.com/show_bug.cgi?id=2236643

logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-Y5JXGB

https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83575916
