### PR TITLE
TFA: Fixing difference in noncurrent event type

### DIFF
--- a/rgw/v2/tests/s3_swift/reusables/bucket_notification.py
+++ b/rgw/v2/tests/s3_swift/reusables/bucket_notification.py
@@ -247,6 +247,13 @@ def verify_event_record(
             raise EventRecordDataError("event record not generated! File is empty")
 
     # verify event record for a particular event type
+    ceph_version_id, _ = utils.get_ceph_version()
+    ceph_version_id = ceph_version_id.split("-")
+    ceph_version_id = ceph_version_id[0].split(".")
+    if float(ceph_version_id[0]) >= 19:
+        non_current = "NonCurrent"
+    else:
+        non_current = "Noncurrent"
     notifications_received = False
     events = []
     if "Delete" in event_type:
@@ -265,14 +272,14 @@ def verify_event_record(
     if "LifecycleExpiration" in event_type:
         events = [
             "ObjectLifecycle:Expiration:Current",
-            "ObjectLifecycle:Expiration:Noncurrent",
+            f"ObjectLifecycle:Expiration:{non_current}",
             "ObjectLifecycle:Expiration:DeleteMarker",
             "ObjectLifecycle:Expiration:AbortMultipartUpload",
         ]
     if "LifecycleTransition" in event_type:
         events = [
             "ObjectLifecycle:Transition:Current",
-            "ObjectLifecycle:Transition:Noncurrent",
+            f"ObjectLifecycle:Transition:{non_current}",
         ]
     if "MultisiteReplication" in event_type:
         events = ["ObjectSynced:Create"]


### PR DESCRIPTION
As per BZ: 2324516
In older version:
both lifecycle expiration and transition has event name as bellow  
1. eventName":"ObjectLifecycle:Expiration:Noncurrent"
2. eventName":"ObjectLifecycle:transition:Noncurrent"

from 8.0:
1. eventName":"ObjectLifecycle:Expiration:NonCurrent"
2. eventName":"ObjectLifecycle:transition:NonCurrent"

hence making changes accordingly.

Fail log: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/fix_noncurrent/noncurrent-fail
Pass log: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/fix_noncurrent/noncurrent-pass2
