### PR TITLE
Fixing the versioned bucket test on colocated archive zone

### DIFF
--- a/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_multipart_archive_colocated.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_multipart_archive_colocated.yaml
@@ -2,6 +2,7 @@
 # script: test_Mbuckets_with_Nobjects.py
 # CEPH-83573389
 config:
+  haproxy: true
   user_count: 1
   bucket_count: 2
   objects_count: 2


### PR DESCRIPTION
This test was run on rgw node of the archive zone hence the bucket creation was failing.
Adding haproxy config with backend rgw as the primary zone's, would fix the issue.

TFA jira ticket :(https://issues.redhat.com/browse/RHCEPHQE-14534)

cephci pr https://github.com/red-hat-storage/cephci/pull/3722
logs http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-HB5QEY