### PR TITLE
Test Max number of generations supported on DBR

### DIFF
--- a/rgw/v2/tests/s3_swift/multisite_configs/test_max_generations.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_max_generations.yaml
@@ -1,0 +1,11 @@
+# Polarian: CEPH-83574625
+# script: test_dynamic_bucket_resharding.py
+config:
+  objects_count: 25
+  objects_size_range:
+    min: 15
+    max: 20
+  test_ops:
+    verify_bucket_gen: true
+    verify_maxgen: true
+    delete_bucket_object: true


### PR DESCRIPTION
Polarion ID : CEPH-83574625

On a MS setup , one site can be resharded more number of times than the other site but only upto 3 times. In this test verify that the primary is resharded 3 times more than secondary.

Pass log : http://magna002.ceph.redhat.com/cephci-jenkins/tchandra/maxgen.txt

Pass log for test_bucket_generation.yaml which uses part of same code : 
http://magna002.ceph.redhat.com/cephci-jenkins/tchandra/test_bucket_generation.txt