### PR TITLE
[TFA] double-check with head_bucket if bkt del fails with NoSuchBucket and reducing listing time because of timeit

### DIFF
--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -1063,13 +1063,16 @@ def delete_bucket(bucket):
         bucket_deleted_response, dict
     ):
         response = HttpResponseParser(bucket_deleted_response)
+        log.info(bucket_deleted_response)
         if response.status_code == 204:
             log.info("bucket deleted ")
             write_bucket_info = BucketIoInfo()
             log.info("adding io info of delete bucket")
             write_bucket_info.set_bucket_deleted(bucket.name)
         else:
-            raise TestExecError("bucket deletion failed")
+            raise TestExecError(
+                f"bucket deletion failed with status code {response.status_code}"
+            )
     else:
         raise TestExecError("bucket deletion failed")
 
@@ -1190,10 +1193,6 @@ def time_to_list_via_radosgw(bucket_name, listing):
         cmd = "radosgw-admin bucket list --max-entries=100000 --bucket=%s " % (
             bucket_name
         )
-        # time_taken = timeit.timeit(
-        #     stmt=time_taken_to_execute_command(cmd), globals=globals()
-        # )
-        # return time_taken
         listing_start_time = time.time()
         utils.exec_shell_cmd(cmd)
         listing_end_time = time.time()
@@ -1207,10 +1206,6 @@ def time_to_list_via_radosgw(bucket_name, listing):
             "radosgw-admin bucket list --max-entries=100000 --bucket=%s --allow-unordered"
             % (bucket_name)
         )
-        # time_taken = timeit.timeit(
-        #     stmt=time_taken_to_execute_command(cmd), globals=globals()
-        # )
-        # return time_taken
         listing_start_time = time.time()
         utils.exec_shell_cmd(cmd)
         listing_end_time = time.time()
@@ -1228,12 +1223,8 @@ def time_to_list_via_boto(bucket_name, rgw):
 
     log.info("listing all objects in bucket: %s" % bucket)
     objects = s3lib.resource_op({"obj": bucket, "resource": "objects", "args": None})
-    # time_taken = timeit.timeit(lambda: bucket.objects.all(), globals=globals())
-    # return time_taken
-    listing_start_time = time.time()
-    lambda: bucket.objects.all()
-    listing_end_time = time.time()
-    return listing_end_time - listing_start_time
+    time_taken = timeit.timeit(lambda: bucket.objects.all(), globals=globals())
+    return time_taken
 
 
 def check_sync_status(retry=None, delay=None):

--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -1190,10 +1190,14 @@ def time_to_list_via_radosgw(bucket_name, listing):
         cmd = "radosgw-admin bucket list --max-entries=100000 --bucket=%s " % (
             bucket_name
         )
-        time_taken = timeit.timeit(
-            stmt=time_taken_to_execute_command(cmd), globals=globals()
-        )
-        return time_taken
+        # time_taken = timeit.timeit(
+        #     stmt=time_taken_to_execute_command(cmd), globals=globals()
+        # )
+        # return time_taken
+        listing_start_time = time.time()
+        utils.exec_shell_cmd(cmd)
+        listing_end_time = time.time()
+        return listing_end_time - listing_start_time
 
     if listing == "unordered":
         log.info(
@@ -1203,10 +1207,14 @@ def time_to_list_via_radosgw(bucket_name, listing):
             "radosgw-admin bucket list --max-entries=100000 --bucket=%s --allow-unordered"
             % (bucket_name)
         )
-        time_taken = timeit.timeit(
-            stmt=time_taken_to_execute_command(cmd), globals=globals()
-        )
-        return time_taken
+        # time_taken = timeit.timeit(
+        #     stmt=time_taken_to_execute_command(cmd), globals=globals()
+        # )
+        # return time_taken
+        listing_start_time = time.time()
+        utils.exec_shell_cmd(cmd)
+        listing_end_time = time.time()
+        return listing_end_time - listing_start_time
 
 
 def time_to_list_via_boto(bucket_name, rgw):
@@ -1220,8 +1228,12 @@ def time_to_list_via_boto(bucket_name, rgw):
 
     log.info("listing all objects in bucket: %s" % bucket)
     objects = s3lib.resource_op({"obj": bucket, "resource": "objects", "args": None})
-    time_taken = timeit.timeit(lambda: bucket.objects.all(), globals=globals())
-    return time_taken
+    # time_taken = timeit.timeit(lambda: bucket.objects.all(), globals=globals())
+    # return time_taken
+    listing_start_time = time.time()
+    lambda: bucket.objects.all()
+    listing_end_time = time.time()
+    return listing_end_time - listing_start_time
 
 
 def check_sync_status(retry=None, delay=None):


### PR DESCRIPTION
this PR is to add code for cross verification of bucket deletion failure(NoSuchBucket) with head_bucket, bucket stats and bucket list
also reducing bucket listing time because of timeit

jira ticket: https://issues.redhat.com/browse/RHCEPHQE-12653

pass logs: 
http://magna002.ceph.redhat.com/ceph-qe-logs/Hemanth_Sai/listing_pseudo_dir_failure/PR_logs/cephci-run-G8UGA5/
http://magna002.ceph.redhat.com/ceph-qe-logs/Hemanth_Sai/listing_pseudo_dir_failure/PR_logs/test_bucket_listing_pseudo_ordered.console.log_passlog2

filed a bz already for objects deletion failure: https://bugzilla.redhat.com/show_bug.cgi?id=2256668