### PR TITLE
[TFA] increasing a sync check time a bit by 2m

### DIFF
--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -1987,8 +1987,8 @@ def verify_object_sync_on_other_site(rgw_ssh_con, bucket, config, bucket_object=
         log.info(
             f"object count mismatch found for bucket {bucket.name} : {site_bkt_objects} expected {bkt_objects}"
         )
-        log.info("Check after 60s")
-        time.sleep(60)
+        log.info("Check after 180s")
+        time.sleep(180)
         _, output, _ = rgw_ssh_con.exec_command(
             f"radosgw-admin bucket stats --bucket {bucket.name}"
         )


### PR DESCRIPTION
http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/openstack/RH/7.0/rhel-9/Weekly/18.2.0-191/rgw/38/sanity_rgw_multisite/Bucket_Granular_Sync_policy_tests_0.log

failure is due to time taken to sync object to another site. So  increasing a sync check time a bit by 2 more minutes

log: http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/test_multisite_granular_bucket_sync_policy.console.log

