### PR TITLE
correcting the sleep time to 240 seconds

### DIFF
--- a/rgw/v2/tests/s3_swift/test_bucket_lifecycle_object_expiration_transition.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_lifecycle_object_expiration_transition.py
@@ -532,7 +532,7 @@ def test_exec(config, ssh_con):
                 log.info(
                     "Test restored objects are not available after restore interval"
                 )
-                time.sleep(210)
+                time.sleep(240)
                 for i in range(0, objs_total):
                     if json_doc_list[i]["tag"] != "delete-marker":
                         object_key = json_doc_list[i]["name"]


### PR DESCRIPTION
correcting the sleep time to 240 seconds

with 210 seconds, it fails with object still accessible http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-D181H9/test_s3_object_restore_and_download,_and_restore_attrs_0.log