### PR TITLE
testing rgw user capability user-info-without-keys

### DIFF
--- a/rgw/v2/tests/curl/configs/test_rgw_user_cap_user_info_without_keys.yaml
+++ b/rgw/v2/tests/curl/configs/test_rgw_user_cap_user_info_without_keys.yaml
@@ -1,0 +1,16 @@
+# script: test_rgw_using_curl.py
+# polarion: CEPH-83582351
+config:
+  user_count: 2
+  bucket_count: 2
+  objects_count: 20
+  objects_size_range:
+    min: 5
+    max: 15
+  local_file_delete: true
+  test_ops:
+    create_bucket: true
+    create_object: true
+    download_object: true
+    user_remove: true
+    test_rgw_user_cap_user_info_without_keys: true

--- a/rgw/v2/tests/curl/test_rgw_using_curl.py
+++ b/rgw/v2/tests/curl/test_rgw_using_curl.py
@@ -6,6 +6,7 @@ Usage: test_rgw_using_curl.py -c <input_yaml>
     test_curl_transfer_encoding_chunked.yaml
     test_rgw_using_curl.yaml
     test_rgw_curl_multipart_upload.yaml
+    test_rgw_user_cap_user_info_without_keys.yaml
 
 Operation:
 
@@ -13,6 +14,7 @@ Operation:
 
 
 import argparse
+import json
 import logging
 import os
 import sys
@@ -45,8 +47,58 @@ def test_exec(config, ssh_con):
     basic_io_structure = BasicIOInfoStructure()
     io_info_initialize.initialize(basic_io_structure.initial())
 
+    # get ceph version
+    ceph_version_id, ceph_version_name = utils.get_ceph_version()
+    user_info_without_keys_cap_available = False
+    ceph_version_id = ceph_version_id.split("-")
+    ceph_version_id = ceph_version_id[0].split(".")
+    if (float(ceph_version_id[0]) >= 19) or (
+        float(ceph_version_id[0]) == 18
+        and float(ceph_version_id[1]) >= 2
+        and float(ceph_version_id[2]) >= 1
+    ):
+        user_info_without_keys_cap_available = True
+
     curl_reusable.install_curl(version="7.88.1")
     all_users_info = resource_op.create_users(no_of_users_to_create=config.user_count)
+
+    if (
+        config.test_ops.get("test_rgw_user_cap_user_info_without_keys")
+        and user_info_without_keys_cap_available
+    ):
+        log.info("testing rgw capability user-info-without-keys")
+        user1 = all_users_info[0]
+        user1_id = user1["user_id"]
+        user2 = all_users_info[1]
+        user2_id = user2["user_id"]
+        curl_auth = CURL(user1, ssh_con, ssl=config.ssl)
+
+        utils.exec_shell_cmd(
+            f"radosgw-admin caps add --uid={user1_id} --caps='users=write'"
+        )
+        curl_reusable.create_subuser(curl_auth, user2_id, user2_id + "_subuser1")
+
+        utils.exec_shell_cmd(
+            f"radosgw-admin caps add --uid={user1_id} --caps='user-info-without-keys=read'"
+        )
+        get_user_resp = json.loads(curl_reusable.get_user_info(curl_auth, user2_id))
+        if get_user_resp.get("keys") or get_user_resp.get("swift_keys"):
+            raise Exception(
+                "user info is returning keys even after setting user-info-without-keys=read capability to user"
+            )
+
+        utils.exec_shell_cmd(
+            f"radosgw-admin caps add --uid={user1_id} --caps='users=read'"
+        )
+        get_user_resp = json.loads(curl_reusable.get_user_info(curl_auth, user2_id))
+        if get_user_resp.get("keys") and get_user_resp.get("swift_keys"):
+            log.info(
+                "user info is returning keys as expected after setting users=read capability"
+            )
+        else:
+            raise Exception(
+                "user info is not returning keys even after setting users=read capability"
+            )
 
     for each_user in all_users_info:
         user_name = each_user["user_id"]


### PR DESCRIPTION
this PR is to test rgw user capability user-info-without-keys which is added in rhcs7.1

polarion: https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83582351

pass logs:
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_rgw_user_cap_user_info_without_keys/