### PR TITLE
Fixing the Object-Size and ArchiveZone filter for LC rule

### DIFF
--- a/rgw/v2/tests/s3cmd/reusable.py
+++ b/rgw/v2/tests/s3cmd/reusable.py
@@ -406,6 +406,8 @@ def Generate_LC_xml(fileName, config):
     rule_filter = xml.SubElement(lc_rule, "Filter")
     if config.test_ops.get("test_lc_objects_size"):
         filter_and = xml.SubElement(rule_filter, "And")
+        if config.test_ops.get("test_lc_archive_zone"):
+            and_archive_zone = xml.SubElement(filter_and, "ArchiveZone")
         and_prefix = xml.SubElement(filter_and, "Prefix")
         and_ObjectSizeGreaterThan = xml.SubElement(filter_and, "ObjectSizeGreaterThan")
         and_ObjectSizeLessThan = xml.SubElement(filter_and, "ObjectSizeLessThan")


### PR DESCRIPTION
**Fixing the Object-Size and ArchiveZone filter for LC rule.**

passed logs http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-EJ5EI1



