### PR TITLE
Include support to add placement and storageclass during user creation

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_user_with_placement_id_storage_class.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_user_with_placement_id_storage_class.yaml
@@ -1,0 +1,10 @@
+#ceph-qe-scripts/rgw/v2/tests/s3_swift/user_create.py
+# Polarian: CEPH-83575880
+# BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2293615
+config:
+    user_count: 1
+    user_type: non-tenanted
+    test_ops:
+        create_bucket: false
+        swift_user: false
+        user_with_default_placement_and_storageclass: true

--- a/rgw/v2/tests/s3_swift/configs/test_user_with_placement_id_storage_class_cold.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_user_with_placement_id_storage_class_cold.yaml
@@ -1,0 +1,11 @@
+#ceph-qe-scripts/rgw/v2/tests/s3_swift/user_create.py
+# Polarian: CEPH-83575880
+# BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2293615
+config:
+    user_count: 1
+    user_type: non-tenanted
+    test_ops:
+        create_bucket: false
+        swift_user: false
+        user_with_default_placement_and_storageclass: true
+        storage_class: "cold"

--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -2611,3 +2611,31 @@ def create_storage_class_in_all_zones(current_zone, rgw_ssh_con, config):
                 f"ceph osd pool application enable {pool_name} rgw"
             )
             rgw_ssh_con.exec_command("radosgw-admin period update --commit")
+
+
+def validate_default_placement_and_storageclass_for_user(
+    uid, placement_id, storage_class
+):
+    """
+    This function is to validate default_placement and storageclass set to user
+    uid: uid of the user
+    placement_id: placement_id set to the user
+    storage_class: storage_class set to the user
+    """
+    out = json.loads(utils.exec_shell_cmd(f"radosgw-admin user info --uid={uid}"))
+    if out["default_placement"] != str(placement_id):
+        raise AssertionError(f"default Placement set for user: {uid} is failed")
+    if out["default_storage_class"] != str(storage_class):
+        raise AssertionError(f"default storage class set for user: {uid} is failed")
+
+
+def get_placement_and_storageclass_from_cluster():
+    """
+    This function is to fetch placement_id and storage_class from the cluster.
+    """
+    cmd = "radosgw-admin zone get"
+    out = json.loads(utils.exec_shell_cmd(cmd))
+    placement_id = out["placement_pools"][0]["key"]
+    storage_classes = out["placement_pools"][0]["val"]["storage_classes"]
+    storage_class_list = list(storage_classes.keys())
+    return placement_id, storage_class_list


### PR DESCRIPTION
Include support to add placement and storageclass during user creation

[RFE] RGW REST API doesn't currently support setting the default storage class when creating a user
https://bugzilla.redhat.com/show_bug.cgi?id=2293615

https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83575880

# radosgw-admin user create --uid test7 --display-name test7 --storage-class cold --placement-id default-placement

logs:
with standard storage class:
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/user_with_storage_class_automation/test_user_with_plac_id_storage.console.log-with-standard

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2311474

With cold storage class:
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/user_with_storage_class_automation/test_user_with_plac_id_storage.console.log-with-cold

Pass log for existing configs:
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/user_with_storage_class_automation/test_user_modify_with_placementid.console.log

http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/user_with_storage_class_automation/tenanted_user.console.log


