### PR TITLE
[Tier-3] CEPH-83581958 - Set sync policy to particular destination owner

### DIFF
--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_granularsync_owner_translation_direc.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_granularsync_owner_translation_direc.yaml
@@ -1,0 +1,32 @@
+# Polarian TC : CEPH-83581958
+# script: test_s3cmd_bucket_granular_sync_policy.py
+config:
+    user_count: 1
+    bucket_count: 1
+    objects_count: 100
+    objects_size_range:
+        min: 5K
+        max: 2M
+    test_ops:
+        dest_param_owner_translation: true
+        zonegroup_group: true
+        zonegroup_status: allowed
+        zonegroup_flow: true
+        zonegroup_flow_type: directional
+        zonegroup_source_zone: primary
+        zonegroup_dest_zone: secondary
+        zonegroup_source_zones: primary
+        zonegroup_dest_zones: secondary
+        zonegroup_pipe: true
+        bucket_group: true
+        bucket_status: enabled
+        bucket_flow: false
+        bucket_pipe: true
+        bucket_source_zones: primary
+        bucket_dest_zones: secondary
+        bucket_policy_details: --dest-owner=<dest_owner> --dest-bucket=<dest_bucket_name>
+        create_object: true
+        create_bucket: true
+        should_sync: false
+        write_io_verify_another_site: true
+        zonegroup_group_remove: true

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_granularsync_owner_translation_symm.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_granularsync_owner_translation_symm.yaml
@@ -1,0 +1,27 @@
+# Polarian TC : CEPH-83581958
+# script: test_s3cmd_bucket_granular_sync_policy.py
+config:
+    user_count: 1
+    bucket_count: 1
+    objects_count: 100
+    objects_size_range:
+        min: 5K
+        max: 2M
+    test_ops:
+        dest_param_owner_translation: true
+        zonegroup_group: true
+        zonegroup_status: allowed
+        zonegroup_flow: true
+        zonegroup_flow_type: symmetrical
+        zonegroup_pipe: true
+        bucket_group: true
+        bucket_status: enabled
+        bucket_flow: false
+        bucket_pipe: true
+        bucket_policy_details: --dest-owner=<dest_owner> --dest-bucket=<dest_bucket_name>
+        create_object: true
+        create_bucket: true
+        should_sync: false
+        write_io_verify_another_site: true
+        write_io_verify_should_sync: false
+        zonegroup_group_remove: true


### PR DESCRIPTION
Seeing issue of not found in http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/

Updated log a a attachment in https://issues.redhat.com/browse/RHCEPHQE-14527

[test_bucket_granularsync_owner_translation_symm.console.log](https://github.com/user-attachments/files/15709997/test_bucket_granularsync_owner_translation_symm.console.log)
[test_bucket_granularsync_owner_translation_direc.console.log](https://github.com/user-attachments/files/15709998/test_bucket_granularsync_owner_translation_direc.console.log)

script is dependent on : https://github.com/red-hat-storage/ceph-qe-scripts/pull/598
