### PR TITLE
Bucket check ehancement based on new output format for reef7.1

### DIFF
--- a/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
+++ b/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
@@ -733,8 +733,12 @@ def test_exec(config, ssh_con):
                             float(ceph_version_id[0]) == 17
                             and float(ceph_version_id[1]) >= 2
                             and float(ceph_version_id[2]) >= 6
+                        ) or (
+                            float(ceph_version_id[0]) == 18
+                            and float(ceph_version_id[1]) >= 2
+                            and float(ceph_version_id[2]) >= 1
                         ):
-                            log.info("Entering quincy")
+                            log.info("validating orphaned object as per new format")
                             if len(bkt_check_before["invalid_multipart_entries"]) < 1:
                                 raise AssertionError(
                                     f"Orphaned object not found in bucket {bucket.name}"
@@ -755,8 +759,12 @@ def test_exec(config, ssh_con):
                             float(ceph_version_id[0]) == 17
                             and float(ceph_version_id[1]) >= 2
                             and float(ceph_version_id[2]) >= 6
+                        ) or (
+                            float(ceph_version_id[0]) == 18
+                            and float(ceph_version_id[1]) >= 2
+                            and float(ceph_version_id[2]) >= 1
                         ):
-                            log.info("Entering quincy")
+                            log.info("validating bucket check as per new format")
                             if len(bkt_check_after["invalid_multipart_entries"]) != 0:
                                 raise AssertionError(
                                     f"bucket check fix did not removed orphan objects on a bucket {bucket.name}"


### PR DESCRIPTION
Bucket check enhancement based on new output format for reef-7.1
logs:
5.3z6: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/bkt-check-newformat/53z6-pass-log
6.1z4: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/bkt-check-newformat/61z4-pass-log
7.0z1: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/bkt-check-newformat/70z1-pass-log
7.1: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/bkt-check-newformat/71-pass-log