### PR TITLE
[Hotfix][MOD]: testing multipart upload with failed upload parts

### DIFF
--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -12,6 +12,7 @@ import logging
 import math
 import time
 import timeit
+from threading import Thread
 
 import configobj
 import v2.lib.manage_data as manage_data
@@ -593,6 +594,124 @@ def upload_mutipart_object(
         log.info("all parts upload completed")
         mpu.complete(MultipartUpload=parts_info)
         log.info("multipart upload complete for key: %s" % s3_object_name)
+
+
+def upload_part(
+    rgw_client,
+    s3_object_name,
+    bucket_name,
+    mpu,
+    part_number,
+    body,
+    content_length,
+    parts_info,
+):
+    try:
+        part_upload_response = rgw_client.upload_part(
+            Bucket=bucket_name,
+            Key=s3_object_name,
+            PartNumber=part_number,
+            UploadId=mpu["UploadId"],
+            Body=body,
+            ContentLength=content_length,
+        )
+        log.info(f"part uploaded response {part_upload_response}")
+    except Exception as e:
+        log.info(e)
+        return
+    part_info = {"PartNumber": part_number, "ETag": part_upload_response["ETag"]}
+    parts_info["Parts"].append(part_info)
+
+
+def test_multipart_upload_failed_parts(
+    rgw_client, s3_object_name, bucket_name, part1_path, part2_path
+):
+    parts_info = {"Parts": []}
+    log.info("no of parts: 2")
+
+    log.info("initiating multipart upload")
+    mpu = rgw_client.create_multipart_upload(Bucket=bucket_name, Key=s3_object_name)
+
+    part_number = 1
+    log.info(f"trying to upload part {part_number}")
+    part_upload_response = rgw_client.upload_part(
+        Bucket=bucket_name,
+        Key=s3_object_name,
+        PartNumber=part_number,
+        UploadId=mpu["UploadId"],
+        Body=open(part1_path, mode="rb"),
+    )
+    log.info(f"part uploaded response {part_upload_response}")
+    part_info = {
+        "PartNumber": part_number,
+        "ETag": part_upload_response["ETag"],
+    }
+    parts_info["Parts"].append(part_info)
+
+    part_number = 2
+    log.info(
+        f"trying to upload part {part_number} with three clients parallely out of which only one is success"
+    )
+    t1 = Thread(
+        target=upload_part,
+        args=(
+            rgw_client,
+            s3_object_name,
+            bucket_name,
+            mpu,
+            part_number,
+            open("/tmp/obj20MB", mode="rb"),
+            12582912,
+            parts_info,
+        ),
+    )
+    t2 = Thread(
+        target=upload_part,
+        args=(
+            rgw_client,
+            s3_object_name,
+            bucket_name,
+            mpu,
+            part_number,
+            open("/tmp/obj30MB", mode="rb"),
+            12582912,
+            parts_info,
+        ),
+    )
+    t3 = Thread(
+        target=upload_part,
+        args=(
+            rgw_client,
+            s3_object_name,
+            bucket_name,
+            mpu,
+            part_number,
+            open(part2_path, mode="rb"),
+            os.stat(part2_path).st_size,
+            parts_info,
+        ),
+    )
+
+    t1.start()
+    t2.start()
+    t3.start()
+
+    t3.join()
+    t1.join()
+    t2.join()
+
+    if len(parts_info["Parts"]) == part_number:
+        log.info("all parts upload completed")
+        response = rgw_client.complete_multipart_upload(
+            Bucket=bucket_name,
+            Key=s3_object_name,
+            UploadId=mpu["UploadId"],
+            MultipartUpload=parts_info,
+        )
+        log.info(f"complete multipart upload: {response}")
+        log.info(f"multipart upload complete for key: {s3_object_name}")
+    else:
+        raise Exception("Multipart upload for part2 failed")
 
 
 def enable_versioning(bucket, rgw_conn, user_info, write_bucket_io_info):

--- a/rgw/v2/tests/s3cmd/configs/test_multipart_upload_with_failed_parts_using_s3cmd_and_boto3.yaml
+++ b/rgw/v2/tests/s3cmd/configs/test_multipart_upload_with_failed_parts_using_s3cmd_and_boto3.yaml
@@ -1,0 +1,13 @@
+# test case id: CEPH-83589550
+# BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2262650
+# BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2266680
+# test_script: test_s3cmd.py
+config:
+  user_count: 1
+  bucket_count: 2
+  objects_count: 100
+  objects_size_range:
+    min: 108M
+    max: 108M
+  test_ops:
+    test_multipart_upload_with_failed_upload_parts: true


### PR DESCRIPTION
polarion: https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83589550
hotfix bz: https://bugzilla.redhat.com/show_bug.cgi?id=2262650
failed parts not deleted bz: https://bugzilla.redhat.com/show_bug.cgi?id=2266680

pass logs on 7.1:
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/mod_multipart_hotfix/test_multipart_upload_with_failed_parts_using_s3cmd_and_boto3.console.log_7.1
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/mod_multipart_hotfix/cephci-run-XHFYNI/

fail logs on 5.3z6:
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/mod_multipart_hotfix/test_multipart_upload_with_failed_parts_using_s3cmd_and_boto3.console.log_5.3_z6

sample pass log on 5.3z6 with only 10 iterations:
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/mod_multipart_hotfix/cephci-run-KR7AF8/