### PR TITLE
[CEPH-83604857]:Tags added during multipart upload are not retrievable

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_multipart_upload_with_tagging.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_multipart_upload_with_tagging.yaml
@@ -1,0 +1,25 @@
+# script: test_Mbuckets_with_Nobjects.py
+# upload type: Multipart
+# Polarion ID: CEPH-83604857
+# BZ: 2323604, 2336076, 2336077
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 1
+  abort_multipart: false
+  split_size: 200
+  objects_size_range:
+    min: 1G
+    max: 2G
+  test_ops:
+    create_bucket: true
+    create_object: true
+    download_object: false
+    delete_bucket_object: false
+    multipart_upload_with_tag: true
+    sharding:
+      enable: false
+      max_shards: 0
+    compression:
+      enable: false
+      type: zlib

--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -511,6 +511,7 @@ def upload_mutipart_object(
     append_msg=None,
     abort_multipart=False,
     complete_abort_race=False,
+    obj_tag=None,
 ):
     log.info("s3 object name: %s" % s3_object_name)
     s3_object_path = os.path.join(TEST_DATA_PATH, s3_object_name)
@@ -550,14 +551,16 @@ def upload_mutipart_object(
         }
     )
     log.info("initiating multipart upload")
-    mpu = s3lib.resource_op(
-        {
-            "obj": s3_obj,
-            "resource": "initiate_multipart_upload",
-            "args": None,
-            "extra_info": upload_info,
-        }
-    )
+    mpu_dict = {
+        "obj": s3_obj,
+        "resource": "initiate_multipart_upload",
+        "args": None,
+        "extra_info": upload_info,
+    }
+    if obj_tag:
+        mpu_dict.update({"kwargs": {"Tagging": obj_tag}})
+
+    mpu = s3lib.resource_op(mpu_dict)
     part_number = 1
     parts_info = {"Parts": []}
     if config.test_ops.get("test_get_object_attributes"):

--- a/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
+++ b/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
@@ -966,7 +966,32 @@ def test_exec(config, ssh_con):
             if final_op != -1:
                 test_info.failed_status("test failed")
                 sys.exit(1)
+        if config.test_ops.get("multipart_upload_with_tag", False):
+            log.info("Testing tag retrival post multipart upload")
+            obj_tag = "mpupload=mpupload"
+            abort_multipart = (config.abort_multipart, False)
+            object_parts_info = reusable.upload_mutipart_object(
+                s3_object_name,
+                bucket,
+                TEST_DATA_PATH,
+                config,
+                each_user,
+                abort_multipart=abort_multipart,
+                obj_tag=obj_tag,
+            )
 
+            log.info("Verify Tag applied is retirievable")
+            log.info(f"object: {s3_object_name}")
+            get_obj_tagging_result = s3lib.resource_op(
+                {
+                    "obj": rgw_conn2,
+                    "resource": "get_object_tagging",
+                    "kwargs": dict(Bucket=bucket.name, Key=s3_object_name),
+                }
+            )
+            log.info(f"get_obj_tagging_result: {get_obj_tagging_result}")
+            if not get_obj_tagging_result.get("TagSet"):
+                raise AssertionError("Tag retrival is failed for multipart objects!")
     # test async rgw_data_notify_interval_msec=0 does not disable async data notifications
     if config.test_aync_data_notifications:
         log.info("Testing async data notifications")


### PR DESCRIPTION
[CEPH-83604857]: Tags added during multipart upload should be retrievable
Polarian: https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83604857
Bugzilla : https://bugzilla.redhat.com/show_bug.cgi?id=2323604

Log: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/mp_tag_retrival/new/test_multipart_upload_with_tagging.console.log-71z3-reproduced

failure expected since BZ is not fixed.

Logs for other existing configs:
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/mp_tag_retrival/new/