### PR TITLE
Adding bucket notification for archive zone for ObjectSync events

### DIFF
--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_broker_archive_delete_replication_from_pri.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_notification_kafka_broker_archive_delete_replication_from_pri.yaml
@@ -1,0 +1,24 @@
+# test case CEPH-83575922
+# script test_bucket_notifications.py
+config:
+ user_count: 1
+ bucket_count: 1
+ objects_count: 10
+ objects_size_range:
+  min: 5
+  max: 15
+ test_ops:
+  create_bucket: true
+  create_object: true
+  enable_version: false
+  test_delete_object_sync_archive: true
+  create_topic: true
+  get_topic_info: true
+  endpoint: kafka
+  ack_type: broker
+  put_get_bucket_notification: true
+  event_type:
+    - MultisiteReplication
+  upload_type: normal
+  delete_bucket_object: false
+  sync_source_zone_master: True

--- a/rgw/v2/tests/s3_swift/test_bucket_notifications.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_notifications.py
@@ -24,6 +24,7 @@ Usage: test_bucket_notification.py -c <input_yaml>
     test_bucket_notification_kafka_broker_persistent_dynamic_reshard.yaml
     test_bucket_notification_kafka_broker_persistent_manual_reshard.yaml
     test_sse_s3_per_bucket_with_notifications_dynamic_reshard.yaml
+    multisite_configs/test_bucket_notification_kafka_broker_archive_delete_replication_from_pri.yaml
 Operation:
     create user (tenant/non-tenant)
     Create topic and get topic
@@ -306,7 +307,10 @@ def test_exec(config, ssh_con):
                     )
                     if status is None:
                         raise TestExecError("copy object failed")
-
+                # delete objects
+                if config.test_ops.get("test_delete_object_sync_archive", False):
+                    bucket_resource = other_site_bucket
+                    reusable.delete_objects(bucket_resource)
                 # delete objects
                 if config.test_ops.get("delete_bucket_object", False):
                     if config.test_ops.get("enable_version", False):
@@ -343,7 +347,9 @@ def test_exec(config, ssh_con):
                         bucket_name_for_verification,
                         event_record_path,
                         ceph_version_name,
+                        config,
                     )
+
                     if verify is False:
                         raise EventRecordDataError(
                             "Event record is empty! notification is not seen"


### PR DESCRIPTION
Adding bucket notification for archive zone for ObjectSync events
This includes Object create and object delete at the active site, for which the notifications will happen for Create events but not for delete events at the archive zone.

Pass logs for bucket notification with archive zone :
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-QQCCFE

dependent cephci pr https://github.com/red-hat-storage/cephci/pull/3860

Ticket https://issues.redhat.com/browse/RHCEPHQE-14898
