### PR TITLE
TFA[RHCEPHQE-15403] for the tier-2_ms_archive suite

### DIFF
--- a/rgw/v2/tests/s3_swift/multisite_configs/test_sse_s3_bucket_enc_multipart_download_archive_site.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_sse_s3_bucket_enc_multipart_download_archive_site.yaml
@@ -14,7 +14,7 @@ config:
  test_ops:
   create_bucket: true
   create_object: true
-  enable_version: false
+  enable_version: true
   sse_s3_per_bucket: true
   upload_type: multipart
   delete_bucket_object: false

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_sse_s3_bucket_enc_multipart_download_remote_site.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_sse_s3_bucket_enc_multipart_download_remote_site.yaml
@@ -5,7 +5,7 @@ config:
  test_sync_consistency_bucket_stats: true
  encryption_keys: s3
  bucket_count: 1
- objects_count: 30
+ objects_count: 5
  local_file_delete: true
  objects_size_range:
   min: 6M
@@ -16,6 +16,6 @@ config:
   enable_version: true
   sse_s3_per_bucket: true
   upload_type: multipart
-  delete_bucket_object: true
+  delete_bucket_object: false
   delete_bucket_object_version: false
   download_object_at_remote_site: true


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCEPHQE-15403.

The tests have passed independently, so the decision was made to divide the suite into two suites, one having the LC and notifications tests and the other having resharding and granular sync policy tests.

Passed logs for lc and notification suite: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ZFE35Y
Passed logs for the resharding and granular sync tests: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-TEY67Y
here one of the granular sync test has failed due to execution timeout (more than 1 hour)
the multipart download tests have failed due issues in ceph-qe-script (PR )
pass logs for the multipart download tests
http://magna002.ceph.redhat.com/cephci-jenkins/vidushi-runs/logs_test_sse_s3_bucket_enc_multipart_download_archive_site
http://magna002.ceph.redhat.com/cephci-jenkins/vidushi-runs/logs_test_sse_s3_bucket_enc_multipart_download_remote_site