### PR TITLE
adding support for testing public_access_block

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_public_access_block_acl.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_public_access_block_acl.yaml
@@ -1,0 +1,16 @@
+# script: test_bucket_policy_ops.py
+# customer bz: https://bugzilla.redhat.com/show_bug.cgi?id=2064260
+# polarion id: CEPH-83575582
+config:
+  objects_count: 25
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    upload_type: normal
+    put_public_access_block: True
+    public_access_block_config:
+      {
+        "BlockPublicAcls": True
+      }
+    verify_public_acl: True

--- a/rgw/v2/tests/s3_swift/configs/test_public_access_block_ignore_acl.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_public_access_block_ignore_acl.yaml
@@ -1,0 +1,16 @@
+# script: test_bucket_policy_ops.py
+# customer bz: https://bugzilla.redhat.com/show_bug.cgi?id=2064260
+# polarion id: CEPH-83575582
+config:
+  objects_count: 25
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    upload_type: normal
+    put_public_access_block: True
+    public_access_block_config:
+      {
+        "IgnorePublicAcls": True
+      }
+    verify_public_acl: True

--- a/rgw/v2/tests/s3_swift/configs/test_public_access_block_post_bucket_policy.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_public_access_block_post_bucket_policy.yaml
@@ -1,0 +1,28 @@
+# script: test_bucket_policy_ops.py
+# customer bz: https://bugzilla.redhat.com/show_bug.cgi?id=2064260
+# polarion id: CEPH-83575582
+config:
+  objects_count: 25
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    upload_type: normal
+    put_public_access_block_post_bucket_policy: True
+    public_access_block_config:
+      {
+        "BlockPublicPolicy": True
+      }
+    policy_document:
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Action": "s3:*",
+            "Principal": {"AWS": "*"},
+            "Resource": "arn:aws:s3:::*",
+            "Effect": "Allow",
+            "Sid": "statement1",
+          }
+        ],
+      }

--- a/rgw/v2/tests/s3_swift/configs/test_public_access_block_pre_bucket_policy.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_public_access_block_pre_bucket_policy.yaml
@@ -1,0 +1,29 @@
+# script: test_bucket_policy_ops.py
+# customer bz: https://bugzilla.redhat.com/show_bug.cgi?id=2064260
+# polarion id: CEPH-83575582
+config:
+  objects_count: 25
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    upload_type: normal
+    put_public_access_block: True
+    test_public_access_block_pre_bucket_policy: True
+    public_access_block_config:
+      {
+        "BlockPublicPolicy": True
+      }
+    policy_document:
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Action": "s3:*",
+            "Principal": {"AWS": "*"},
+            "Resource": "arn:aws:s3:::*",
+            "Effect": "Allow",
+            "Sid": "statement1",
+          }
+        ],
+      }

--- a/rgw/v2/tests/s3_swift/configs/test_public_access_block_restricted_public_buckets.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_public_access_block_restricted_public_buckets.yaml
@@ -1,0 +1,46 @@
+# script: test_bucket_policy_ops.py
+# customer bz: https://bugzilla.redhat.com/show_bug.cgi?id=2064260
+# polarion id: CEPH-83575582
+config:
+  objects_count: 25
+  objects_size_range:
+    min: 5
+    max: 15
+  encryption_keys: kms
+  lifecycle_conf:
+    - ID: LC_Rule_1
+      Filter:
+        Prefix: key2
+      Status: Enabled
+      Expiration:
+        Days: 20
+  test_ops:
+    upload_type: normal
+    put_public_access_block: True
+    verify_restricted_public_buckets: True
+    public_access_block_config:
+      {
+        "RestrictPublicBuckets": True
+      }
+    verify_policy: True
+    endpoint: kafka
+    ack_type: broker
+    bucket_tags: [
+      {
+          "Key": "product",
+          "Value": "ceph"
+      }
+    ]
+    policy_document:
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Action": ["s3:PutObject", "s3:ListBucket", "s3:GetObject", "s3:DeleteObject", "s3:AbortMultipartUpload", "s3:PutBucketVersioning", "s3:GetBucketVersioning", "s3:PutBucketWebsite", "s3:GetBucketWebsite", "s3:PutLifecycleConfiguration", "s3:GetLifecycleConfiguration", "s3:PutBucketEncryption", "s3:GetBucketEncryption", "s3:PutBucketTagging", "s3:GetBucketTagging", "s3:PutBucketPolicy", "s3:GetBucketPolicy", "s3:DeleteBucketPolicy"],
+            "Principal": {"AWS": "*"},
+            "Resource": "arn:aws:s3:::*",
+            "Effect": "Allow",
+            "Sid": "statement1",
+          }
+        ],
+      }

--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -152,17 +152,13 @@ def create_bucket_readonly(bucket_name, rgw, user_info):
         log.info("Bucket creation failed as expected")
 
 
-def set_get_object_acl(
-    s3_object_name,
-    bucket_name,
-    rgw_conn2,
-):
+def set_get_object_acl(s3_object_name, bucket_name, rgw_conn2, acl="private"):
     """
     put object acl as private for a given object
     """
     log.info("Set object acl on s3 object name: %s" % s3_object_name)
     put_obj_acl = rgw_conn2.put_object_acl(
-        ACL="private", Bucket=bucket_name, Key=s3_object_name
+        ACL=acl, Bucket=bucket_name, Key=s3_object_name
     )
     if put_obj_acl:
         get_obj_acl = rgw_conn2.get_object_acl(Bucket=bucket_name, Key=s3_object_name)
@@ -2769,3 +2765,29 @@ def generate_presigned_url(rgw_s3_client, client_method, http_method, params):
     )
     log.info(f"presigned_url: {presigned_url}")
     return presigned_url
+
+
+def put_get_public_access_block(rgw_s3_client, bucket_name, public_access_block_config):
+    log.info(
+        f"setting public access block for bucket {bucket_name} with config {public_access_block_config}"
+    )
+    put_response = rgw_s3_client.put_public_access_block(
+        Bucket=bucket_name, PublicAccessBlockConfiguration=public_access_block_config
+    )
+    log.info(f"put response: {put_response}")
+    get_response = rgw_s3_client.get_public_access_block(Bucket=bucket_name)
+    log.info(f"get response: {get_response}")
+    return True
+
+
+def put_get_bucket_acl(rgw_client, bucket_name, acl):
+    """
+    put bucket acl for a given object
+    """
+    log.info(f"Set bucket acl on bucket : {bucket_name}")
+    put_bkt_acl = rgw_client.put_bucket_acl(ACL=acl, Bucket=bucket_name)
+    log.info(f"put bucket acl resp: {put_bkt_acl}")
+
+    get_bkt_acl = rgw_client.get_bucket_acl(Bucket=bucket_name)
+    get_bkt_acl_json = json.dumps(get_bkt_acl, indent=2)
+    log.info(f"get bucket acl response: {get_bkt_acl_json}")


### PR DESCRIPTION
customer bz: https://bugzilla.redhat.com/show_bug.cgi?id=2064260
polarion: https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83575582

pass logs: http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_public_access_block/new_pass_logs/

failures are product bugs, filed below bz's for them:
[Bug 2344639](https://bugzilla.redhat.com/show_bug.cgi?id=2344639) - [rgw] public-access-block with BlockPublicAcls set on a Bucket is denying normal object upload without any public-acl in the request

[Bug 2344730](https://bugzilla.redhat.com/show_bug.cgi?id=2344730) - [rgw] public-access-block with RestrictPublicBuckets set and then bucket policy with public access set on a bucket is still allowing anonymous public access to the bucket

sample pass log for existing config: http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_public_access_block/new_pass_logs/test_bucket_policy_multiple_statements.console.log