### PR TITLE
Mdlog check enhance

### DIFF
--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -1653,9 +1653,25 @@ def test_log_trimming(bucket, config):
         if len(output2) == 0:
             log.info(f"{config.log_trimming} log is empty after the interval")
         else:
-            raise TestExecError(
-                f"{config.log_trimming} log is not empty after the interval"
-            )
+            if config.log_trimming == "mdlog":
+                retry = 25
+                delay = 60
+                for retry_count in range(retry):
+                    time.sleep(delay)
+                    output2 = json.loads(utils.exec_shell_cmd(cmd))
+                    if len(output2) == 0:
+                        log.info(f"{config.log_trimming} log is empty")
+                        break
+                time.sleep(delay)
+                output2 = json.loads(utils.exec_shell_cmd(cmd))
+                if retry_count > retry and len(output2) != 0:
+                    raise TestExecError(
+                        f"{config.log_trimming} log is not empty even after waiting extra 25min interval"
+                    )
+            else:
+                raise TestExecError(
+                    f"{config.log_trimming} log is not empty after the interval"
+                )
         if config.test_bilog_trim_on_non_existent_bucket:
             utils.exec_shell_cmd(
                 f"radosgw-admin bucket rm --purge-objects --bucket {bucket.name}"


### PR DESCRIPTION
Adding enhancement to wait for additionally 25 min with retry interval of 1 minute to check if mdlog list is empty.
as per BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2230359

Fail log: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-VZ8UOY/Mdlog_trimming_test_on_primary_0.log

Pass log: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-ZCFO84/
