### PR TITLE
Unset the swift at root url which will cause all S3 tests folloing to…

### DIFF
--- a/rgw/v2/tests/s3_swift/test_swift_basic_ops.py
+++ b/rgw/v2/tests/s3_swift/test_swift_basic_ops.py
@@ -858,6 +858,13 @@ def test_exec(config, ssh_con):
                 log.info(f"Bucket creation failed as expected with {e}")
             else:
                 raise TestExecError("Bucket creation succeeded")
+            log.info("Unsetting the swift at root config option")
+            ceph_conf.set_to_ceph_conf(
+                "global", ConfigOpts.rgw_swift_url_prefix, "\ ", ssh_con
+            )
+            log.info("trying to restart services ")
+            srv_restarted = rgw_service.restart(ssh_con)
+            time.sleep(30)
 
         else:
             container_name = utils.gen_bucket_name_from_userid(


### PR DESCRIPTION
… fail

In the recent swift at root script , the swift url was not unset at the end of the script , which would cause all S3 tests following it to fail, this PR addresses that 
Fail log for reference : http://magna002.ceph.redhat.com/cephci-jenkins/tchandra/cephci-run-T5WEBQ/

Pass log: http://magna002.ceph.redhat.com/cephci-jenkins/tchandra/swift_config_opts_fix.txt