### PR TITLE
CEPH-83575592: Automate assume-role at multisite.

### DIFF
--- a/rgw/v2/tests/s3_swift/multisite_configs/test_sts_multisite.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_sts_multisite.yaml
@@ -1,0 +1,34 @@
+# polarion test case id: CEPH-83575592
+# test scripts : test_sts_using_boto.py
+config:
+     bucket_count: 2
+     objects_count: 100
+     objects_size_range:
+          min: 5
+          max: 15
+     test_ops:
+          create_bucket: true
+          create_object: true
+     sts:
+          policy_document:
+               "Version": "2012-10-17"
+               "Statement":
+                    [
+                         {
+                              "Effect": "Allow",
+                              "Principal":
+                                   {
+                                        "AWS":
+                                             ["arn:aws:iam:::user/<user_name>"],
+                                   },
+                              "Action": ["sts:AssumeRole"],
+                         },
+                    ]
+          role_policy:
+               "Version": "2012-10-17"
+               "Statement":
+                    {
+                         "Effect": "Allow",
+                         "Action": "s3:*",
+                         "Resource": "arn:aws:s3:::*",
+                    }

--- a/rgw/v2/tests/s3_swift/test_sts_using_boto.py
+++ b/rgw/v2/tests/s3_swift/test_sts_using_boto.py
@@ -4,6 +4,7 @@ test_sts_using_boto.py - Test STS using boto
 Usage: test_sts_using_boto.py -c <input_yaml>
 <input_yaml>
     test_sts_using_boto.yaml
+    multisite_configs/test_sts_multisite.yaml
 
 Operation:
     s1: Create 2 Users.
@@ -116,6 +117,15 @@ def test_exec(config, ssh_con):
 
         log.info("put_policy_response")
         log.info(put_policy_response)
+
+        log.info(
+            "Test if the cluster is multisite, to perform sts operations via multisite"
+        )
+        is_multisite = utils.is_cluster_multisite()
+        if is_multisite:
+            # Test assume-role at multisite,CEPH-83575592.
+            log.info("Cluster is multisite")
+            ssh_con = reusable.get_remote_conn_in_multisite()
 
         auth = Auth(user2, ssh_con, ssl=config.ssl)
         sts_client = auth.do_auth_sts_client()


### PR DESCRIPTION
CEPH-83575592:sts assume-role at multisite.

The flow of the test is as follows:

1. On the primary zone, 
- create 2 users, user1 and user2
- Add role caps to the user1, create a role, and attach role policy.

2. Connect to the secondary zone, and perform the below steps
-  test sts assume role call on the secondary zone
-  perform s3 bucket creation and other operations via the session token generated with assume role call.

Currently with this automation, we saw that the s3 bucket operations fails on the secondary (https://bugzilla.redhat.com/show_bug.cgi?id=2271399)

logs: will fail at bucket creation (expected) 
http://magna002.ceph.redhat.com/ceph-qe-logs/vidushi/580/logs_stst_assumerole_ms