### PR TITLE
add support to download multipart object using aws

### DIFF
--- a/rgw/v2/tests/aws/test_aws.py
+++ b/rgw/v2/tests/aws/test_aws.py
@@ -89,6 +89,9 @@ def test_exec(config, ssh_con):
                     raise AssertionError(
                         "Etag not generated during complete multipart upload operation"
                     )
+                log.info(f"Download multipart object {key_name}")
+                aws_reusable.get_object(bucket_name, key_name, endpoint)
+
         if config.test_ops.get("verify_non_ascii_character_upload", False):
             log.info(f"Object name and body containing non ascii character upload")
             object_name = "ˍ´--øÆ.txt"
@@ -96,6 +99,7 @@ def test_exec(config, ssh_con):
             aws_reusable.put_object(bucket_name, object_name, endpoint)
             log.info("Object upload successful")
             aws_reusable.get_object(bucket_name, object_name, endpoint)
+            log.info("Object download successful")
 
         if config.user_remove is True:
             s3_reusable.remove_user(user)


### PR DESCRIPTION
Add support to download multipart object to existing config 

Pass logs : http://magna002.ceph.redhat.com/ceph-qe-logs/madhavi/PRs/test_complete_multipart_upload_etag_not_empty_console.log 