### PR TITLE
adding support for lc processing on existing user and bucket passed from the config

### DIFF
--- a/rgw/v2/lib/resource_op.py
+++ b/rgw/v2/lib/resource_op.py
@@ -68,7 +68,9 @@ def resource_op(exec_info):
         return False
 
 
-def create_users(no_of_users_to_create, user_names=None, cluster_name="ceph"):
+def create_users(
+    no_of_users_to_create, user_names=None, cluster_name="ceph", config=None
+):
     """
     This function is to create n users on the cluster
 
@@ -83,11 +85,11 @@ def create_users(no_of_users_to_create, user_names=None, cluster_name="ceph"):
     all_users_details = []
     primary = utils.is_cluster_primary()
     user_detail_file = os.path.join(lib_dir, "user_details.json")
-    if primary:
+    if primary or (config and config.user_names):
         for i in range(no_of_users_to_create):
             if user_names:
                 user_details = admin_ops.create_admin_user(
-                    user_id=user_names,
+                    user_id=user_names[i],
                     displayname=user_names,
                     cluster_name=cluster_name,
                 )
@@ -308,6 +310,7 @@ class Config(object):
             "rgw_lifecycle_work_time", "00:00-06:00"
         )
         self.rgw_lc_max_worker = self.doc["config"].get("rgw_lc_max_worker", 10)
+        self.rgw_lc_max_wp_worker = self.doc["config"].get("rgw_lc_max_wp_worker", 10)
         self.parallel_lc = self.doc["config"].get("parallel_lc", False)
         self.multiple_delete_marker_check = self.doc["config"].get(
             "multiple_delete_marker_check", False
@@ -440,6 +443,8 @@ class Config(object):
         )
         self.user_conflict_write_ops = self.doc["config"].get("user_conflict_write_ops")
         self.permutation_count = self.doc["config"].get("permutation_count")
+        self.user_names = self.doc["config"].get("user_names")
+        self.bucket_names = self.doc["config"].get("bucket_names")
         ceph_version_id, ceph_version_name = utils.get_ceph_version()
         # todo: improve Frontend class
         if ceph_version_name in ["luminous", "nautilus"]:


### PR DESCRIPTION
this PR contains below changes:
1. make necessary changes for lc_exp_tran test so that we can pass user name and bucket names from the config that will enable lc exp and tran test automation at scale.
2. added a config variable `set_ceph_configs_to_all_daemons` to leverage existing support of setting ceph configs to all rgw daemons, so that lc transition/expiration happens aggressively.
3. also added support for restarting all rgw daemons with the same above config parameter. introduced a new method in utils. restart_rgw instead of disturbing the existing code.
4. also added support for setting `rgw_lc_max_wp_worker` to 10. its default vaule is 3. `rgw_lc_max_worker` is useful if we have multiple buckets and `rgw_lc_max_wp_worker` helps to accelerate processing for each bucket. refer https://www.ibm.com/docs/en/storage-ceph/7?topic=storage-optimizing-bucket-lifecycle
5. added support to set same lc config parameters on multisite as well, to test if lc expiration taking effect on the other site. I have done minor tweaks to remote_exec_shell_cmd to execute the commands on the other site.

polarion:
[CEPH-83574046 - Test transition 12: Test bulk transition of objects (around ~1 to 2M)](https://polarion.engineering.redhat.com/polarion/redirect/project/CEPH/workitem?id=CEPH-83574046)
[CEPH-83575432 - Deleting millions of objects via LC from Primary](https://polarion.engineering.redhat.com/polarion/redirect/project/CEPH/workitem?id=CEPH-83575432)
[CEPH-83574800 - Scale tests [LC]: Delete saturation tests with lc_debug_interval = 3600](https://polarion.engineering.redhat.com/polarion/redirect/project/CEPH/workitem?id=CEPH-83574800)


sample pass logs with 5000 objects on VM cluster:
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_lc_baremetal_changes/cephci-run-7YO4D3/
(failure is because of timing issue, exp took more time than expected)

pass log for parallel object and lc expiration on mero single site cluster: with 100K objects: http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_lc_baremetal_changes/cephci-run-EGQZEH/

pass logs (incremental) for lc transition and expiration tests with 100K objects on multisite scale cluster(as mero multisite is in error state, tested on extensa):
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_lc_baremetal_changes/cephci-run-CLSM5S/ (haproxy and cosbench deployment)
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_lc_baremetal_changes/cephci-run-X9FP0I/ (lc transition failed because of sync rgw crash)
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_lc_baremetal_changes/cephci-run-TZR29T/ (lc exp failed because of of rga command incorrect, automation issue)
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_lc_baremetal_changes/test_lc_exp_on_600K_objects.console.log(updated pass log for lc exp test)

sample pass logs for existing configs of lc transition and expiration:
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_lc_baremetal_changes/test_lc_transition_with_prefix_rule.console.log
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_lc_baremetal_changes/test_lc_rule_prefix_and_tag.console.log