### PR TITLE
[TFA] Upstream main 19.0.0-.. format update for radosgw-admin bucket stats --uid ...

### DIFF
--- a/rgw/v2/tests/s3_swift/test_swift_basic_ops.py
+++ b/rgw/v2/tests/s3_swift/test_swift_basic_ops.py
@@ -270,16 +270,25 @@ def test_exec(config, ssh_con):
                 )
                 num_obj_current = utils.exec_shell_cmd(current_count)
                 num_obj_current = json.loads(num_obj_current)
+                ceph_version_id, _ = utils.get_ceph_version()
+                ceph_version_id = ceph_version_id.split("-")
+                ceph_version_id = ceph_version_id[0].split(".")
+                num_objects_cur = (
+                    num_obj_current
+                    if float(ceph_version_id[0]) >= 19
+                    else num_obj_current[0]
+                )
                 num_obj_current = (
-                    num_obj_current[0].get("usage").get("rgw.main").get("num_objects")
+                    num_objects_cur.get("usage").get("rgw.main").get("num_objects")
                 )
-                old_count = "radosgw-admin bucket stats --uid={uid} --tenant={tenant} --bucket='{bucket}' ".format(
-                    uid=user_name, tenant=tenant, bucket=container_name_old
-                )
+                old_count = f"radosgw-admin bucket stats --uid={user_name} --tenant={tenant} --bucket='{container_name_old}'"
                 num_obj_old = utils.exec_shell_cmd(old_count)
                 num_obj_old = json.loads(num_obj_old)
+                num_objects_old = (
+                    num_obj_old if float(ceph_version_id[0]) >= 19 else num_obj_old[0]
+                )
                 num_obj_old = (
-                    num_obj_old[0].get("usage").get("rgw.main").get("num_objects")
+                    num_objects_old.get("usage").get("rgw.main").get("num_objects")
                 )
                 version_count_from_config = (
                     config.objects_count * config.version_count


### PR DESCRIPTION
Till reef bucket stats is obtained as list of dictionary, but in main (19.0.0-..) there is a format change and now its a dictionary

reef pass log: http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/18.2.1-738.gdd302ccd/Upstream/27/tier-1_rgw_and_lc/swift_versioning_tests_0.log

main fail log: http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/19.0.0-1951.g0a9aa2fa/Upstream/29/tier-1_rgw_and_lc/swift_versioning_tests_0.log

after the fix, main pass log: http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/test_swift_versioning.console.log