### PR TITLE
Fix failure seen with mfa testcase

### DIFF
--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -614,15 +614,8 @@ def enable_mfa_versioning(
             ),
         }
     )
-
-    if mfa_version_put is False:
-        return token, mfa_version_put
-
-    response = HttpResponseParser(mfa_version_put)
-    if response.status_code == 200:
-        log.info("MFA and version enabled")
-    else:
-        raise MFAVersionError("bucket mfa and versioning enable failed")
+    log.info(f"mfa_version_put: {mfa_version_put}")
+    return token, mfa_version_put
 
 
 def put_get_bucket_lifecycle_test(


### PR DESCRIPTION
We were seeing issue: cannot unpack non-iterable NoneType object
when put operation of MFA and version enabled is succeeded in the first iteration.

since previously we were returning : return token, mfa_version_put
only in case of the situation where put mfa is a failure: i.e
if mfa_version_put is False:
        return token, mfa_version_put

but we are checking condition: if status is False:
https://github.com/red-hat-storage/ceph-qe-scripts/pull/561/files#diff-e65bb0e4957600e7835ff2af409a6e7bff1c9e1cbc5dd3ad2124b41a6b91d0deL149

so if mfa version enable i s successful in first attempt it was not returning any value , but in the script we are looking for the condition check
fail log: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/mfa-failure/test_rgw_mfa.console.log2-fail

Post fix:
Pass log: 
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/mfa-failure/test_rgw_mfa.console.log5-pass(where mfs enable success in first attempt)
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/mfa-failure/test_rgw_mfa.console.log3-pass

http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/mfa-failure/test_rgw_mfa.console.log4-pass
(where mfs enable success in second attempt)

