### PR TITLE
[Tier-3] Create regular and Versioned bucket for future use

### DIFF
--- a/rgw/v2/tests/aws/configs/test_aws_regular_and_versioned_bucket_creation.yaml
+++ b/rgw/v2/tests/aws/configs/test_aws_regular_and_versioned_bucket_creation.yaml
@@ -1,5 +1,5 @@
 # script: test_aws.py
-# polarion-ID: CEPH-83575073 [PUT Workload] Test sync with 20M bi-directional with LB. (Versioned buckets)
+# polarion-ID: CEPH-83575382
 config:
   user_count: 1
   bucket_count: 1
@@ -10,5 +10,6 @@ config:
     max: 3M
   test_ops:
     user_name: cosbench01
-    bucket_name: cosbench01-bkt-
-    enable_version: true
+    reg_bucket_name: reg-cosbench-bkt-
+    ver_bucket_name: ver-cosbench-bkt-
+    regular_and_version: true


### PR DESCRIPTION
pre-requisite for [T3-automation]: CEPH-83575382 Scale on 2 zone mirror config verify 10M sync
log: 
[test_aws_regular_and_versioned_bucket_creation.console.log](https://github.com/user-attachments/files/15964722/test_aws_regular_and_versioned_bucket_creation.console.log)

changes does not effect other runs
[test_aws_non_ascii.console.log](https://github.com/user-attachments/files/15964721/test_aws_non_ascii.console.log)

[test_aws_versioned_bucket_creation.console.log](https://github.com/user-attachments/files/15964723/test_aws_versioned_bucket_creation.console.log)

[test_complete_multipart_upload_etag_not_empty.console.log](https://github.com/user-attachments/files/15964724/test_complete_multipart_upload_etag_not_empty.console.log)
