### PR TITLE
symlink for sse integration configs in multisite

### DIFF
--- a/rgw/v2/tests/s3_swift/multisite_configs/test_sse_kms_per_bucket_multipart_object_download_after_transition.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_sse_kms_per_bucket_multipart_object_download_after_transition.yaml
@@ -1,0 +1,1 @@
+../configs/test_sse_kms_per_bucket_multipart_object_download_after_transition.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_sse_kms_per_bucket_with_bucket_policy.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_sse_kms_per_bucket_with_bucket_policy.yaml
@@ -1,0 +1,1 @@
+../configs/test_sse_kms_per_bucket_with_bucket_policy.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_sse_s3_per_bucket_with_notifications_dynamic_reshard.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_sse_s3_per_bucket_with_notifications_dynamic_reshard.yaml
@@ -1,0 +1,1 @@
+../configs/test_sse_s3_per_bucket_with_notifications_dynamic_reshard.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_sse_s3_per_object_with_sts.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_sse_s3_per_object_with_sts.yaml
@@ -1,0 +1,1 @@
+../configs/test_sse_s3_per_object_with_sts.yaml


### PR DESCRIPTION
This PR is to fix failures for sse integration tests in pipeline because of config file not found in multisite_configs

failure log in pipeline: http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/openstack/RH/7.0/rhel-9/Weekly/18.2.0-189/rgw/37/sanity_rgw_multisite/

pass log: http://magna002.ceph.redhat.com/ceph-qe-logs/Hemanth_Sai/ss3_s3_tfa_fix/cephci-run-4XLNNJ/