### PR TITLE
test how many versions of a key can be archived

### DIFF
--- a/rgw/v2/tests/s3_swift/multisite_configs/test_archive_versions.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_archive_versions.yaml
@@ -1,0 +1,23 @@
+# Polarian - CEPH-83575862 test how many versions of a key can be archived
+# test_script : test_sse_s3_kms_with_vault.py
+config:
+ user_count: 1
+ test_sync_consistency_bucket_stats: true
+ remote_zone: archive
+ encryption_keys: s3
+ bucket_count: 1
+ objects_count: 1
+ local_file_delete: true
+ objects_size_range:
+  min: 6
+  max: 15
+ test_ops:
+  create_bucket: true
+  create_object: true
+  enable_version: true
+  version_count: 10000
+  sse_s3_per_bucket: true
+  upload_type: normal
+  delete_bucket_object: false
+  delete_bucket_object_version: false
+  download_object_at_remote_site: false

--- a/rgw/v2/tests/s3_swift/test_sse_s3_kms_with_vault.py
+++ b/rgw/v2/tests/s3_swift/test_sse_s3_kms_with_vault.py
@@ -47,6 +47,9 @@ from v2.lib.s3.auth import Auth
 from v2.lib.s3.write_io_info import BasicIOInfoStructure, BucketIoInfo, IOInfoInitialize
 from v2.tests.s3_swift import reusable
 from v2.tests.s3_swift.reusables import server_side_encryption_s3 as sse_s3
+from v2.tests.s3_swift.reusables import (
+    upload_object_via_s3client as put_object_s3client,
+)
 from v2.utils.log import configure_logging
 from v2.utils.test_desc import AddTestInfo
 from v2.utils.utils import RGWService
@@ -179,13 +182,28 @@ def test_exec(config, ssh_con):
                             sse_s3.get_bucket_encryption(
                                 s3_client, bucket_name_to_create
                             )
-                            reusable.get_object_upload_type(
-                                s3_object_name,
-                                bucket,
-                                TEST_DATA_PATH,
-                                config,
-                                each_user,
-                            )
+                            if config.test_ops["version_count"] > 0:
+                                for vc in range(config.test_ops["version_count"]):
+                                    log.info(
+                                        f"version count for {s3_object_name} is {vc}"
+                                    )
+                                    log.info("modifying data: %s" % s3_object_name)
+                                    put_object_s3client.upload_object_via_s3client(
+                                        s3_client,
+                                        bucket_name_to_create,
+                                        s3_object_name,
+                                        TEST_DATA_PATH,
+                                        config,
+                                        each_user,
+                                    )
+                            else:
+                                reusable.get_object_upload_type(
+                                    s3_object_name,
+                                    bucket,
+                                    TEST_DATA_PATH,
+                                    config,
+                                    each_user,
+                                )
 
                         else:
                             log.info(f"Encryption type is per-object.")


### PR DESCRIPTION
[CEPH-83575862](https://polarion.engineering.redhat.com/polarion/redirect/project/CEPH/workitem/question_mark/id=CEPH-83575862)test how many versions of a key can be archived

This is a bug which is closed as wontfix https://bugzilla.redhat.com/show_bug.cgi?id=2242292

logs http://magna002.ceph.redhat.com/cephci-jenkins/vidushi-runs/logs_test_archive_versions_1
Note: for 10000 objects archive for one key, it took around 14mins to upload and sync to the archive zone.