### PR TITLE
[hotfix][apple] testing sts session policy behaviour for actions like batch deletes

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_bucket_policy_deny_actions.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_policy_deny_actions.yaml
@@ -1,0 +1,40 @@
+# script: test_bucket_policy_ops.py
+# bucket policy deny actions
+# polarion id: CEPH-11216
+config:
+  objects_count: 25
+  objects_size_range:
+    min: 5
+    max: 15
+  encryption_keys: kms
+  lifecycle_conf:
+    - ID: LC_Rule_1
+      Filter:
+        Prefix: key2
+      Status: Enabled
+      Expiration:
+        Days: 20
+  test_ops:
+    upload_type: normal
+    verify_policy: True
+    endpoint: kafka
+    ack_type: broker
+    bucket_tags: [
+      {
+          "Key": "product",
+          "Value": "ceph"
+      }
+    ]
+    policy_document:
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Action": ["s3:PutObject", "s3:ListBucket", "s3:GetObject", "s3:DeleteObject", "s3:AbortMultipartUpload", "s3:PutBucketVersioning", "s3:GetBucketVersioning", "s3:PutBucketWebsite", "s3:GetBucketWebsite", "s3:PutLifecycleConfiguration", "s3:GetLifecycleConfiguration", "s3:PutBucketEncryption", "s3:GetBucketEncryption", "s3:PutBucketNotification", "s3:GetBucketNotification", "s3:PutBucketTagging", "s3:GetBucketTagging", "s3:DeleteBucket", "s3:CreateBucket", "s3:PutBucketPolicy", "s3:GetBucketPolicy", "s3:DeleteBucketPolicy"],
+            "Principal": {"AWS": "arn:aws:iam::<tenant_name>:user/<user_name>"},
+            "Resource": "arn:aws:s3:::*",
+            "Effect": "Deny",
+            "Sid": "statement1",
+          }
+        ],
+      }

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_policy_multiple_statements.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_policy_multiple_statements.yaml
@@ -6,31 +6,47 @@ config:
   objects_size_range:
     min: 5
     max: 15
+  encryption_keys: kms
+  lifecycle_conf:
+    - ID: LC_Rule_1
+      Filter:
+        Prefix: key2
+      Status: Enabled
+      Expiration:
+        Days: 20
   test_ops:
     upload_type: normal
     verify_policy: True
+    endpoint: kafka
+    ack_type: broker
+    bucket_tags: [
+      {
+          "Key": "product",
+          "Value": "ceph"
+      }
+    ]
     policy_document:
       {
         "Version": "2012-10-17",
         "Statement": [
           {
-            "Action": ["s3:GetObject", "s3:DeleteObject", "s3:PutObject", "s3:AbortMultipartUpload"],
+            "Action": ["s3:PutObject", "s3:ListBucket", "s3:GetObject", "s3:DeleteObject", "s3:AbortMultipartUpload"],
             "Principal": {"AWS": "arn:aws:iam::<tenant_name>:user/<user_name>"},
-            "Resource": "arn:aws:s3:::<bucket_name>/*",
+            "Resource": "arn:aws:s3:::*",
             "Effect": "Allow",
             "Sid": "statement1",
           },
           {
             "Action": "s3:DeleteBucket",
             "Principal": {"AWS": "arn:aws:iam::<tenant_name>:user/<user_name>"},
-            "Resource": "arn:aws:s3:::<bucket_name>",
+            "Resource": "arn:aws:s3:::*",
             "Effect": "Deny",
             "Sid": "statement2",
           },
           {
-            "Action": ["s3:PutBucketVersioning", "s3:GetBucketVersioning", "s3:PutBucketPolicy", "s3:GetBucketPolicy", "s3:DeleteBucketPolicy"],
+            "Action": ["s3:PutBucketVersioning", "s3:GetBucketVersioning", "s3:PutBucketWebsite", "s3:GetBucketWebsite", "s3:PutLifecycleConfiguration", "s3:GetLifecycleConfiguration", "s3:PutBucketEncryption", "s3:GetBucketEncryption", "s3:PutBucketNotification", "s3:GetBucketNotification", "s3:PutBucketTagging", "s3:GetBucketTagging", "s3:PutBucketPolicy", "s3:GetBucketPolicy", "s3:DeleteBucketPolicy"],
             "Principal": {"AWS": "arn:aws:iam::<tenant_name>:user/<user_name>"},
-            "Resource": "arn:aws:s3:::<bucket_name>",
+            "Resource": "arn:aws:s3:::*",
             "Effect": "Allow",
             "Sid": "statement3",
           }

--- a/rgw/v2/tests/s3_swift/configs/test_sts_aswi_verify_role_policy_allow_actions.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_aswi_verify_role_policy_allow_actions.yaml
@@ -1,0 +1,51 @@
+# polarion test case id: CEPH-83593390
+# test scripts : test_sts_aswi.py
+config:
+     bucket_count: 2
+     objects_count: 50
+     objects_size_range:
+          min: 5
+          max: 15
+     encryption_keys: kms
+     lifecycle_conf:
+        - ID: LC_Rule_1
+          Filter:
+            Prefix: key2
+          Status: Enabled
+          Expiration:
+            Days: 20
+     test_ops:
+          create_bucket: true
+          create_object: true
+          endpoint: kafka
+          ack_type: broker
+          verify_policy: role_policy
+          bucket_tags: [
+              {
+                  "Key": "product",
+                  "Value": "ceph"
+              }
+          ]
+     sts:
+          policy_document:
+                "Version": "2012-10-17"
+                "Statement": [
+                    {
+                         "Effect": "Allow",
+                         "Principal": {
+                           "Federated": ["arn:aws:iam:::oidc-provider/ip_addr:8180/realms/master"]
+                         },
+                         "Action": ["sts:AssumeRoleWithWebIdentity"],
+                    }
+                ]
+          role_policy:
+               "Version": "2012-10-17"
+               "Statement":
+                [
+                    {
+                         "Action": ["s3:PutObject", "s3:ListBucket", "s3:GetObject", "s3:DeleteObject", "s3:AbortMultipartUpload", "s3:PutBucketVersioning", "s3:GetBucketVersioning", "s3:PutBucketNotification", "s3:GetBucketNotification", "s3:PutBucketPolicy", "s3:GetBucketPolicy", "s3:DeleteBucketPolicy", "s3:PutBucketWebsite", "s3:GetBucketWebsite", "s3:PutLifecycleConfiguration", "s3:GetLifecycleConfiguration", "s3:PutBucketEncryption", "s3:GetBucketEncryption", "s3:PutBucketTagging", "s3:GetBucketTagging", "s3:DeleteBucket", "s3:CreateBucket"],
+                         "Resource": "arn:aws:s3:::*",
+                         "Effect": "Allow",
+                         "Sid": "statement1",
+                    },
+               ]

--- a/rgw/v2/tests/s3_swift/configs/test_sts_aswi_verify_role_policy_deny_actions.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_aswi_verify_role_policy_deny_actions.yaml
@@ -1,0 +1,51 @@
+# polarion test case id: CEPH-83593390
+# test scripts : test_sts_aswi.py
+config:
+     bucket_count: 2
+     objects_count: 50
+     objects_size_range:
+          min: 5
+          max: 15
+     encryption_keys: kms
+     lifecycle_conf:
+        - ID: LC_Rule_1
+          Filter:
+            Prefix: key2
+          Status: Enabled
+          Expiration:
+            Days: 20
+     test_ops:
+          create_bucket: true
+          create_object: true
+          endpoint: kafka
+          ack_type: broker
+          verify_policy: role_policy
+          bucket_tags: [
+              {
+                  "Key": "product",
+                  "Value": "ceph"
+              }
+          ]
+     sts:
+          policy_document:
+                "Version": "2012-10-17"
+                "Statement": [
+                    {
+                         "Effect": "Allow",
+                         "Principal": {
+                           "Federated": ["arn:aws:iam:::oidc-provider/ip_addr:8180/realms/master"]
+                         },
+                         "Action": ["sts:AssumeRoleWithWebIdentity"],
+                    }
+                ]
+          role_policy:
+               "Version": "2012-10-17"
+               "Statement":
+                [
+                    {
+                         "Action": ["s3:PutObject", "s3:ListBucket", "s3:GetObject", "s3:DeleteObject", "s3:AbortMultipartUpload", "s3:PutBucketVersioning", "s3:GetBucketVersioning", "s3:PutBucketNotification", "s3:GetBucketNotification", "s3:PutBucketPolicy", "s3:GetBucketPolicy", "s3:DeleteBucketPolicy", "s3:PutBucketWebsite", "s3:GetBucketWebsite", "s3:PutLifecycleConfiguration", "s3:GetLifecycleConfiguration", "s3:PutBucketEncryption", "s3:GetBucketEncryption", "s3:PutBucketTagging", "s3:GetBucketTagging", "s3:DeleteBucket", "s3:CreateBucket"],
+                         "Resource": "arn:aws:s3:::*",
+                         "Effect": "Deny",
+                         "Sid": "statement1",
+                    }
+               ]

--- a/rgw/v2/tests/s3_swift/configs/test_sts_using_boto_verify_session_policy_allow_actions.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_using_boto_verify_session_policy_allow_actions.yaml
@@ -1,0 +1,62 @@
+# polarion test case id: CEPH-83593390
+# test scripts : test_sts_using_boto_session_policy.py
+config:
+     bucket_count: 2
+     objects_count: 25
+     objects_size_range:
+          min: 5
+          max: 15
+     encryption_keys: kms
+     lifecycle_conf:
+        - ID: LC_Rule_1
+          Filter:
+            Prefix: key2
+          Status: Enabled
+          Expiration:
+            Days: 20
+     test_ops:
+          create_bucket: true
+          create_object: true
+          endpoint: kafka
+          ack_type: broker
+          verify_policy: session_policy
+          bucket_tags: [
+              {
+                  "Key": "product",
+                  "Value": "ceph"
+              }
+          ]
+     sts:
+          policy_document:
+               "Version": "2012-10-17"
+               "Statement":
+                    [
+                         {
+                              "Effect": "Allow",
+                              "Principal":
+                                   {
+                                        "AWS":
+                                             ["arn:aws:iam:::user/<user_name>"],
+                                   },
+                              "Action": ["sts:AssumeRole"],
+                         },
+                    ]
+          role_policy:
+               "Version": "2012-10-17"
+               "Statement":
+                    {
+                         "Effect": "Allow",
+                         "Action": "s3:*",
+                         "Resource": "arn:aws:s3:::*",
+                    }
+          session_policy:
+               "Version": "2012-10-17"
+               "Statement":
+                [
+                    {
+                         "Action": ["s3:PutObject", "s3:ListBucket", "s3:GetObject", "s3:DeleteObject", "s3:AbortMultipartUpload", "s3:PutBucketVersioning", "s3:GetBucketVersioning", "s3:PutBucketPolicy", "s3:GetBucketPolicy", "s3:DeleteBucketPolicy", "s3:PutBucketWebsite", "s3:GetBucketWebsite", "s3:PutLifecycleConfiguration", "s3:GetLifecycleConfiguration", "s3:PutBucketEncryption", "s3:GetBucketEncryption", "s3:PutBucketNotification", "s3:GetBucketNotification", "s3:PutBucketTagging", "s3:GetBucketTagging", "s3:DeleteBucket", "s3:CreateBucket"],
+                         "Resource": "arn:aws:s3:::*",
+                         "Effect": "Allow",
+                         "Sid": "statement4",
+                    }
+               ]

--- a/rgw/v2/tests/s3_swift/configs/test_sts_using_boto_verify_session_policy_allow_put_object_and_deny_abort_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_using_boto_verify_session_policy_allow_put_object_and_deny_abort_multipart.yaml
@@ -1,0 +1,69 @@
+# polarion test case id: CEPH-83593390
+# bz: https://bugzilla.redhat.com/show_bug.cgi?id=2302541
+# test scripts : test_sts_using_boto_session_policy.py
+config:
+     bucket_count: 2
+     objects_count: 25
+     objects_size_range:
+          min: 5
+          max: 15
+     encryption_keys: kms
+     lifecycle_conf:
+        - ID: LC_Rule_1
+          Filter:
+            Prefix: key2
+          Status: Enabled
+          Expiration:
+            Days: 20
+     test_ops:
+          create_bucket: true
+          create_object: true
+          endpoint: kafka
+          ack_type: broker
+          verify_policy: session_policy
+          bucket_tags: [
+              {
+                  "Key": "product",
+                  "Value": "ceph"
+              }
+          ]
+     sts:
+          policy_document:
+               "Version": "2012-10-17"
+               "Statement":
+                    [
+                         {
+                              "Effect": "Allow",
+                              "Principal":
+                                   {
+                                        "AWS":
+                                             ["arn:aws:iam:::user/<user_name>"],
+                                   },
+                              "Action": ["sts:AssumeRole"],
+                         },
+                    ]
+          role_policy:
+               "Version": "2012-10-17"
+               "Statement":
+                    {
+                         "Effect": "Allow",
+                         "Action": "s3:*",
+                         "Resource": "arn:aws:s3:::*",
+                    }
+          session_policy:
+               "Version": "2012-10-17"
+               "Statement":
+                [
+                    {
+                         "Action": ["s3:PutObject"],
+                         "Resource": "arn:aws:s3:::*",
+                         "Effect": "Allow",
+                         "Sid": "statement1",
+                    },
+                    {
+                         "Action": ["s3:AbortMultipartUpload"],
+                         "Resource": "arn:aws:s3:::*",
+                         "Effect": "Deny",
+                         "Sid": "statement2",
+                    }
+               ]

--- a/rgw/v2/tests/s3_swift/configs/test_sts_using_boto_verify_session_policy_deny_actions.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_using_boto_verify_session_policy_deny_actions.yaml
@@ -1,0 +1,62 @@
+# polarion test case id: CEPH-83593390
+# test scripts : test_sts_using_boto_session_policy.py
+config:
+     bucket_count: 2
+     objects_count: 25
+     objects_size_range:
+          min: 5
+          max: 15
+     encryption_keys: kms
+     lifecycle_conf:
+        - ID: LC_Rule_1
+          Filter:
+            Prefix: key2
+          Status: Enabled
+          Expiration:
+            Days: 20
+     test_ops:
+          create_bucket: true
+          create_object: true
+          endpoint: kafka
+          ack_type: broker
+          verify_policy: session_policy
+          bucket_tags: [
+              {
+                  "Key": "product",
+                  "Value": "ceph"
+              }
+          ]
+     sts:
+          policy_document:
+               "Version": "2012-10-17"
+               "Statement":
+                    [
+                         {
+                              "Effect": "Allow",
+                              "Principal":
+                                   {
+                                        "AWS":
+                                             ["arn:aws:iam:::user/<user_name>"],
+                                   },
+                              "Action": ["sts:AssumeRole"],
+                         },
+                    ]
+          role_policy:
+               "Version": "2012-10-17"
+               "Statement":
+                    {
+                         "Effect": "Allow",
+                         "Action": "s3:*",
+                         "Resource": "arn:aws:s3:::*",
+                    }
+          session_policy:
+               "Version": "2012-10-17"
+               "Statement":
+                [
+                    {
+                         "Action": ["s3:PutObject", "s3:ListBucket", "s3:GetObject", "s3:DeleteObject", "s3:AbortMultipartUpload", "s3:PutBucketVersioning", "s3:GetBucketVersioning", "s3:PutBucketPolicy", "s3:GetBucketPolicy", "s3:DeleteBucketPolicy", "s3:PutBucketWebsite", "s3:GetBucketWebsite", "s3:PutLifecycleConfiguration", "s3:GetLifecycleConfiguration", "s3:PutBucketEncryption", "s3:GetBucketEncryption", "s3:PutBucketNotification", "s3:GetBucketNotification", "s3:PutBucketTagging", "s3:GetBucketTagging", "s3:DeleteBucket", "s3:CreateBucket"],
+                         "Resource": "arn:aws:s3:::*",
+                         "Effect": "Deny",
+                         "Sid": "statement1",
+                    }
+               ]

--- a/rgw/v2/tests/s3_swift/configs/test_sts_using_boto_verify_session_policy_deny_sns_topic_actions.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_using_boto_verify_session_policy_deny_sns_topic_actions.yaml
@@ -1,0 +1,63 @@
+# polarion test case id: CEPH-83593390
+# bz: https://bugzilla.redhat.com/show_bug.cgi?id=2293233
+# test scripts : test_sts_using_boto_session_policy.py
+config:
+     bucket_count: 2
+     objects_count: 25
+     objects_size_range:
+          min: 5
+          max: 15
+     encryption_keys: kms
+     lifecycle_conf:
+        - ID: LC_Rule_1
+          Filter:
+            Prefix: key2
+          Status: Enabled
+          Expiration:
+            Days: 20
+     test_ops:
+          create_bucket: true
+          create_object: true
+          endpoint: kafka
+          ack_type: broker
+          verify_policy: session_policy
+          bucket_tags: [
+              {
+                  "Key": "product",
+                  "Value": "ceph"
+              }
+          ]
+     sts:
+          policy_document:
+               "Version": "2012-10-17"
+               "Statement":
+                    [
+                         {
+                              "Effect": "Allow",
+                              "Principal":
+                                   {
+                                        "AWS":
+                                             ["arn:aws:iam:::user/<user_name>"],
+                                   },
+                              "Action": ["sts:AssumeRole"],
+                         },
+                    ]
+          role_policy:
+               "Version": "2012-10-17"
+               "Statement":
+                    {
+                         "Effect": "Allow",
+                         "Action": "s3:*",
+                         "Resource": "arn:aws:s3:::*",
+                    }
+          session_policy:
+               "Version": "2012-10-17"
+               "Statement":
+                [
+                    {
+                         "Action": ["sns:CreateTopic", "sns:DeleteTopic"],
+                         "Resource": "*",
+                         "Effect": "deny",
+                         "Sid": "statement1",
+                    },
+               ]

--- a/rgw/v2/tests/s3_swift/reusables/bucket_policy_ops.py
+++ b/rgw/v2/tests/s3_swift/reusables/bucket_policy_ops.py
@@ -1,41 +1,60 @@
 import json
 import logging
+import random
+import time
 
 import v2.lib.resource_op as s3lib
 from v2.lib.exceptions import TestExecError
+from v2.tests.s3_swift import reusable
+from v2.tests.s3_swift.reusables import bucket_notification as notification
+from v2.tests.s3_swift.reusables import server_side_encryption_s3 as sse_s3
 from v2.utils.utils import HttpResponseParser
 
 log = logging.getLogger()
+topic_arn = None
 
 
 # s3 actions verification
 
 
+def classify_response(response):
+    if response:
+        resp = HttpResponseParser(response)
+        if resp.status_code == 200 or resp.status_code == 204:
+            return True
+        else:
+            return False
+    else:
+        return False
+
+
 def AbortMultipartUpload(**kw):
+    bucket_owner_rgw_client = kw.get("bucket_owner_rgw_client")
     rgw_client = kw.get("rgw_client")
     bucket_name = kw.get("bucket_name")
     object_name = kw.get("object_name")
     object_name = f"{object_name}_verify_abort_multipart"
     out = CreateMultipartUpload(
-        rgw_client=rgw_client,
+        rgw_client=bucket_owner_rgw_client,
         bucket_name=bucket_name,
         object_name=object_name,
     )
-    if out:
-        response = HttpResponseParser(out)
-        if response.status_code != 200 and response.status_code != 204:
-            raise TestExecError("Create Multipart upload failed")
-    else:
-        raise TestExecError("Create Multipart upload failed")
+    if classify_response(out) is False:
+        raise TestExecError("Create Multipart upload failed with bucket owner client")
     upload_id = out["UploadId"]
 
+    log.info("sleeping for 5 seconds")
+    time.sleep(5)
+
     log.info("Aborting multipart upload")
-    abort_multipart_status = rgw_client.abort_multipart_upload(
-        Bucket=bucket_name,
-        Key=object_name,
-        UploadId=upload_id,
+    abort_multipart_status = s3lib.resource_op(
+        {
+            "obj": rgw_client,
+            "resource": "abort_multipart_upload",
+            "kwargs": dict(Bucket=bucket_name, Key=object_name, UploadId=upload_id),
+        }
     )
-    log.info(abort_multipart_status)
+    log.info(f"abort_multipart_status: {abort_multipart_status}")
     return abort_multipart_status
 
 
@@ -49,7 +68,7 @@ def CreateMultipartUpload(**kw):
         Bucket=bucket_name,
         Key=object_name,
     )
-    log.info(response)
+    log.info(f"response: {response}")
     return response
 
 
@@ -64,8 +83,23 @@ def DeleteBucketPolicy(**kw):
             "kwargs": dict(Bucket=bucket_name),
         }
     )
-    log.info(delete_policy_status)
+    log.info(f"delete_policy_status: {delete_policy_status}")
     return delete_policy_status
+
+
+def CreateBucket(**kw):
+    rgw_client = kw.get("rgw_client")
+    bucket_name = kw.get("bucket_name")
+    log.info(f"creating bucket: {bucket_name}")
+    create_bucket_status = s3lib.resource_op(
+        {
+            "obj": rgw_client,
+            "resource": "create_bucket",
+            "kwargs": dict(Bucket=bucket_name),
+        }
+    )
+    log.info(f"create_bucket_status: {create_bucket_status}")
+    return create_bucket_status
 
 
 def DeleteBucket(**kw):
@@ -79,24 +113,51 @@ def DeleteBucket(**kw):
             "kwargs": dict(Bucket=bucket_name),
         }
     )
-    log.info(delete_bucket_status)
+    log.info(f"delete_bucket_status: {delete_bucket_status}")
     return delete_bucket_status
 
 
 def DeleteObject(**kw):
     rgw_client = kw.get("rgw_client")
+    bucket_owner_rgw_client = kw.get("bucket_owner_rgw_client")
     bucket_name = kw.get("bucket_name")
     object_name = kw.get("object_name")
+    effect = kw.get("effect")
     log.info(f"s3 object name to delete: {object_name}")
-    object_get_status = s3lib.resource_op(
+    object_delete_response = s3lib.resource_op(
         {
             "obj": rgw_client,
             "resource": "delete_object",
             "kwargs": dict(Bucket=bucket_name, Key=object_name),
         }
     )
-    log.info(object_get_status)
-    return object_get_status
+    log.info(f"object_delete_response: {object_delete_response}")
+    object_delete_status = classify_response(object_delete_response)
+
+    list_objects_response = ListBucket(
+        rgw_client=bucket_owner_rgw_client, bucket_name=bucket_name
+    )
+    if classify_response(list_objects_response) is False:
+        raise TestExecError("list objects failed with bucket owner client")
+    objects_dict = {"Objects": []}
+    for key in list_objects_response["Contents"]:
+        key_dict = {"Key": key["Key"]}
+        objects_dict["Objects"].append(key_dict)
+
+    log.info(f"s3 objects to delete: {objects_dict}")
+    objects_delete_response = s3lib.resource_op(
+        {
+            "obj": rgw_client,
+            "resource": "delete_objects",
+            "kwargs": dict(Bucket=bucket_name, Delete=objects_dict),
+        }
+    )
+    log.info(f"objects_delete_response: {objects_delete_response}")
+    objects_delete_status = classify_response(objects_delete_response)
+    if effect == "Allow":
+        return object_delete_status and objects_delete_status
+    else:
+        return object_delete_status or objects_delete_status
 
 
 def GetBucketPolicy(**kw):
@@ -110,7 +171,7 @@ def GetBucketPolicy(**kw):
             "kwargs": dict(Bucket=bucket_name),
         }
     )
-    log.info(get_policy_status)
+    log.info(f"get_policy_status: {get_policy_status}")
     return get_policy_status
 
 
@@ -125,7 +186,7 @@ def GetBucketVersioning(**kw):
             "kwargs": dict(Bucket=bucket_name),
         }
     )
-    log.info(get_versioning_status)
+    log.info(f"get_versioning_status: {get_versioning_status}")
     return get_versioning_status
 
 
@@ -141,7 +202,7 @@ def GetObject(**kw):
             "kwargs": dict(Bucket=bucket_name, Key=object_name),
         }
     )
-    log.info(object_get_status)
+    log.info(f"object_get_status: {object_get_status}")
     return object_get_status
 
 
@@ -162,7 +223,7 @@ def ListBucket(**kw):
             "kwargs": kwargs,
         }
     )
-    log.info(objects)
+    log.info(f"list objects response: {objects}")
     return objects
 
 
@@ -171,7 +232,9 @@ def PutBucketPolicy(**kw):
     rgw_client = kw.get("rgw_client")
     bucket_name = kw.get("bucket_name")
     log.info(f"put bucket policy for bucket: {bucket_name}")
-    policy = json.dumps(config.test_ops["policy_document"])
+    policy = json.dumps(
+        kw.get("policy_document", config.test_ops.get("policy_document", {}))
+    )
     policy_put_status = s3lib.resource_op(
         {
             "obj": rgw_client,
@@ -179,7 +242,7 @@ def PutBucketPolicy(**kw):
             "kwargs": dict(Bucket=bucket_name, Policy=policy),
         }
     )
-    log.info(policy_put_status)
+    log.info(f"policy_put_status: {policy_put_status}")
     return policy_put_status
 
 
@@ -197,7 +260,7 @@ def PutBucketVersioning(**kw):
             ),
         }
     )
-    log.info(put_versioning_status)
+    log.info(f"put_versioning_status: {put_versioning_status}")
     return put_versioning_status
 
 
@@ -205,7 +268,6 @@ def PutObject(**kw):
     rgw_client = kw.get("rgw_client")
     bucket_name = kw.get("bucket_name")
     object_name = kw.get("object_name")
-    object_name = f"{object_name}_policy_verify"
     log.info(f"s3 object name to upload: {object_name}")
     object_put_status = s3lib.resource_op(
         {
@@ -218,8 +280,210 @@ def PutObject(**kw):
             ),
         }
     )
-    log.info(object_put_status)
+    log.info(f"object_put_status: {object_put_status}")
     return object_put_status
+
+
+def CreateTopic(**kw):
+    global topic_arn
+    config = kw.get("config")
+    sns_client = kw.get("sns_client")
+    topic_name = kw.get("topic_name")
+    log.info(f"creating topic with name: {topic_name}")
+    try:
+        topic_arn_resp = notification.create_topic(
+            sns_client,
+            config.test_ops.get("endpoint", "kafka"),
+            config.test_ops.get("ack_type", "broker"),
+            topic_name,
+        )
+        topic_arn = topic_arn_resp
+        log.info("sleeping for 5 seconds")
+        time.sleep(5)
+    except Exception as e:
+        log.error(f"create topic failed with error {e}")
+        return False
+    return True
+
+
+def DeleteTopic(**kw):
+    global topic_arn
+    sns_client = kw.get("sns_client")
+    log.info(f"deleting topic with arn: {topic_arn}")
+    delete_topic_resp = s3lib.resource_op(
+        {
+            "obj": sns_client,
+            "resource": "delete_topic",
+            "kwargs": dict(TopicArn=topic_arn),
+        }
+    )
+    log.info(f"delete_topic_resp: {delete_topic_resp}")
+    return delete_topic_resp
+
+
+def PutBucketNotification(**kw):
+    config = kw.get("config")
+    rgw_client = kw.get("rgw_client")
+    sns_client = kw.get("sns_client")
+    bucket_name = kw.get("bucket_name")
+    topic_name = kw.get("topic_name")
+    notification_name = kw.get("notification_name")
+    events = kw.get("events")
+
+    # we need to create topic with bucket owner sts client here
+    # but for bucket policy tests with tenanted user, it fails because of cross tenanted topic access is not supported
+    # refer bz: https://bugzilla.redhat.com/show_bug.cgi?id=2238814
+    log.info(f"creating topic with name: {topic_name}")
+    topic_arn = notification.create_topic(
+        sns_client,
+        config.test_ops.get("endpoint", "kafka"),
+        config.test_ops.get("ack_type", "broker"),
+        topic_name,
+    )
+    log.info("sleeping for 5 seconds")
+    time.sleep(5)
+
+    try:
+        notification.put_bucket_notification(
+            rgw_client,
+            bucket_name,
+            notification_name,
+            topic_arn,
+            events,
+            config,
+        )
+    except Exception as e:
+        log.error(f"put bucket notification failed with error {e}")
+        return False
+    return True
+
+
+def GetBucketNotification(**kw):
+    rgw_client = kw.get("rgw_client")
+    bucket_name = kw.get("bucket_name")
+    try:
+        notification.get_bucket_notification(rgw_client, bucket_name)
+    except Exception as e:
+        log.error(f"get bucket notification failed with error {e}")
+        return False
+    return True
+
+
+def PutBucketEncryption(**kw):
+    config = kw.get("config")
+    rgw_client = kw.get("rgw_client")
+    bucket_name = kw.get("bucket_name")
+    try:
+        sse_s3.put_bucket_encryption(
+            rgw_client,
+            bucket_name,
+            config.encryption_keys,
+            config.test_ops.get("encrypt_decrypt_key", "testKey01"),
+        )
+    except Exception as e:
+        log.error(f"put bucket encryption failed with error {e}")
+        return False
+    return True
+
+
+def GetBucketEncryption(**kw):
+    rgw_client = kw.get("rgw_client")
+    bucket_name = kw.get("bucket_name")
+    get_bucket_encryption_result = s3lib.resource_op(
+        {
+            "obj": rgw_client,
+            "resource": "get_bucket_encryption",
+            "kwargs": dict(Bucket=bucket_name),
+        }
+    )
+    log.info(f"get_bucket_encryption_result: {get_bucket_encryption_result}")
+    return get_bucket_encryption_result
+
+
+def PutLifecycleConfiguration(**kw):
+    config = kw.get("config")
+    rgw_client = kw.get("rgw_client")
+    bucket_name = kw.get("bucket_name")
+    put_bkt_lc_config_result = s3lib.resource_op(
+        {
+            "obj": rgw_client,
+            "resource": "put_bucket_lifecycle_configuration",
+            "kwargs": dict(
+                Bucket=bucket_name,
+                LifecycleConfiguration={"Rules": config.lifecycle_conf},
+            ),
+        }
+    )
+    log.info(f"put_bkt_lc_config_result: {put_bkt_lc_config_result}")
+    return put_bkt_lc_config_result
+
+
+def GetLifecycleConfiguration(**kw):
+    rgw_client = kw.get("rgw_client")
+    bucket_name = kw.get("bucket_name")
+    get_bkt_lc_config_result = s3lib.resource_op(
+        {
+            "obj": rgw_client,
+            "resource": "get_bucket_lifecycle_configuration",
+            "kwargs": dict(Bucket=bucket_name),
+        }
+    )
+    log.info(f"get_bkt_lc_config_result: {get_bkt_lc_config_result}")
+    return get_bkt_lc_config_result
+
+
+def PutBucketWebsite(**kw):
+    rgw_client = kw.get("rgw_client")
+    bucket_name = kw.get("bucket_name")
+    try:
+        reusable.put_bucket_website(rgw_client, bucket_name)
+        return True
+    except Exception as e:
+        log.error(f"put bucket website failed with error {e}")
+        return False
+
+
+def GetBucketWebsite(**kw):
+    rgw_client = kw.get("rgw_client")
+    bucket_name = kw.get("bucket_name")
+    try:
+        reusable.get_bucket_website(rgw_client, bucket_name)
+        return True
+    except Exception as e:
+        log.error(f"get bucket website failed with error {e}")
+        return False
+
+
+def PutBucketTagging(**kw):
+    config = kw.get("config")
+    rgw_client = kw.get("rgw_client")
+    bucket_name = kw.get("bucket_name")
+    put_bkt_tagging_result = s3lib.resource_op(
+        {
+            "obj": rgw_client,
+            "resource": "put_bucket_tagging",
+            "kwargs": dict(
+                Bucket=bucket_name,
+                Tagging={"TagSet": config.test_ops.get("bucket_tags")},
+            ),
+        }
+    )
+    log.info(f"put_bkt_tagging_result: {put_bkt_tagging_result}")
+    return put_bkt_tagging_result
+
+
+def GetBucketTagging(**kw):
+    rgw_client = kw.get("rgw_client")
+    bucket_name = kw.get("bucket_name")
+    get_bkt_tagging_result = s3lib.resource_op(
+        {
+            "obj": rgw_client,
+            "resource": "get_bucket_tagging",
+            "kwargs": dict(Bucket=bucket_name),
+        }
+    )
+    log.info(f"get_bkt_tagging_result: {get_bkt_tagging_result}")
+    return get_bkt_tagging_result
 
 
 # fetch condition key value pairs
@@ -248,12 +512,21 @@ def get_condition_keys(condition_dict):
 def verify_policy(**kw):
     log.info("Verifying all statements in Bucket Policy")
     config = kw.get("config")
+    policy_doc = kw.get("policy_document", config.test_ops.get("policy_document", {}))
+    bucket_owner_rgw_client = kw.get("bucket_owner_rgw_client")
     rgw_client = kw.get("rgw_client")
     bucket_name = kw.get("bucket_name")
     object_name = kw.get("object_name")
+    rgw_s3_resource = kw.get("rgw_s3_resource")
+    sns_client = kw.get("sns_client")
+    random_suffix = random.randint(1, 10000)
+    topic_name = kw.get("topic_name", f"rgw_topic_{random_suffix}")
+    notification_name = kw.get("topic_name", f"rgw_notif_{random_suffix}")
+    events = kw.get("events", ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"])
+
     conflicting_statements = config.test_ops.get("conflicting_statements", False)
     log.info(f"Conflicting Statements: {conflicting_statements}")
-    statements = config.test_ops.get("policy_document", {}).get("Statement", [])
+    statements = policy_doc.get("Statement", [])
     for statement in statements:
         effect = statement.get("Effect", "Allow")
         actions = statement.get("Action", [])
@@ -267,10 +540,18 @@ def verify_policy(**kw):
             method = globals()[method_name]
 
             out = method(
+                bucket_owner_rgw_client=bucket_owner_rgw_client,
                 rgw_client=rgw_client,
                 bucket_name=bucket_name,
                 object_name=object_name,
+                rgw_s3_resource=rgw_s3_resource,
+                sns_client=sns_client,
+                topic_name=topic_name,
+                notification_name=notification_name,
+                events=events,
                 config=config,
+                policy_document=policy_doc,
+                effect=effect,
                 **condition_keys,
             )
             if out is False:
@@ -284,9 +565,22 @@ def verify_policy(**kw):
                     )
                 else:
                     raise TestExecError(
-                        f"{action} is denied from other tenanted user after setting bucket policy"
+                        f"{action} is denied after setting bucket policy"
                     )
-
+            elif out is True:
+                if effect == "Allow":
+                    log.info(
+                        f"{action} is allowed as expected because of allow statement"
+                    )
+                elif conflicting_statements:
+                    raise TestExecError(
+                        f"{effect} {action} is allowed with conflicting statements in policy,"
+                        + "ideally it should deny object get from other tenanted user"
+                    )
+                elif effect == "Deny":
+                    raise TestExecError(
+                        f"{action} is allowed even if effect is deny in policy"
+                    )
             elif out is not None:
                 response = HttpResponseParser(out)
                 if response.status_code == 200 or response.status_code == 204:
@@ -302,7 +596,18 @@ def verify_policy(**kw):
                     else:
                         raise TestExecError(f"Verification of {effect} {action} failed")
                 else:
-                    raise TestExecError(
-                        f"Verification of {effect} {action} failed with status code {response.status_code}"
-                    )
+                    if effect == "Deny":
+                        log.info(
+                            f"{action} is denied as expected because of deny statement"
+                        )
+                    elif conflicting_statements:
+                        log.info(
+                            f"{action} is denied as expected because of conflict between allow and deny"
+                        )
+                    else:
+                        raise TestExecError(
+                            f"{action} is denied after setting bucket policy. status code is {response.status_code}"
+                        )
             log.info(f"{effect} {action} verified successfully")
+            log.info("sleeping for 3 seconds before verifying next action")
+            time.sleep(3)


### PR DESCRIPTION
this PR adds support for testing policy actions for features like notification, encryption, tagging, lifecycle, bucket website other than batch deletes.
added support for testing bucket policy, sts assume-role with session policy, aswi role policy (both allow and deny effect).

hotfix bz: https://bugzilla.redhat.com/show_bug.cgi?id=2284153

polarion id: https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83593390 


found below bz through automation:
https://bugzilla.redhat.com/show_bug.cgi?id=2302541

automated below bz verification as well, as they are targetted to 8.1 commented the test in lower versions
https://bugzilla.redhat.com/show_bug.cgi?id=2302541
https://bugzilla.redhat.com/show_bug.cgi?id=2293233


pass logs: http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_apple_sts_batch_deletes/