### PR TITLE
Introduce rate limit conflict between global and user scope.

### DIFF
--- a/rgw/v2/lib/resource_op.py
+++ b/rgw/v2/lib/resource_op.py
@@ -428,6 +428,14 @@ class Config(object):
         self.user_max_read_bytes = self.doc["config"].get("user_max_read_bytes")
         self.user_max_write_ops = self.doc["config"].get("user_max_write_ops")
         self.user_max_write_bytes = self.doc["config"].get("user_max_write_bytes")
+        self.user_conflict_read_bytes = self.doc["config"].get(
+            "user_conflict_read_bytes"
+        )
+        self.user_conflict_read_ops = self.doc["config"].get("user_conflict_read_ops")
+        self.user_conflict_write_bytes = self.doc["config"].get(
+            "user_conflict_write_bytes"
+        )
+        self.user_conflict_write_ops = self.doc["config"].get("user_conflict_write_ops")
         self.permutation_count = self.doc["config"].get("permutation_count")
         ceph_version_id, ceph_version_name = utils.get_ceph_version()
         # todo: improve Frontend class

--- a/rgw/v2/tests/s3cmd/configs/test_ratelimit_global.yaml
+++ b/rgw/v2/tests/s3cmd/configs/test_ratelimit_global.yaml
@@ -1,5 +1,5 @@
 # script: test_rate_limit.py
-# Polarion ID : CEPH-83574915, CEPH-83574916
+# Polarion ID : CEPH-83574915, CEPH-83574916, CEPH-83574919
 config:
   user_count: 1
   bucket_count: 2
@@ -7,7 +7,11 @@ config:
   bucket_max_read_bytes: 4096
   bucket_max_write_ops: 2
   bucket_max_write_bytes: 4096
-  user_max_read_bytes: 4096
-  user_max_read_ops: 2
-  user_max_write_bytes: 4096
-  user_max_write_ops: 2
+  user_max_read_bytes: 8192
+  user_max_read_ops: 4
+  user_max_write_bytes: 8192
+  user_max_write_ops: 4
+  user_conflict_read_bytes: 4096
+  user_conflict_read_ops: 2
+  user_conflict_write_bytes: 4096
+  user_conflict_write_ops: 2

--- a/rgw/v2/tests/s3cmd/reusable.py
+++ b/rgw/v2/tests/s3cmd/reusable.py
@@ -230,17 +230,28 @@ def rate_limit_set_enable(
     max_write_ops,
     max_write_bytes,
     global_scope=None,
+    uid=None,
 ):
     """Set and enable rate limits for the scope mentioned"""
-    limset = utils.exec_shell_cmd(
-        f"radosgw-admin {global_scope} ratelimit set --ratelimit-scope={scope}"
-        + f" --max-read-ops={max_read_ops} --max-read-bytes={max_read_bytes}"
-        + f" --max-write-bytes={max_write_bytes} --max-write-ops={max_write_ops}"
-    )
-    log.info(f"Rate limits set on {scope}")
-    limenable = utils.exec_shell_cmd(
-        f"radosgw-admin {global_scope} ratelimit enable --ratelimit-scope={scope}"
-    )
+    if uid is None:
+        limset = utils.exec_shell_cmd(
+            f"radosgw-admin {global_scope} ratelimit set --ratelimit-scope={scope}"
+            + f" --max-read-ops={max_read_ops} --max-read-bytes={max_read_bytes}"
+            + f" --max-write-bytes={max_write_bytes} --max-write-ops={max_write_ops}"
+        )
+        limenable = utils.exec_shell_cmd(
+            f"radosgw-admin {global_scope} ratelimit enable --ratelimit-scope={scope}"
+        )
+    else:
+        limset = utils.exec_shell_cmd(
+            f"radosgw-admin ratelimit set --ratelimit-scope={scope} --uid {uid}"
+            + f" --max-read-ops={max_read_ops} --max-read-bytes={max_read_bytes}"
+            + f" --max-write-bytes={max_write_bytes} --max-write-ops={max_write_ops}"
+        )
+        limenable = utils.exec_shell_cmd(
+            f"radosgw-admin ratelimit enable --ratelimit-scope={scope} --uid {uid}"
+        )
+    log.info(f"Rate limits set and enabled on {scope}")
 
 
 def rate_limit_read(bucket, max_read_ops, ssl=None, file=None):


### PR DESCRIPTION
Steps:
1. With global rate limit configured , add a user scope rate limit.
2. The user rate limit should take precedence.

Pass log:
http://magna002.ceph.redhat.com/ceph-qe-logs/tejas/Ratelimit_conflict.txt