### PR TITLE
testing bucket notifications with radosgw-admin notification commands

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_kafka_broker_rgw_admin_notif_rm.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_kafka_broker_rgw_admin_notif_rm.yaml
@@ -1,0 +1,23 @@
+# polarion_id: CEPH-83582345
+# test_script: test_bucket_notifications.py
+config:
+ user_count: 1
+ bucket_count: 2
+ objects_count: 25
+ objects_size_range:
+  min: 5
+  max: 15
+ test_ops:
+  create_bucket: true
+  create_object: true
+  copy_object: true
+  enable_version: false
+  create_topic: true
+  get_topic_info: true
+  endpoint: kafka
+  ack_type: broker
+  put_get_bucket_notification: true
+  event_type: Copy
+  upload_type: normal
+  delete_bucket_object: false
+  rgw_admin_notification_rm: true

--- a/rgw/v2/tests/s3_swift/reusables/bucket_notification.py
+++ b/rgw/v2/tests/s3_swift/reusables/bucket_notification.py
@@ -149,21 +149,21 @@ def get_topic(client, topic_arn, ceph_version):
             log.info(f"get topic attributes: {get_topic_info_json}")
 
 
-def rgw_topic_ops(op, args):
+def rgw_admin_topic_notif_ops(op, args, sub_command="topic"):
     """
-    perform radosgw-admin topic operation with arguments passed
+    perform radosgw-admin topic/notification operation with arguments passed
     args:
         op: one of get, list, rm
     """
-    cmd = f"radosgw-admin topic {op}"
+    cmd = f"radosgw-admin {sub_command} {op}"
     for arg, val in args.items():
         cmd = f"{cmd} --{arg} {val}"
     out = utils.exec_shell_cmd(cmd)
     log.info(out)
     if out is False:
-        log.info(f"topic {op} using rgw cli is failed")
+        log.info(f"{sub_command} {op} using rgw cli failed")
         return False
-    log.info(f"topic {op} using rgw cli is successful")
+    log.info(f"{sub_command} {op} using rgw cli is successful")
     if out:
         out = json.loads(out)
     return out

--- a/rgw/v2/tests/s3_swift/test_bucket_policy_with_tenant_user.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_policy_with_tenant_user.py
@@ -63,7 +63,6 @@ TEST_DATA_PATH = None
 
 
 def get_svc_time(ssh_con=None):
-
     cmd = "pidof radosgw"
     if ssh_con:
         _, pid, _ = ssh_con.exec_command(cmd)
@@ -89,7 +88,6 @@ def get_svc_time(ssh_con=None):
 
 
 def test_exec(config, ssh_con):
-
     io_info_initialize = IOInfoInitialize()
     basic_io_structure = BasicIOInfoStructure()
     write_bucket_io_info = BucketIoInfo()
@@ -228,7 +226,7 @@ def test_exec(config, ssh_con):
                             "uid": tenant1_user1_info["user_id"],
                         }
 
-                    get_rgw_topic = notification.rgw_topic_ops(
+                    get_rgw_topic = notification.rgw_admin_topic_notif_ops(
                         op="get", args={"topic": topic_name, **extra_topic_args}
                     )
                     if get_rgw_topic is False:
@@ -704,7 +702,6 @@ def test_exec(config, ssh_con):
 
 
 if __name__ == "__main__":
-
     test_info = AddTestInfo("test bucket policy")
     test_info.started_info()
 


### PR DESCRIPTION
this PR is to add support for testing bucket notifications with radosgw-admin notification commands
7.1 feature bz: https://bugzilla.redhat.com/show_bug.cgi?id=2130292

also testing whether `radosgw-admin topic list` lists even auto-generated topic or not
bz: https://bugzilla.redhat.com/show_bug.cgi?id=1954461

polarion: https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83582345

pass logs: http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_rgw_admin_notif_commands/