### PR TITLE
Automation of Inditex hotfix bz testing: CORS presigned put url

### DIFF
--- a/rgw/v2/tests/curl/configs/test_cors_presigned_put_url_using_curl.yaml
+++ b/rgw/v2/tests/curl/configs/test_cors_presigned_put_url_using_curl.yaml
@@ -1,0 +1,28 @@
+# script: test_cors_using_curl.py
+# polarion: CEPH-83604475
+# hotfix bz: https://bugzilla.redhat.com/show_bug.cgi?id=2299642
+config:
+  user_count: 1
+  bucket_count: 2
+  objects_count: 25
+  objects_size_range:
+    min: 5
+    max: 15
+  local_file_delete: true
+  test_ops:
+    create_bucket: true
+    create_object: true
+    user_remove: true
+    cors_origin: "http://www.cors-example.com"
+    cors_presigned_put_url: true
+    object_acl: "private"
+    policy_document:
+      "CORSRules":
+        [
+          {
+            "AllowedOrigins": ["http://www.cors-example.com"],
+            "AllowedHeaders": ["*"],
+            "AllowedMethods": ["PUT", "GET", "DELETE"],
+            "MaxAgeSeconds": 3000
+          },
+        ]

--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -2742,3 +2742,14 @@ def get_object_attributes(
         else:
             log.info(f"{attr} verified successfully")
     log.info("GetObjectAttributes verified successfully")
+
+
+def generate_presigned_url(rgw_s3_client, client_method, http_method, params):
+    log.info(
+        f"generating presigned url for client_method {client_method}, http_method {http_method} with params {params}"
+    )
+    presigned_url = rgw_s3_client.generate_presigned_url(
+        ClientMethod=client_method, HttpMethod=http_method, Params=params
+    )
+    log.info(f"presigned_url: {presigned_url}")
+    return presigned_url


### PR DESCRIPTION
CORS ACL's prevents access to buckets with presigned PUT URI's with ACL:private header
hotfix bz: https://bugzilla.redhat.com/show_bug.cgi?id=2299642
polarion: https://polarion.engineering.redhat.com/polarion/redirect/project/CEPH/workitem?id=CEPH-83604475

pass logs:
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_hotfix_inditex_cors_presigned_put_url/test_cors_presigned_put_url_using_curl.console.log

sample pass logs for other configs:
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_hotfix_inditex_cors_presigned_put_url/