### PR TITLE
[TFA] AttributeError: for 'test_ops' seen, as config was not sent to the function declartion

### DIFF
--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -2143,7 +2143,7 @@ def verify_object_sync_on_other_site(rgw_ssh_con, bucket, config, bucket_object=
     )
     cmd_output = json.loads(stdout.read().decode())
     if "rgw.main" not in cmd_output["usage"].keys():
-        for retry_count in range(20):
+        for retry_count in range(25):
             time.sleep(60)
             _, re_stdout, _ = rgw_ssh_con.exec_command(
                 f"radosgw-admin bucket stats --bucket {bucket.name}"
@@ -2160,9 +2160,9 @@ def verify_object_sync_on_other_site(rgw_ssh_con, bucket, config, bucket_object=
                 log.info(f"bucket stats synced for bucket {bucket.name}")
                 break
 
-        if (retry_count > 20) and ("rgw.main" not in re_cmd_output["usage"].keys()):
+        if (retry_count > 25) and ("rgw.main" not in re_cmd_output["usage"].keys()):
             raise TestExecError(
-                f"object not synced on bucket {bucket.name} in another site even after 20m"
+                f"object not synced on bucket {bucket.name} in another site even after 25m"
             )
         cmd_output = re_cmd_output
 

--- a/rgw/v2/tests/s3_swift/reusables/bucket_notification.py
+++ b/rgw/v2/tests/s3_swift/reusables/bucket_notification.py
@@ -463,7 +463,7 @@ class NotificationService:
         # verify all the attributes of the event record. if event not received abort testcase
         log.info("verify event record attributes")
         verify = verify_event_record(
-            event, bucket_name, event_record_path, self.ceph_version_name
+            event, bucket_name, event_record_path, self.ceph_version_name, self.config
         )
         if verify is False:
             raise EventRecordDataError(


### PR DESCRIPTION
due to issue of https://bugzilla.redhat.com/show_bug.cgi?id=2324516

in 8.0:
both lifecycle transition and lifecycle expiration has event name as till ceph version "19.1.0-66"
1. eventName":"ObjectLifecycle:Expiration:Noncurrent"
2. eventName":"ObjectLifecycle:transition:Noncurrent"

then post ceph version "19.2.0-X" we have 
1. eventName":"ObjectLifecycle:Expiration:NonCurrent"
2. eventName":"ObjectLifecycle:transition:NonCurrent"

just a difference in case between "NonCurrent" and "Noncurrent"

due to this script was unable to find the events in the record, so it got failed with AttributeError: for 'test_ops'
Since method verify_event_record was receiving config as none, as test config was not sent in the test declaraion
log of issue : http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9/Weekly/19.2.0-52/rgw/12/tier-2_rgw_test_bucket_notifications/notify_on_lifecycle_expiration_non_current_objects_with_prefix_rule_0.log

pass log : http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/test_lc_rule_prefix_non_current_days_notifications.console.log   

2nd change is have some buffer time for objects sync

