### PR TITLE
Support format change for owneridentidty in event record squid

### DIFF
--- a/rgw/v2/tests/s3_swift/reusables/bucket_notification.py
+++ b/rgw/v2/tests/s3_swift/reusables/bucket_notification.py
@@ -337,8 +337,14 @@ def verify_event_record(
 
             # verify bucket owner in event record
             bucket_owner = bucket_stats_json["owner"]
-            if "$" in bucket_owner:
+
+            ceph_version_id, _ = utils.get_ceph_version()
+            ceph_version_id = ceph_version_id.split("-")
+            ceph_version_id = ceph_version_id[0].split(".")
+
+            if "$" in bucket_owner and int(ceph_version_id[0]) < 19:
                 bucket_owner = bucket_owner.split("$")[-1]
+
             bkt_owner_evnt = event_record_json["Records"][0]["s3"]["bucket"][
                 "ownerIdentity"
             ]["principalId"]


### PR DESCRIPTION
Support format change for owneridentidty in event record squid
https://bugzilla.redhat.com/show_bug.cgi?id=2309013

as per: https://tracker.ceph.com/issues/67857
this changes is expected in squid.

http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/notification/test_put_get_bucket_notification_with_tenant_same_and_different_user.console.log
