### PR TITLE
[TFA] Due to index bucket left in cluster issue was seen in radoslist

### DIFF
--- a/rgw/v2/tests/s3_swift/test_indexless_buckets.py
+++ b/rgw/v2/tests/s3_swift/test_indexless_buckets.py
@@ -99,20 +99,23 @@ def test_exec(config, ssh_con):
                             s3_object_name, bucket, TEST_DATA_PATH, config, each_user
                         )
 
-        # verify the bucket created has index_type = Indexless
-        log.info("verify the default placement is Indexless placement")
-        zonegroup_get = utils.exec_shell_cmd("radosgw-admin zonegroup get")
-        zonegroup_get_json = json.loads(zonegroup_get)
-        default_place = zonegroup_get_json["default_placement"]
-        if default_place == "indexless-placement":
-            log.info("default placement is Indexless placement")
-        else:
-            raise TestExecError("default placement is not Indexless placement")
+                # verify the bucket created has index_type = Indexless
+                log.info("verify the default placement is Indexless placement")
+                zonegroup_get = utils.exec_shell_cmd("radosgw-admin zonegroup get")
+                zonegroup_get_json = json.loads(zonegroup_get)
+                default_place = zonegroup_get_json["default_placement"]
+                if default_place == "indexless-placement":
+                    log.info("default placement is Indexless placement")
+                else:
+                    raise TestExecError("default placement is not Indexless placement")
 
-        # delete bucket and objects
-        if config.test_ops["delete_bucket"] is True:
-            log.info("Deleting buckets and objects")
-            reusable.delete_bucket(bucket)
+                # delete bucket and objects
+                if config.test_ops["delete_bucket"] is True:
+                    log.info("Deleting buckets and objects")
+                    reusable.delete_bucket(bucket)
+
+        if config.user_remove:
+            reusable.remove_user(each_user)
 
     # reverting to default placement group
     log.info("revert changes to zone, zonegroup and default placement target")


### PR DESCRIPTION
Reason: 
Since its a baremetal execution, after radoslist we trigger testcases indexless bucket where only one bucket was deleted. in Next baremetal run rwhen we trigger radoslist testcase it will fail due to existence ofindexless bucket from previous run.

Failure is due to the undeleted buckets in testcase indexless bucket..

(venv) [root@mero006 s3_swift]# radosgw-admin user rm --uid=lillianx.832 --purge-data
(venv) [root@mero006 s3_swift]# radosgw-admin bucket rm --bucket charlesw.814-bucky-1257-0 --purge-data
(venv) [root@mero006 s3_swift]# radosgw-admin user rm --uid=charlesw.814 --purge-data
(venv) [root@mero006 s3_swift]# radosgw-admin bucket radoslist | grep -i ERROR
ERROR: because there is at least one indexless bucket (ericr.770-bucky-4671-0) the results of radoslist are incomplete; use --yes-i-really-mean-it to bypass error
ERROR: bucket radoslist failed to finish before encountering error: (22) Invalid argument
************************************************************************
WARNING: THE RESULTS ARE NOT RELIABLE AND SHOULD NOT BE USED IN DELETING ORPHANS
************************************************************************
(venv) [root@mero006 s3_swift]# radosgw-admin user rm --uid=ericr.770 --purge-data
2024-04-22T06:18:51.387+0000 7f25c1411800  0 lifecycle: RGWLC::RGWPutLC() failed to acquire lock on lc.27, retry in 100ms, ret=-16
2024-04-22T06:18:51.550+0000 7f25c1411800  0 lifecycle: RGWLC::RGWPutLC() failed to acquire lock on lc.27, retry in 100ms, ret=-16
2024-04-22T06:18:51.692+0000 7f25c1411800  0 lifecycle: RGWLC::RGWPutLC() failed to acquire lock on lc.27, retry in 100ms, ret=-16
2024-04-22T06:18:51.837+0000 7f25c1411800  0 lifecycle: RGWLC::RGWPutLC() failed to acquire lock on lc.27, retry in 100ms, ret=-16
2024-04-22T06:18:51.978+0000 7f25c1411800  0 lifecycle: RGWLC::RGWPutLC() failed to acquire lock on lc.27, retry in 100ms, ret=-16
2024-04-22T06:18:52.125+0000 7f25c1411800  0 lifecycle: RGWLC::RGWPutLC() failed to acquire lock on lc.27, retry in 100ms, ret=-16
2024-04-22T06:18:52.270+0000 7f25c1411800  0 lifecycle: RGWLC::RGWPutLC() failed to acquire lock on lc.27, retry in 100ms, ret=-16
2024-04-22T06:18:52.436+0000 7f25c1411800  0 lifecycle: RGWLC::RGWPutLC() failed to acquire lock on lc.27, retry in 100ms, ret=-16
2024-04-22T06:18:52.578+0000 7f25c1411800  0 lifecycle: RGWLC::RGWPutLC() failed to acquire lock on lc.27, retry in 100ms, ret=-16
(venv) [root@mero006 s3_swift]# radosgw-admin user rm --uid=ericr.770 --purge-data
could not remove user: unable to remove user, user does not exist
(venv) [root@mero006 s3_swift]# radosgw-admin bucket radoslist | grep -i ERROR
ERROR: because there is at least one indexless bucket (jackieg.812-bucky-1443-0) the results of radoslist are incomplete; use --yes-i-really-mean-it to bypass error
ERROR: bucket radoslist failed to finish before encountering error: (22) Invalid argument
************************************************************************
WARNING: THE RESULTS ARE NOT RELIABLE AND SHOULD NOT BE USED IN DELETING ORPHANS
************************************************************************
(venv) [root@mero006 s3_swift]# radosgw-admin user rm --uid=jackieg.812 --purge-data
(venv) [root@mero006 s3_swift]# radosgw-admin bucket radoslist | grep -i ERROR
(venv) [root@mero006 s3_swift]#

post deleteing all index bucket triggered 

1. http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/test_indexless_buckets_s3.console.log
2. http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/test_bucket_radoslist.console.log

issue not seen