### PR TITLE
[TFA]improvise delete_objects policy action verification and remove notif actions from policy verification configs

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_bucket_policy_deny_actions.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_policy_deny_actions.yaml
@@ -30,7 +30,7 @@ config:
         "Version": "2012-10-17",
         "Statement": [
           {
-            "Action": ["s3:PutObject", "s3:ListBucket", "s3:GetObject", "s3:DeleteObject", "s3:AbortMultipartUpload", "s3:PutBucketVersioning", "s3:GetBucketVersioning", "s3:PutBucketWebsite", "s3:GetBucketWebsite", "s3:PutLifecycleConfiguration", "s3:GetLifecycleConfiguration", "s3:PutBucketEncryption", "s3:GetBucketEncryption", "s3:PutBucketNotification", "s3:GetBucketNotification", "s3:PutBucketTagging", "s3:GetBucketTagging", "s3:DeleteBucket", "s3:CreateBucket", "s3:PutBucketPolicy", "s3:GetBucketPolicy", "s3:DeleteBucketPolicy"],
+            "Action": ["s3:PutObject", "s3:ListBucket", "s3:GetObject", "s3:DeleteObject", "s3:AbortMultipartUpload", "s3:PutBucketVersioning", "s3:GetBucketVersioning", "s3:PutBucketWebsite", "s3:GetBucketWebsite", "s3:PutLifecycleConfiguration", "s3:GetLifecycleConfiguration", "s3:PutBucketEncryption", "s3:GetBucketEncryption", "s3:PutBucketTagging", "s3:GetBucketTagging", "s3:DeleteBucket", "s3:CreateBucket", "s3:PutBucketPolicy", "s3:GetBucketPolicy", "s3:DeleteBucketPolicy"],
             "Principal": {"AWS": "arn:aws:iam::<tenant_name>:user/<user_name>"},
             "Resource": "arn:aws:s3:::*",
             "Effect": "Deny",

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_policy_multiple_statements.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_policy_multiple_statements.yaml
@@ -44,7 +44,7 @@ config:
             "Sid": "statement2",
           },
           {
-            "Action": ["s3:PutBucketVersioning", "s3:GetBucketVersioning", "s3:PutBucketWebsite", "s3:GetBucketWebsite", "s3:PutLifecycleConfiguration", "s3:GetLifecycleConfiguration", "s3:PutBucketEncryption", "s3:GetBucketEncryption", "s3:PutBucketNotification", "s3:GetBucketNotification", "s3:PutBucketTagging", "s3:GetBucketTagging", "s3:PutBucketPolicy", "s3:GetBucketPolicy", "s3:DeleteBucketPolicy"],
+            "Action": ["s3:PutBucketVersioning", "s3:GetBucketVersioning", "s3:PutBucketWebsite", "s3:GetBucketWebsite", "s3:PutLifecycleConfiguration", "s3:GetLifecycleConfiguration", "s3:PutBucketEncryption", "s3:GetBucketEncryption", "s3:PutBucketTagging", "s3:GetBucketTagging", "s3:PutBucketPolicy", "s3:GetBucketPolicy", "s3:DeleteBucketPolicy"],
             "Principal": {"AWS": "arn:aws:iam::<tenant_name>:user/<user_name>"},
             "Resource": "arn:aws:s3:::*",
             "Effect": "Allow",

--- a/rgw/v2/tests/s3_swift/configs/test_sse_kms_per_bucket_with_bucket_policy.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_kms_per_bucket_with_bucket_policy.yaml
@@ -7,23 +7,38 @@ config:
   objects_size_range:
     min: 5
     max: 15
+  lifecycle_conf:
+    - ID: LC_Rule_1
+      Filter:
+        Prefix: key2
+      Status: Enabled
+      Expiration:
+        Days: 20
   test_ops:
     upload_type: normal
     sse_s3_per_bucket: true
     verify_policy: True
+    endpoint: kafka
+    ack_type: broker
+    bucket_tags: [
+      {
+          "Key": "product",
+          "Value": "ceph"
+      }
+    ]
     policy_document:
       {
         "Version": "2012-10-17",
         "Statement": [
           {
-            "Action": ["s3:GetObject", "s3:DeleteObject", "s3:PutObject", "s3:AbortMultipartUpload"],
+            "Action": ["s3:PutObject", "s3:ListBucket", "s3:GetObject", "s3:DeleteObject", "s3:AbortMultipartUpload"],
             "Principal": {"AWS": "arn:aws:iam::<tenant_name>:user/<user_name>"},
-            "Resource": "arn:aws:s3:::<bucket_name>/*",
+            "Resource": "arn:aws:s3:::*",
             "Effect": "Allow",
             "Sid": "statement1",
           },
           {
-            "Action": ["s3:PutBucketVersioning", "s3:GetBucketVersioning", "s3:PutBucketPolicy", "s3:GetBucketPolicy", "s3:DeleteBucketPolicy"],
+            "Action": ["s3:PutBucketVersioning", "s3:GetBucketVersioning", "s3:PutBucketWebsite", "s3:GetBucketWebsite", "s3:PutLifecycleConfiguration", "s3:GetLifecycleConfiguration", "s3:PutBucketEncryption", "s3:GetBucketEncryption", "s3:PutBucketTagging", "s3:GetBucketTagging", "s3:PutBucketPolicy", "s3:GetBucketPolicy", "s3:DeleteBucketPolicy"],
             "Principal": {"AWS": "arn:aws:iam::<tenant_name>:user/<user_name>"},
             "Resource": "arn:aws:s3:::<bucket_name>",
             "Effect": "Allow",

--- a/rgw/v2/tests/s3_swift/configs/test_sts_aswi_verify_role_policy_allow_actions.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_aswi_verify_role_policy_allow_actions.yaml
@@ -43,7 +43,7 @@ config:
                "Statement":
                 [
                     {
-                         "Action": ["s3:PutObject", "s3:ListBucket", "s3:GetObject", "s3:DeleteObject", "s3:AbortMultipartUpload", "s3:PutBucketVersioning", "s3:GetBucketVersioning", "s3:PutBucketNotification", "s3:GetBucketNotification", "s3:PutBucketPolicy", "s3:GetBucketPolicy", "s3:DeleteBucketPolicy", "s3:PutBucketWebsite", "s3:GetBucketWebsite", "s3:PutLifecycleConfiguration", "s3:GetLifecycleConfiguration", "s3:PutBucketEncryption", "s3:GetBucketEncryption", "s3:PutBucketTagging", "s3:GetBucketTagging", "s3:DeleteBucket", "s3:CreateBucket"],
+                         "Action": ["s3:PutObject", "s3:ListBucket", "s3:GetObject", "s3:DeleteObject", "s3:AbortMultipartUpload", "s3:PutBucketVersioning", "s3:GetBucketVersioning", "s3:PutBucketPolicy", "s3:GetBucketPolicy", "s3:DeleteBucketPolicy", "s3:PutBucketWebsite", "s3:GetBucketWebsite", "s3:PutLifecycleConfiguration", "s3:GetLifecycleConfiguration", "s3:PutBucketEncryption", "s3:GetBucketEncryption", "s3:PutBucketTagging", "s3:GetBucketTagging", "s3:DeleteBucket", "s3:CreateBucket"],
                          "Resource": "arn:aws:s3:::*",
                          "Effect": "Allow",
                          "Sid": "statement1",

--- a/rgw/v2/tests/s3_swift/configs/test_sts_aswi_verify_role_policy_deny_actions.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_aswi_verify_role_policy_deny_actions.yaml
@@ -43,7 +43,7 @@ config:
                "Statement":
                 [
                     {
-                         "Action": ["s3:PutObject", "s3:ListBucket", "s3:GetObject", "s3:DeleteObject", "s3:AbortMultipartUpload", "s3:PutBucketVersioning", "s3:GetBucketVersioning", "s3:PutBucketNotification", "s3:GetBucketNotification", "s3:PutBucketPolicy", "s3:GetBucketPolicy", "s3:DeleteBucketPolicy", "s3:PutBucketWebsite", "s3:GetBucketWebsite", "s3:PutLifecycleConfiguration", "s3:GetLifecycleConfiguration", "s3:PutBucketEncryption", "s3:GetBucketEncryption", "s3:PutBucketTagging", "s3:GetBucketTagging", "s3:DeleteBucket", "s3:CreateBucket"],
+                         "Action": ["s3:PutObject", "s3:ListBucket", "s3:GetObject", "s3:DeleteObject", "s3:AbortMultipartUpload", "s3:PutBucketVersioning", "s3:GetBucketVersioning", "s3:PutBucketPolicy", "s3:GetBucketPolicy", "s3:DeleteBucketPolicy", "s3:PutBucketWebsite", "s3:GetBucketWebsite", "s3:PutLifecycleConfiguration", "s3:GetLifecycleConfiguration", "s3:PutBucketEncryption", "s3:GetBucketEncryption", "s3:PutBucketTagging", "s3:GetBucketTagging", "s3:DeleteBucket", "s3:CreateBucket"],
                          "Resource": "arn:aws:s3:::*",
                          "Effect": "Deny",
                          "Sid": "statement1",

--- a/rgw/v2/tests/s3_swift/configs/test_sts_using_boto_verify_session_policy_allow_actions.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_using_boto_verify_session_policy_allow_actions.yaml
@@ -54,7 +54,7 @@ config:
                "Statement":
                 [
                     {
-                         "Action": ["s3:PutObject", "s3:ListBucket", "s3:GetObject", "s3:DeleteObject", "s3:AbortMultipartUpload", "s3:PutBucketVersioning", "s3:GetBucketVersioning", "s3:PutBucketPolicy", "s3:GetBucketPolicy", "s3:DeleteBucketPolicy", "s3:PutBucketWebsite", "s3:GetBucketWebsite", "s3:PutLifecycleConfiguration", "s3:GetLifecycleConfiguration", "s3:PutBucketEncryption", "s3:GetBucketEncryption", "s3:PutBucketNotification", "s3:GetBucketNotification", "s3:PutBucketTagging", "s3:GetBucketTagging", "s3:DeleteBucket", "s3:CreateBucket"],
+                         "Action": ["s3:PutObject", "s3:ListBucket", "s3:GetObject", "s3:DeleteObject", "s3:AbortMultipartUpload", "s3:PutBucketVersioning", "s3:GetBucketVersioning", "s3:PutBucketPolicy", "s3:GetBucketPolicy", "s3:DeleteBucketPolicy", "s3:PutBucketWebsite", "s3:GetBucketWebsite", "s3:PutLifecycleConfiguration", "s3:GetLifecycleConfiguration", "s3:PutBucketEncryption", "s3:GetBucketEncryption", "s3:PutBucketTagging", "s3:GetBucketTagging", "s3:DeleteBucket", "s3:CreateBucket"],
                          "Resource": "arn:aws:s3:::*",
                          "Effect": "Allow",
                          "Sid": "statement4",

--- a/rgw/v2/tests/s3_swift/configs/test_sts_using_boto_verify_session_policy_deny_actions.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_using_boto_verify_session_policy_deny_actions.yaml
@@ -54,7 +54,7 @@ config:
                "Statement":
                 [
                     {
-                         "Action": ["s3:PutObject", "s3:ListBucket", "s3:GetObject", "s3:DeleteObject", "s3:AbortMultipartUpload", "s3:PutBucketVersioning", "s3:GetBucketVersioning", "s3:PutBucketPolicy", "s3:GetBucketPolicy", "s3:DeleteBucketPolicy", "s3:PutBucketWebsite", "s3:GetBucketWebsite", "s3:PutLifecycleConfiguration", "s3:GetLifecycleConfiguration", "s3:PutBucketEncryption", "s3:GetBucketEncryption", "s3:PutBucketNotification", "s3:GetBucketNotification", "s3:PutBucketTagging", "s3:GetBucketTagging", "s3:DeleteBucket", "s3:CreateBucket"],
+                         "Action": ["s3:PutObject", "s3:ListBucket", "s3:GetObject", "s3:DeleteObject", "s3:AbortMultipartUpload", "s3:PutBucketVersioning", "s3:GetBucketVersioning", "s3:PutBucketPolicy", "s3:GetBucketPolicy", "s3:DeleteBucketPolicy", "s3:PutBucketWebsite", "s3:GetBucketWebsite", "s3:PutLifecycleConfiguration", "s3:GetLifecycleConfiguration", "s3:PutBucketEncryption", "s3:GetBucketEncryption", "s3:PutBucketTagging", "s3:GetBucketTagging", "s3:DeleteBucket", "s3:CreateBucket"],
                          "Resource": "arn:aws:s3:::*",
                          "Effect": "Deny",
                          "Sid": "statement1",


### PR DESCRIPTION
this PR is to fix STS policy and bucket policy verfication failures with put_bucket_notification and delete_objects
also to update sse_s3_with_bucket_policy config according to the changes in script

failures in TFA:

1. put_bucket_notification failed on quincy, bz filed: [bz-2306898](https://bugzilla.redhat.com/show_bug.cgi?id=2306898)
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/6.1/rhel-9/Weekly/17.2.6-239/rgw/34/tier-2_rgw_regression/test_bucket_policy_with_multiple_statements_0.log
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/IBM/6.1/rhel-9/Regression/17.2.6-239/rgw/64/tier-1-extn_rgw/STS_test_to_verify_session_policy_allow_actions_0.log

2. create_topic failed because permission not added for it in sts role policy. check bz: [bz-2293233](https://bugzilla.redhat.com/show_bug.cgi?id=2293233)
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/6.1/rhel-9/Weekly/17.2.6-246/rgw/35/tier-2_rgw_sts_aswi/STS_aswi_Tests_to_veify_role_policy_allow_actions_0.log
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/6.1/rhel-9/Weekly/17.2.6-246/rgw/35/tier-2_rgw_sts_aswi/STS_aswi_Tests_to_veify_role_policy_deny_actions_0.log

3. sse_s3_with_bucket_policy failed as its config is not updated according to the changes in script:
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/7.1/rhel-9/Stage/18.2.1-229/13/sanity_rgw_multisite/test_sse_kms_per_bucket_with_bucket_policy_0.log
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/6.1/rhel-9/Weekly/17.2.6-239/rgw/34/tier-2_sse_s3_encryption/test_sse_kms_per_bucket_with_bucket_policy_0.log


4. deny delete_objects failed on squid because the response status is 200 and the response has AccessDenied Errors for keys. added a check for Errors as well instead of just checking status_code
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9/Weekly/19.1.0-22/rgw/4/tier-2_ssl_rgw_regression_test/STS_test_to_verify_session_policy_deny_actions_0.log



TFA ticket:
https://issues.redhat.com/browse/RHCEPHQE-15568

pass logs on quincy: 
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/TFA_sts_and_bucket_policy/quincy/

pass logs on reef:
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/TFA_sts_and_bucket_policy/reef/

pass logs on squid:
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/TFA_sts_and_bucket_policy/squid/