### PR TITLE
adding support for testing sse-kms with kmip backned and gklm key management server

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_sse_kms_kmip_gklm_per_bucket_encryption_multipart_object_upload.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_kms_kmip_gklm_per_bucket_encryption_multipart_object_upload.yaml
@@ -1,0 +1,23 @@
+# script: test_sse_s3_kms_with_vault.py
+# polarion-id: CEPH-83592485
+config:
+ user_count: 1
+ encryption_keys: kms
+ bucket_count: 2
+ objects_count: 25
+ local_file_delete: true
+ objects_size_range:
+  min: 6M
+  max: 15M
+ test_ops:
+  sse_kms_backend: kmip
+  key_management_tool: gklm
+  encrypt_decrypt_key: gkl001a174c2000000000
+  create_bucket: true
+  create_object: true
+  enable_version: false
+  sse_s3_per_bucket: true
+  upload_type: multipart
+  download_object: true
+  delete_bucket_object: true
+  delete_bucket_object_version: false

--- a/rgw/v2/tests/s3_swift/configs/test_sse_kms_kmip_gklm_per_bucket_encryption_normal_object_upload.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_kms_kmip_gklm_per_bucket_encryption_normal_object_upload.yaml
@@ -1,0 +1,22 @@
+# script: test_sse_s3_kms_with_vault.py
+# polarion-id: CEPH-83592485
+config:
+ user_count: 1
+ encryption_keys: kms
+ bucket_count: 2
+ objects_count: 25
+ objects_size_range:
+  min: 5
+  max: 15
+ test_ops:
+  sse_kms_backend: kmip
+  key_management_tool: gklm
+  encrypt_decrypt_key: gkl001a174c2000000000
+  create_bucket: true
+  create_object: true
+  enable_version: false
+  sse_s3_per_bucket: true
+  upload_type: normal
+  download_object: true
+  delete_bucket_object: true
+  delete_bucket_object_version: false

--- a/rgw/v2/tests/s3_swift/configs/test_sse_kms_kmip_gklm_per_bucket_encryption_version_enabled.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_kms_kmip_gklm_per_bucket_encryption_version_enabled.yaml
@@ -1,0 +1,22 @@
+# script: test_sse_s3_kms_with_vault.py
+# polarion-id: CEPH-83592485
+config:
+ user_count: 1
+ encryption_keys: kms
+ bucket_count: 2
+ objects_count: 25
+ objects_size_range:
+  min: 5
+  max: 15
+ test_ops:
+  sse_kms_backend: kmip
+  key_management_tool: gklm
+  encrypt_decrypt_key: gkl001a174c2000000000
+  create_bucket: true
+  create_object: true
+  enable_version: true
+  sse_s3_per_bucket: true
+  upload_type: normal
+  download_object: true
+  delete_bucket_object: false
+  delete_bucket_object_version: true

--- a/rgw/v2/tests/s3_swift/configs/test_sse_kms_kmip_gklm_per_object.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_kms_kmip_gklm_per_object.yaml
@@ -1,0 +1,21 @@
+# script: test_sse_s3_kms_with_vault.py
+# polarion-id: CEPH-83592485
+config:
+ user_count: 1
+ encryption_keys: kms
+ bucket_count: 2
+ objects_count: 25
+ objects_size_range:
+  min: 5
+  max: 15
+ test_ops:
+  sse_kms_backend: kmip
+  key_management_tool: gklm
+  encrypt_decrypt_key: gkl001a174c2000000000
+  create_bucket: true
+  create_object: true
+  enable_version: false
+  download_object: true
+  sse_s3_per_bucket: false
+  delete_bucket_object: true
+  delete_bucket_object_version: false

--- a/rgw/v2/tests/s3_swift/configs/test_sse_kms_kmip_gklm_per_object_versioninig_enabled.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_kms_kmip_gklm_per_object_versioninig_enabled.yaml
@@ -1,0 +1,21 @@
+# script: test_sse_s3_kms_with_vault.py
+# polarion-id: CEPH-83592485
+config:
+ user_count: 1
+ encryption_keys: kms
+ bucket_count: 2
+ objects_count: 25
+ objects_size_range:
+  min: 5
+  max: 15
+ test_ops:
+  sse_kms_backend: kmip
+  key_management_tool: gklm
+  encrypt_decrypt_key: gkl001a174c2000000000
+  create_bucket: true
+  create_object: true
+  enable_version: true
+  sse_s3_per_bucket: false
+  download_object: true
+  delete_bucket_object: false
+  delete_bucket_object_version: true

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_sse_kms_kmip_gklm_per_bucket_encryption_multipart_object_upload.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_sse_kms_kmip_gklm_per_bucket_encryption_multipart_object_upload.yaml
@@ -1,0 +1,1 @@
+../configs/test_sse_kms_kmip_gklm_per_bucket_encryption_multipart_object_upload.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_sse_kms_kmip_gklm_per_bucket_encryption_normal_object_upload.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_sse_kms_kmip_gklm_per_bucket_encryption_normal_object_upload.yaml
@@ -1,0 +1,1 @@
+../configs/test_sse_kms_kmip_gklm_per_bucket_encryption_normal_object_upload.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_sse_kms_kmip_gklm_per_bucket_encryption_version_enabled.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_sse_kms_kmip_gklm_per_bucket_encryption_version_enabled.yaml
@@ -1,0 +1,1 @@
+../configs/test_sse_kms_kmip_gklm_per_bucket_encryption_version_enabled.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_sse_kms_kmip_gklm_per_object.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_sse_kms_kmip_gklm_per_object.yaml
@@ -1,0 +1,1 @@
+../configs/test_sse_kms_kmip_gklm_per_object.yaml

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_sse_kms_kmip_gklm_per_object_versioninig_enabled.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_sse_kms_kmip_gklm_per_object_versioninig_enabled.yaml
@@ -1,0 +1,1 @@
+../configs/test_sse_kms_kmip_gklm_per_object_versioninig_enabled.yaml

--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -236,7 +236,10 @@ def upload_object(
             args.append(extra_args)
         elif config.encryption_keys == "kms":
             log.info("SSE KMS encryption method applied with vault backend")
-            extra_args = {"ServerSideEncryption": "aws:kms", "SSEKMSKeyId": "testKey01"}
+            extra_args = {
+                "ServerSideEncryption": "aws:kms",
+                "SSEKMSKeyId": config.test_ops.get("encrypt_decrypt_key", "testKey01"),
+            }
             args.append(extra_args)
     object_uploaded_status = s3lib.resource_op(
         {


### PR DESCRIPTION
polarion: https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83592485

pass logs:
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_gklm/cephci-run-L6I9ET/
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_gklm/cephci-run-H4PGL5/