### PR TITLE
Add support to run multipart upload test via haproxy

### DIFF
--- a/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_multipart_via_haproxy.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_multipart_via_haproxy.yaml
@@ -1,0 +1,24 @@
+# upload type: non multipart
+# script: test_Mbuckets_with_Nobjects.py
+config:
+  haproxy: true
+  user_count: 1
+  bucket_count: 2
+  objects_count: 2
+  split_size: 100
+  objects_size_range:
+    min: 300M
+    max: 500M
+  local_file_delete: true
+  test_ops:
+    create_bucket: true
+    create_object: true
+    upload_type: multipart
+    download_object: true
+    delete_bucket_object: false
+    sharding:
+      enable: false
+      max_shards: 0
+    compression:
+      enable: false
+      type: zlib


### PR DESCRIPTION
Add config support to run the test via HAproxy node

Pass logs - http://magna002.ceph.redhat.com/ceph-qe-logs/madhavi/PRs/test_Mbuckets_with_Nobjects_multipart_via_haproxy_console.log 