### PR TITLE
[Tier-2] datalog trimming post restart of rgw service

### DIFF
--- a/rgw/v2/tests/s3_swift/multisite_configs/test_datalog_trimming_post_rgw_restart.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_datalog_trimming_post_rgw_restart.yaml
@@ -1,0 +1,15 @@
+# upload type: non multipart
+# script: test_bilog_trimming.py
+# polarion_id: CEPH-10959
+config:
+  log_trimming: datalog
+  user_count: 1
+  bucket_count: 2
+  objects_count: 100
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    create_bucket: true
+    create_object: true
+    datalog_trim_post_rgw_restart: true

--- a/rgw/v2/tests/s3_swift/test_bilog_trimming.py
+++ b/rgw/v2/tests/s3_swift/test_bilog_trimming.py
@@ -6,6 +6,10 @@ Usage: test_bilog_trimming.py -c <input_yaml>
 <input_yaml>
     Note: Following yaml can be used
     test_bilog_trimming.yaml
+    test_bilog_trim_archive.yaml
+    test_datalog_trimming.yaml
+    test_mdlog_trimming.yaml
+    test_datalog_trimming_post_rgw_restart.yaml
 
 Operation:
     Create an user
@@ -35,6 +39,7 @@ from v2.lib.s3.write_io_info import BasicIOInfoStructure, IOInfoInitialize
 from v2.tests.s3_swift import reusable
 from v2.utils.log import configure_logging
 from v2.utils.test_desc import AddTestInfo
+from v2.utils.utils import RGWService
 
 log = logging.getLogger()
 TEST_DATA_PATH = None
@@ -82,6 +87,13 @@ def test_exec(config, ssh_con):
                             config,
                             each_user,
                         )
+                if config.test_ops.get("datalog_trim_post_rgw_restart", False) is True:
+                    rgw_service = RGWService()
+                    log.info("trying to restart services")
+                    srv_restarted = rgw_service.restart(ssh_con)
+                    time.sleep(30)
+                    if srv_restarted is False:
+                        raise TestExecError("RGW service restart failed")
 
                 # test log trimming
                 reusable.test_log_trimming(bucket, config)


### PR DESCRIPTION
 Post restart of rgw service perform datalog trim issue should not be seen https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-10959
 
 log : http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/test_datalog_trimming_post_rgw_restart.console.log
 
 other log: 
 bilog trim : http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-M9YUEX/test_no_bilogs_are_generated_at_archive_zone_0.log
 mdlog trim : http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-M9YUEX/Mdlog_trimming_test_on_primary_0.log
 datalog: http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-M9YUEX/Datalog_trimming_test_on_primary_0.log