### PR TITLE
[Tier-3] adding pre-requisite for CEPH-83575073 for cosbench workload

### DIFF
--- a/rgw/v2/tests/aws/configs/test_aws.yaml
+++ b/rgw/v2/tests/aws/configs/test_aws.yaml
@@ -1,4 +1,0 @@
-# script: test_aws.py
-config:
-  user_count: 2
-  bucket_count: 2

--- a/rgw/v2/tests/aws/configs/test_aws_versioned_bucket_creation.yaml
+++ b/rgw/v2/tests/aws/configs/test_aws_versioned_bucket_creation.yaml
@@ -1,0 +1,10 @@
+# script: test_aws.py
+# polarion-ID: CEPH-83575073 [PUT Workload] Test sync with 20M bi-directional with LB. (Versioned buckets)
+config:
+  user_count: 1
+  bucket_count: 1
+  user_remove: false
+  test_ops:
+    user_name: cosbench01
+    bucket_name: cosbench01-bkt
+    enable_version: true


### PR DESCRIPTION
We do not have versioned bucket creation in cosbench, so creating versioned bucket using aws ceph-qde-script as a pre-req

log: http://magna006.ceph.redhat.com/ceph-qe-logs/anuchaithra/test_aws_versioned_bucket_creation.console.log 