### PR TITLE
reverting lc_debug_interval to 30 for lc transition conflict testcase

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_lc_rule_conflict_transition_actions.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_rule_conflict_transition_actions.yaml
@@ -14,7 +14,6 @@ config:
   second_pool_name: data.glacier
   second_storage_class: glacier
   conflict_transition_actions: True
-  rgw_lc_debug_interval: 80
   objects_size_range:
     min: 5
     max: 15


### PR DESCRIPTION
this PR is to revert the lc_debug_interval to 30 for lc transition conflict testcase
lc reverse transition is getting passed with the same debug interval(30), and lc transition conflict testcase is failing intermittently in pipeline.

jira ticket: https://issues.redhat.com/browse/RHCEPHQE-13054

pass logs:

quincy:
entire suite: http://magna002.ceph.redhat.com/ceph-qe-logs/Hemanth_Sai/TFA_lc_conflict_failure/cephci-run-A6S7H8/
http://magna002.ceph.redhat.com/ceph-qe-logs/Hemanth_Sai/TFA_lc_conflict_failure/quincy_test_lc_rule_conflict_transition_actions.console.log

reef: http://magna002.ceph.redhat.com/ceph-qe-logs/Hemanth_Sai/TFA_lc_conflict_failure/reef_test_lc_rule_conflict_transition_actions.console.log