### PR TITLE
Remove the cors configuration file , as it would lead to inconsistenc…

### DIFF
--- a/rgw/v2/tests/curl/test_cors_using_curl.py
+++ b/rgw/v2/tests/curl/test_cors_using_curl.py
@@ -122,6 +122,8 @@ def test_exec(config, ssh_con):
                 utils.exec_shell_cmd(f"rm -rf  {s3_object_path}")
         if config.user_remove:
             s3_reusable.remove_user(each_user)
+        log.info("deleting the cors configuration file")
+        utils.exec_shell_cmd(f"rm -rf {file_name}")
 
     # check for any crashes during the execution
     crash_info = s3_reusable.check_for_crash()


### PR DESCRIPTION
…ies for next test in CI

Not removing the "core.json" file caused a failure in the CI run when multiple CORS tests run in the same suite.

