### PR TITLE
adding support for testing s3api GetObjectAttributes

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_get_object_attributes.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_get_object_attributes.yaml
@@ -1,0 +1,22 @@
+# upload type: non multipart
+# script: test_Mbuckets_with_Nobjects.py
+# polarion: CEPH-83595849
+config:
+  user_count: 1
+  bucket_count: 2
+  objects_count: 25
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    create_bucket: true
+    create_object: true
+    download_object: true
+    delete_bucket_object: true
+    test_get_object_attributes: true
+    sharding:
+      enable: false
+      max_shards: 0
+    compression:
+      enable: false
+      type: zlib

--- a/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_get_object_attributes_checksum_sha256.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_get_object_attributes_checksum_sha256.yaml
@@ -1,0 +1,24 @@
+# upload type: non multipart
+# script: test_Mbuckets_with_Nobjects.py
+# polarion: CEPH-83595849
+config:
+  user_count: 1
+  bucket_count: 2
+  objects_count: 25
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    create_bucket: true
+    create_object: true
+    download_object: true
+    delete_bucket_object: true
+    test_get_object_attributes: true
+    test_checksum: true
+    checksum_algorithm: SHA256
+    sharding:
+      enable: false
+      max_shards: 0
+    compression:
+      enable: false
+      type: zlib

--- a/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_get_object_attributes_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_get_object_attributes_multipart.yaml
@@ -1,0 +1,23 @@
+# upload type: multipart
+# script: test_Mbuckets_with_Nobjects.py
+# polarion: CEPH-83595849
+config:
+  user_count: 1
+  bucket_count: 2
+  objects_count: 20
+  objects_size_range:
+    min: 30M
+    max: 50M
+  test_ops:
+    create_bucket: true
+    create_object: true
+    upload_type: multipart
+    download_object: true
+    delete_bucket_object: true
+    test_get_object_attributes: true
+    sharding:
+      enable: false
+      max_shards: 0
+    compression:
+      enable: false
+      type: zlib


### PR DESCRIPTION
this PR is to add support for testing s3api GetObjectAttributes
added basic support for checksum to test with GetObjectAttributes

polarion: https://polarion.engineering.redhat.com/polarion/redirect/project/CEPH/workitem?id=CEPH-83595849

there is an existing issue with ObjectParts with multipart objects, failure in multipart log is because of that
bz: https://bugzilla.redhat.com/show_bug.cgi?id=2311872

pass logs for existing and new configs: 
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_get_object_attributes/