### PR TITLE
Test the CRLF fault injection using CORS

### DIFF
--- a/rgw/v2/lib/curl/resource_op.py
+++ b/rgw/v2/lib/curl/resource_op.py
@@ -10,7 +10,7 @@ log = logging.getLogger()
 
 
 class CURL:
-    def __init__(self, user_info, ssh_con, ssl=None):
+    def __init__(self, user_info, ssh_con, curl_silent=True, ssl=None):
         """
         Constructor for curl class
         user_info(dict) : user details
@@ -19,7 +19,10 @@ class CURL:
         self.username = user_info["access_key"]
         self.password = user_info["secret_key"]
         self.endpoint_url = aws_reusable.get_endpoint(ssh_con, ssl)
-        self.prefix = f"curl --show-error --fail-with-body -v -s --aws-sigv4 aws:amz:us-east-1:s3 -u '{self.username}:{self.password}'"
+        if curl_silent:
+            self.prefix = f"curl --show-error --fail-with-body -v -s --aws-sigv4 aws:amz:us-east-1:s3 -u '{self.username}:{self.password}'"
+        else:
+            self.prefix = f"curl --show-error --fail-with-body -v --aws-sigv4 aws:amz:us-east-1:s3 -u '{self.username}:{self.password}'"
         if ssl:
             self.prefix = self.prefix + " --insecure"
 

--- a/rgw/v2/tests/curl/configs/test_crlf_injection_curl.yaml
+++ b/rgw/v2/tests/curl/configs/test_crlf_injection_curl.yaml
@@ -1,0 +1,25 @@
+# script: test_cors_using_curl.py
+# polarion: CEPH-83574745
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 25
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    create_bucket: true
+    CRLF_injection: true
+    create_object: true
+    cors_origin: "http://www.cors-example.com"
+    policy_document:
+      "CORSRules":
+        [
+          {
+            "AllowedOrigins": ["http://www.cors-example.com"],
+            "AllowedHeaders": ["Authorization"],
+            "AllowedMethods": ["PUT", "GET"],
+            "ExposeHeaders": ["XXX\rArbitrary: Header\rAccess-Control-Allow-Credentials: true\rSet-Cookie: CRLF=Injection; \npath=/;"],
+            "MaxAgeSeconds": 3000,
+          },
+        ]

--- a/rgw/v2/tests/curl/reusable.py
+++ b/rgw/v2/tests/curl/reusable.py
@@ -268,11 +268,12 @@ def put_cors_object(
         input_file=s3_object_path,
         url_suffix=f"{bucket_name}/{s3_object_name}",
     )
-    upload_object_status = utils.exec_shell_cmd(command)
+    upload_object_status, err = utils.exec_shell_cmd(command, debug_info=True)
+    log.info(upload_object_status)
     if upload_object_status is False:
         raise TestExecError("object upload failed")
     log.info(f"object {s3_object_name} uploaded")
-    return True
+    return upload_object_status
 
 
 def download_object(


### PR DESCRIPTION
BZ Details : https://bugzilla.redhat.com/show_bug.cgi?id=2040886
Polarion ID : CEPH-83574745

1. create bucket 
2. set cors configuration to the created bucket with 'Expose-headers' set to CRLF fault
3. Put object with Origin header and observe the debug response the '\r' from the expose header should be escaped from the output.

Pass log : http://magna002.ceph.redhat.com/cephci-jenkins/tchandra/CRLF_injection.txt

Related pass log due to changed in curl/resource_op.py : 
http://magna002.ceph.redhat.com/cephci-jenkins/tchandra/cors_using_curl.txt
http://magna002.ceph.redhat.com/cephci-jenkins/tchandra/test_rgw_using_curl.txt