### PR TITLE
Lc expiration with custom lc worktime

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_lc_with_custom_worktime.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_with_custom_worktime.yaml
@@ -1,0 +1,27 @@
+# BZ: 2255938 (Issue was seen with default rgw_lc_debug_interval of 1 day)
+# Polarian: CEPH-83583080: Test LC with custom lc worktime
+# Script: test_bucket_lifecycle_object_expiration_transition.py
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 10
+  rgw_lc_debug_interval: 1
+  rgw_lifecycle_work_time: "17:00-16:59"
+  parallel_lc: true
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    create_bucket: true
+    create_object: true
+    enable_versioning: false
+    version_count: 0
+    delete_marker: false
+    rgw_lc_debug: true
+  lifecycle_conf:
+    - ID: LC_Rule_1
+      Filter:
+        Prefix: key1
+      Status: Enabled
+      Expiration:
+        Days: 1

--- a/rgw/v2/tests/s3_swift/test_bucket_lifecycle_object_expiration_transition.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_lifecycle_object_expiration_transition.py
@@ -14,6 +14,7 @@ where : <input-yaml> are test_lc_date.yaml, test_rgw_enable_lc_threads.yaml, tes
  test_lc_rule_conflict_btw_exp_transition.yaml, test_lc_rule_conflict_exp_days.yaml,
  test_lc_rule_conflict_transition_actions.yaml
  test_lc_rule_reverse_transition.yaml
+ test_lc_with_custom_worktime.yaml
 
 Operation:
 
@@ -80,12 +81,12 @@ def test_exec(config, ssh_con):
             str(config.rgw_enable_lc_threads),
             ssh_con,
         )
-        ceph_conf.set_to_ceph_conf(
-            "global",
-            ConfigOpts.rgw_lifecycle_work_time,
-            str(config.rgw_lifecycle_work_time),
-            ssh_con,
-        )
+    ceph_conf.set_to_ceph_conf(
+        "global",
+        ConfigOpts.rgw_lifecycle_work_time,
+        str(config.rgw_lifecycle_work_time),
+        ssh_con,
+    )
     _, version_name = utils.get_ceph_version()
     if "nautilus" in version_name:
         ceph_conf.set_to_ceph_conf(


### PR DESCRIPTION
Lc expiration with custom lc worktime of format:
rgw_lifecycle_work_time: "17:00-16:59"

Pass log: http://magna006.ceph.redhat.com/ceph-qe-logs/Chaithra/lc_custom_worktime/pass-log
Pass log for existing config: http://magna006.ceph.redhat.com/ceph-qe-logs/Chaithra/lc_custom_worktime/test_enable_lc_threads.log
