### PR TITLE
[TFA]removing topic get for auto-generated notif topic on all versions and removing topic list on quincy

### DIFF
--- a/rgw/v2/tests/s3_swift/test_bucket_notifications.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_notifications.py
@@ -133,7 +133,7 @@ def test_exec(config, ssh_con):
         rgw_admin_notif_commands_available = False
         ceph_version_id = ceph_version_id.split("-")
         ceph_version_id = ceph_version_id[0].split(".")
-        if (
+        if (float(ceph_version_id[0]) >= 19) or (
             float(ceph_version_id[0]) == 18
             and float(ceph_version_id[1]) >= 2
             and float(ceph_version_id[2]) >= 1
@@ -235,36 +235,25 @@ def test_exec(config, ssh_con):
                         rgw_s3_client, bucket_name_to_create
                     )
 
-                    # get bucket notification using rgw cli
-                    log.info("get notification topic using rgw cli")
-                    get_notif_topic = notification.rgw_admin_topic_notif_ops(
-                        op="get",
-                        args={"topic": bkt_notif_topic_name, **extra_topic_args},
-                    )
-                    if get_notif_topic is False:
-                        raise TestExecError(
-                            "radosgw-admin topic get failed for bucket notification topic"
-                        )
-
-                    # list rgw topics using rgw admin cli
-                    log.info("list topic using rgw cli")
-                    topics_list = notification.rgw_admin_topic_notif_ops(
-                        op="list",
-                        args={"topic": bkt_notif_topic_name, **extra_topic_args},
-                    )
-                    topic_listed = False
-                    notif_topic_listed = False
-                    for topic_dict in topics_list["topics"]:
-                        if topic_dict["name"] == topic_name:
-                            topic_listed = True
-                        if topic_dict["name"] == bkt_notif_topic_name:
-                            notif_topic_listed = True
-                    if topic_listed is False:
-                        raise TestExecError(
-                            f"radosgw-admin topic list doesnot contain topic: {topic_name}"
-                        )
-
                     if rgw_admin_notif_commands_available:
+                        # list rgw topics using rgw admin cli
+                        log.info("list topic using rgw cli")
+                        topics_list = notification.rgw_admin_topic_notif_ops(
+                            op="list",
+                            args={**extra_topic_args},
+                        )
+                        topic_listed = False
+                        notif_topic_listed = False
+                        for topic_dict in topics_list["topics"]:
+                            if topic_dict["name"] == topic_name:
+                                topic_listed = True
+                            if topic_dict["name"] == bkt_notif_topic_name:
+                                notif_topic_listed = True
+                        if topic_listed is False:
+                            raise TestExecError(
+                                f"radosgw-admin topic list doesnot contain topic: {topic_name}"
+                            )
+
                         # verify notification topic does not list in radosgw-admin topic list
                         if notif_topic_listed is True:
                             raise TestExecError(


### PR DESCRIPTION
TFA ticket: https://issues.redhat.com/browse/RHCEPHQE-15402

executing topic list commands verification only on reef and squid as quincy topic list has different format
see this log: http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/6.1/rhel-9/Weekly/17.2.6-239/rgw/34/tier-2_rgw_ssl_test_bucket_notifications/notify_put,delete_events_with_kafka_broker_persistent_with_rgw_ssl_0.log

removing radsogw-admin topic get for autogenerated notif topic as suggested by dev: https://bugzilla.redhat.com/show_bug.cgi?id=2303775


pass logs on quincy and squid:
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/TFA_quincy_topic_list/