### PR TITLE
[TFA] Fetch realm name from sync status as period config will not have realm name

### DIFF
--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -818,7 +818,11 @@ def get_multisite_info():
         zone_names = zone_names + zone_name
         if i != len(period_list.get("period_map")["zonegroups"][0]["zones"]) - 1:
             zone_names = zone_names + ","
-    realm_name = period_list.get("realm_name")
+    op = utils.exec_shell_cmd("radosgw-admin sync status")
+    lines = list(op.split("\n"))
+    for line in lines:
+        if "realm" in line:
+            realm_name = line[line.find("(") + 1 : line.find(")")]
     return zone_names, realm_name
 
 
@@ -1986,7 +1990,9 @@ def pipe_operation(
         cmd = cmd + policy_detail
 
     utils.exec_shell_cmd(cmd)
-    update_commit()
+    if bucket_name is None:
+        update_commit()
+
     return pipe_id
 
 


### PR DESCRIPTION
[TFA] Fetch realm name from sync status as period config will not have realm name

BZ which removed realm name from period config : https://bugzilla.redhat.com/show_bug.cgi?id=2196109

.Renaming a realm now updates after performing a period update 

Previously, performing a period update after renaming a realm would not reflect the new realm name when running the `radosgw-admin period get` command. 

 With this fix, the realm name is not shown in the period and therefore does not reflect the wrong realm name.
 
 024-02-11 23:54:26,386 INFO: executing cmd: radosgw-admin sync status
2024-02-11 23:54:35,285 INFO: cmd excuted
2024-02-11 23:54:35,286 INFO:           realm 13f703a7-0c19-4e43-95c6-3d3f4300c5ad (india)
      zonegroup 5889bda4-fef8-43a1-953d-7f11b8994c0e (shared)
           zone 8df886ee-2737-4150-b7a1-5ac9b95bef76 (primary)
   current time 2024-02-12T04:54:31Z
zonegroup features enabled: resharding
                   disabled: compress-encrypted
  metadata sync no sync (zone is master)
      data sync source: 9f0e8e31-8c4d-49d0-9d3b-51cb103f9530
                        syncing
                        full sync: 0/128 shards
                        incremental sync: 128/128 shards
                        data is caught up with source

2024-02-11 23:54:35,286 INFO: executing cmd: radosgw-admin period update --rgw-realm=india --commit
2024-02-11 23:54:43,066 INFO: cmd excuted
2024-02-11 23:54:43,066 INFO: {

log: http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/test_multisite_granular_bucketsync_forbidden_enabled.console.log