### PR TITLE
[Tier-2][CEPH-83575140] Configure sync from different bucket

### DIFF
--- a/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucketsync_sync_from_diff_bucket.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucketsync_sync_from_diff_bucket.yaml
@@ -1,0 +1,27 @@
+# Polarian TC : CEPH-83575140
+# script: test_multisite_bucket_granular_sync_policy.py
+config:
+    user_count: 1
+    bucket_count: 1
+    objects_count: 100
+    objects_size_range:
+        min: 5K
+        max: 2M
+    test_ops:
+        zonegroup_group: true
+        zonegroup_status: allowed
+        zonegroup_flow: true
+        zonegroup_flow_type: symmetrical
+        zonegroup_pipe: true
+        bucket_group: true
+        bucket_status: enabled
+        bucket_flow: false
+        bucket_pipe: true
+        create_object: true
+        create_bucket: true
+        create_new_bucket: true
+        new_bucket_count: 2
+        sync_from_diff_bucket: true
+        bucket_policy_details: --source-bucket <source_bucket_name>
+        write_io_verify_another_site: true
+        zonegroup_group_remove: true

--- a/rgw/v2/tests/s3_swift/test_multisite_bucket_granular_sync_policy.py
+++ b/rgw/v2/tests/s3_swift/test_multisite_bucket_granular_sync_policy.py
@@ -11,6 +11,7 @@ Usage: test_multisite_bucket_granular_sync_policy.py
     multisite_configs/test_multisite_granular_bucketsync_forbidden_forbidden.yaml
     multisite_configs/test_multisite_granular_bucketsync_forbidden_allowed.yaml
     multisite_configs/test_multisite_granular_bucketsync_sync_to_diff_bucket.yaml
+    multisite_configs/test_multisite_granular_bucketsync_sync_from_diff_bucket.yaml
 
 Operation:
 	Creates delete sync policy group bucket , zonegroupl level


### PR DESCRIPTION
Sync from different bucket : [Tier-2][CEPH-83575140] Configure sync to different bucket

log: http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/test_multisite_granular_bucketsync_sync_from_diff_bucket.console.log