### PR TITLE
List Versioned bucket with marker entry

### DIFF
--- a/rgw/v2/tests/aws/configs/test_versioned_list_marker.yaml
+++ b/rgw/v2/tests/aws/configs/test_versioned_list_marker.yaml
@@ -1,0 +1,13 @@
+# script: test_aws.py
+# polarion-ID: CEPH-83572736
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 3
+  user_remove: true
+  objects_size_range:
+    min: 1M
+    max: 3M
+  test_ops:
+    versioned_list_objects_marker: true
+    enable_version: true

--- a/rgw/v2/tests/aws/reusable.py
+++ b/rgw/v2/tests/aws/reusable.py
@@ -512,3 +512,36 @@ def get_object(bucket_name, object_name, end_point, ssl=None):
         return get_response
     except Exception as e:
         raise AWSCommandExecError(message=str(e))
+
+
+def list_objects(bucket_name, endpoint, marker=None, ssl=None):
+    """
+    List all the objects in the bucket
+    Args:
+        bucket_name(str): Name of the bucket from which object needs to be listed
+        end_point(str): endpoint
+        marker(str): The key name from where the listing needs to start
+        ssl:
+    Return:
+        Returns details of every object in the bucket post the marker
+    """
+    get_method = AWS(operation="list-objects")
+    if ssl:
+        ssl_param = "-s"
+    else:
+        ssl_param = " "
+    if marker:
+        marker_param = marker
+    else:
+        marker_param = " "
+    command = get_method.command(
+        params=[
+            f"--bucket {bucket_name} --marker {marker_param} --endpoint-url {endpoint}",
+            ssl_param,
+        ]
+    )
+    try:
+        get_response = utils.exec_shell_cmd(command)
+        return get_response
+    except Exception as e:
+        raise AWSCommandExecError(message=str(e))


### PR DESCRIPTION
BZ : https://bugzilla.redhat.com/show_bug.cgi?id=1504291
Tracker : http://tracker.ceph.com/issues/21500

On a versioned bucket  with multiple objects, if a marker is passed to list objects , the list should return objects after the marker , and should not include the marker entry.

Pass log : http://magna002.ceph.redhat.com/cephci-jenkins/tchandra/Versioned_list_marker.txt