### PR TITLE
[RGW-T2-Automation]: Test LC process (perform radosgw-admin lc proces…

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_lc_process_without_applying_rule.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_process_without_applying_rule.yaml
@@ -1,0 +1,30 @@
+#test_bucket_lifecycle_object_expiration_transition.py
+# Polarian: CEPH-83574044: Test LC process (perform radosgw-admin lc process) with and without applying LC rule.
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 1
+  parallel_lc: False
+  rgw_lc_debug_interval: 600
+  rgw_enable_lc_threads: false
+  test_lc_transition: True
+  enable_resharding: False
+  pool_name: data.cold
+  storage_class: cold
+  ec_pool_transition: False
+  multiple_transitions: False
+  two_pool_transition: False
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    create_bucket: true
+    create_object: true
+    enable_versioning: true
+    version_count: 1
+    delete_marker: false
+    transition_with_lc_process_without_rule: true
+  lifecycle_conf:
+    - ID: LC_Rule_1
+      Filter:
+        Prefix: key1

--- a/rgw/v2/tests/s3_swift/configs/test_lc_transition_with_lc_process.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_transition_with_lc_process.yaml
@@ -1,0 +1,34 @@
+#test_bucket_lifecycle_object_expiration_transition.py
+# Polarian: CEPH-83574044: Test LC process (perform radosgw-admin lc process) with and without applying LC rule.
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 10
+  parallel_lc: False
+  rgw_lc_debug_interval: 600
+  rgw_enable_lc_threads: false
+  test_lc_transition: True
+  enable_resharding: False
+  pool_name: data.cold
+  storage_class: cold
+  ec_pool_transition: False
+  multiple_transitions: False
+  two_pool_transition: False
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    create_bucket: true
+    create_object: true
+    enable_versioning: true
+    version_count: 1
+    delete_marker: false
+    transition_with_lc_process: true
+  lifecycle_conf:
+    - ID: LC_Rule_1
+      Filter:
+        Prefix: key1
+      Status: Enabled
+      Transitions:
+        - Date: "2022-02-19"
+          StorageClass: cold


### PR DESCRIPTION
…s) with and without applying LC rule.

Polarian: CEPH-83574044: Test LC process (perform radosgw-admin lc process) with and without applying LC rule.

LC transition with rule log: 
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/automation_transition_with_without_rule_lc_proces/lc_process_with_transition_rule.log
Failure BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2269490


LC transition without rule log:
pacific: Pass
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/automation_transition_with_without_rule_lc_proces/lc_process_without_rule.log

Reef: Fail
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/automation_transition_with_without_rule_lc_proces/test_lc_process_without_applying_rule.console.log
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2270402

Pass log for existing config:
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/automation_transition_with_without_rule_lc_proces/test_lc_rule_reverse_transition.console.log