### PR TITLE
Address TFA failure, s3cmd user profile switch needed

### DIFF
--- a/rgw/v2/tests/s3cmd/test_ratelimit_bucketowner.py
+++ b/rgw/v2/tests/s3cmd/test_ratelimit_bucketowner.py
@@ -138,6 +138,8 @@ def test_exec(config, ssh_con):
     rc = utils.exec_shell_cmd(
         f"radosgw-admin bucket chown --bucket {bucket_name} --uid {uname2}"
     )
+
+    s3_auth.do_auth(user_info[1], ip_and_port)
     # Test the bucket ratelimit is still valid
     log.info(f"Test the read ops limits")
     s3cmd_reusable.rate_limit_read(bucket_name, max_read_ops, ssl)


### PR DESCRIPTION
Due to 7.1 BZ on bucket owner change, we could not hit this TFA issue until now 
https://issues.redhat.com/browse/RHCEPHQE-14173

This change address this failure.
Pass log: http://magna002.ceph.redhat.com/ceph-qe-logs/tejas/ratelimit_ownerchange.txt