### PR TITLE
[Customer-BZ][Automation]: radosgw-admin lc process --bucket <bucket>…

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_lc_process_with_versioning_suspended.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_process_with_versioning_suspended.yaml
@@ -1,0 +1,25 @@
+# Customer BZ:2319199
+# Polarion ID: CEPH-83574809
+# Script file: s3_swift/test_bucket_lifecycle_object_expiration_transition.py
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 10
+  parallel_lc: false
+  rgw_lc_debug_interval: 600
+  rgw_enable_lc_threads: false
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    create_bucket: true
+    create_object: true
+    enable_versioning: false
+    lc_process_with_ver_suspended: true
+  lifecycle_conf:
+    - ID: LC_Rule_1
+      Filter:
+        Prefix: key1
+      Status: Enabled
+      Expiration:
+        Date: "2022-01-01"

--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -774,6 +774,29 @@ def enable_versioning(bucket, rgw_conn, user_info, write_bucket_io_info):
         raise TestExecError("version enable failed")
 
 
+def suspend_versioning(bucket, rgw_conn, user_info, write_bucket_io_info):
+    """
+    Method to perform suspend versioning operation
+    bucket: Name of teh bucket
+    rgw_conn: rgw connection
+    user_info: user info
+    """
+    bucket_versioning = s3lib.resource_op(
+        {"obj": rgw_conn, "resource": "BucketVersioning", "args": [bucket.name]}
+    )
+    version_suspended_status = s3lib.resource_op(
+        {"obj": bucket_versioning, "resource": "suspend", "args": None}
+    )
+    suspended_response = HttpResponseParser(version_suspended_status)
+    if suspended_response.status_code == 200:
+        log.info("version Suspended Successfully")
+        write_bucket_io_info.add_versioning_status(
+            user_info["access_key"], bucket.name, "suspended"
+        )
+    else:
+        raise TestExecError("Suspending versioning is failed")
+
+
 def generate_totp(seed):
     cmd = "oathtool -d6 --totp %s" % seed
     totp_token = utils.exec_shell_cmd(cmd)


### PR DESCRIPTION
… doesn't remove objects if versioning is suspended

[Customer-BZ][Automation]: radosgw-admin lc process --bucket <bucket> doesn't remove objects if versioning is suspended
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2319199

Log: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/lc_process_with_ver_suspended/test_lc_process_with_versioning_suspended.console.log_final

Failure expected since BZ not fixed yet.

pass logs for some existing configs:
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-Q0APPH/