### PR TITLE
s3 object restore feature automation

### DIFF
--- a/rgw/v2/tests/s3_swift/multisite_configs/test_lc_cloud_transition_restore_object.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_lc_cloud_transition_restore_object.yaml
@@ -1,0 +1,46 @@
+#test_bucket_lifecycle_object_expiration_transition.py
+#CEPH-83591622, CEPH-83591672, CEPH-83591621
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 10
+  parallel_lc: False
+  test_lc_transition: True
+  enable_resharding: True
+  sharding_type: manual
+  shards: 211
+  pool_name: data.cold
+  storage_class: cold
+  ec_pool_transition: False
+  multiple_transitions: True
+  two_pool_transition: False
+  second_pool_name: data.glacier
+  second_storage_class: glacier
+  remote_zone: secondary
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    create_bucket: true
+    create_object: true
+    enable_versioning: true
+    version_count: 3
+    delete_marker: false
+    test_cloud_transition: true
+    test_pool_transition: false
+    test_ibm_cloud_transition: true
+    test_aws_cloud_transition: false
+    test_retain_head: true
+    test_cloud_transition_at_remote: false
+    test_s3_restore_from_cloud: true
+  lifecycle_conf:
+    - ID: LC_Rule_1
+      Filter:
+        Prefix: key1
+      Status: Enabled
+      Transitions:
+        - Days: 2
+          StorageClass: CLOUDIBM
+      NoncurrentVersionTransitions:
+        - NoncurrentDays: 1
+          StorageClass: CLOUDIBM

--- a/rgw/v2/tests/s3_swift/reusables/s3_object_restore.py
+++ b/rgw/v2/tests/s3_swift/reusables/s3_object_restore.py
@@ -1,0 +1,106 @@
+import json
+import logging
+import os
+import random
+import time
+import timeit
+from urllib import parse as urlparse
+
+import boto3
+import v2.lib.manage_data as manage_data
+import v2.utils.utils as utils
+from botocore.exceptions import ClientError
+from v2.lib.exceptions import RGWBaseException, TestExecError
+from v2.lib.resource_op import Config
+from v2.lib.rgw_config_opts import ConfigOpts
+
+log = logging.getLogger()
+
+
+def restore_s3_object(
+    s3_client, each_user, config, bucket_name, object_key, version_id=None, days=7
+):
+    """
+    Restore an S3 object, verify restore attributes, and download the restored object.
+
+    :param bucket_name: Name of the S3 bucket.
+    :param object_key: Key of the S3 object.
+    :param version_id: Version ID of the object (optional).
+    :param days: Number of days to keep the restored object.
+    """
+    try:
+        # Initiate restore request
+        restore_request = {
+            "Days": days,
+        }
+
+        if version_id:
+            response = s3_client.restore_object(
+                Bucket=bucket_name,
+                Key=object_key,
+                VersionId=version_id,
+                RestoreRequest=restore_request,
+            )
+        else:
+            response = s3_client.restore_object(
+                Bucket=bucket_name, Key=object_key, RestoreRequest=restore_request
+            )
+
+        log.info("Restore initiated:", response)
+
+        # Validate restore attributes
+        head_response = s3_client.head_object(
+            Bucket=bucket_name, Key=object_key, VersionId=version_id
+        )
+        log.info(f" the head_object is  {head_response}")
+        restore_status = head_response.get("Restore", "")
+        if 'ongoing-request="false"' in restore_status:
+            log.info("Object is successfully restored.")
+        else:
+            log.info("Restore status:", restore_status)
+
+        # Download the restored object
+        download_path = f"restored-{object_key}"
+        s3_client.download_file(
+            Bucket=bucket_name,
+            Key=object_key,
+            Filename=download_path,
+            ExtraArgs={"VersionId": version_id} if version_id else None,
+        )
+        log.info(f"Restored object downloaded to {download_path}.")
+
+    except ClientError as e:
+        log.info("Error:", e)
+
+
+def check_restore_expiry(
+    s3_client, each_user, config, bucket_name, object_key, version_id=None
+):
+    """
+    Check if the restored object is no longer accessible after the restore period.
+
+    :param s3_client: The S3 client instance.
+    :param bucket_name: Name of the S3 bucket.
+    :param object_key: Key of the S3 object.
+    :param version_id: Version ID of the object (optional).
+    """
+    try:
+        download_path = f"expired-{object_key}"
+        s3_client.download_file(
+            Bucket=bucket_name,
+            Key=object_key,
+            Filename=download_path,
+            ExtraArgs={"VersionId": version_id} if version_id else None,
+        )
+        raise Exception(
+            "Unexpected: Object is still accessible after the restore period."
+        )
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "NoSuchKey":
+            log.info("Restore has expired and the object is no longer accessible.")
+        elif e.response["Error"]["Code"] == "InvalidObjectState":
+            log.info(
+                "Restore has expired, and the object is no longer in a restored state."
+            )
+        else:
+            log.info("Error while checking restore expiration:", e)


### PR DESCRIPTION


This PR addresses feature automation for the s3 restore object feature and automates the below test cases

https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83591621
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83591622
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83591623
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83591672

Note: 
- The time for object restoration interval has been 7 days which is 210 seconds (based on the 30 seconds proxy LC debug interval.)
- 210 seconds also ensures an object is restored and downloaded within that interval, after which the objects would not be accessed.


logs 
[deploy_cluster_0.log](https://github.com/user-attachments/files/18313624/deploy_cluster_0.log)
[setup_2-way_multisite_0.log](https://github.com/user-attachments/files/18313625/setup_2-way_multisite_0.log)
[create_non-tenanted_user_0.log](https://github.com/user-attachments/files/18313627/create_non-tenanted_user_0.log)
[configure_client_0.log](https://github.com/user-attachments/files/18313633/configure_client_0.log)
[test_s3_object_restore_and_download,_and_restore_attrs_0.log](https://github.com/user-attachments/files/18320842/test_s3_object_restore_and_download._and_restore_attrs_0.log)

