### PR TITLE
automate testing of hotfix bz2337265: segfault in kafka topic name compare operator overload

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_kafka_broker_multipart_with_kafka_acl_config_set.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_kafka_broker_multipart_with_kafka_acl_config_set.yaml
@@ -1,0 +1,24 @@
+# test-script: test_bucket_notifications.py
+# polarion-id: CEPH-83607419
+config:
+ user_count: 1
+ bucket_count: 2
+ objects_count: 100
+ local_file_delete: true
+ objects_size_range:
+  min: 6M
+  max: 8M
+ test_ops:
+  create_bucket: true
+  create_object: true
+  enable_version: false
+  create_topic: true
+  get_topic_info: true
+  endpoint: kafka
+  ack_type: broker
+  put_get_bucket_notification: true
+  event_type: Multipart
+  upload_type: multipart
+  delete_bucket_object: false
+  add_acl_config_in_kafka_properties: true
+  expected_event_record_empty: true

--- a/rgw/v2/tests/s3_swift/reusables/bucket_notification.py
+++ b/rgw/v2/tests/s3_swift/reusables/bucket_notification.py
@@ -54,6 +54,19 @@ def start_stop_kafka_server(option):
     log.info(f"kafka and zookeeper servers {option} successful")
 
 
+def add_acl_authorizer_config_in_kafka_properties():
+    """
+    add acl authorizer config in kafka server.properties to configure acl security.
+    """
+    acl_config = "authorizer.class.name=kafka.security.authorizer.AclAuthorizer"
+    log.info(
+        f"adding acl config to {KAFKA_HOME}/config/server.properties : '{acl_config}'"
+    )
+    cmd = f"echo '{acl_config}' >> {KAFKA_HOME}/config/server.properties"
+    utils.exec_shell_cmd(cmd)
+    log.info(f"acl config added successfully to {KAFKA_HOME}/config/server.properties")
+
+
 def start_kafka_broker_consumer(topic_name, event_record_path):
     """
     start kafka consumer
@@ -242,7 +255,10 @@ def verify_event_record(
     """
     if os.path.getsize(event_record_path) == 0:
         if config and config.test_ops.get("test_delete_object_sync_archive", False):
-            log.info("event record not generated! File is empty, excpected behavior")
+            log.info("event record not generated! File is empty, expected behavior")
+        elif config and config.test_ops.get("expected_event_record_empty", False):
+            log.info("event record not generated! File is empty, expected behavior")
+            return
         else:
             raise EventRecordDataError("event record not generated! File is empty")
 

--- a/rgw/v2/tests/s3_swift/test_bucket_notifications.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_notifications.py
@@ -26,6 +26,7 @@ Usage: test_bucket_notification.py -c <input_yaml>
     test_sse_s3_per_bucket_with_notifications_dynamic_reshard.yaml
     multisite_configs/test_bucket_notification_kafka_broker_archive_delete_replication_from_pri.yaml
     test_bucket_notification_kafka_broker_rgw_admin_notif_rm.yaml
+    test_bucket_notification_kafka_broker_multipart_with_kafka_acl_config_set.yaml
 Operation:
     create user (tenant/non-tenant)
     Create topic and get topic
@@ -76,6 +77,11 @@ def test_exec(config, ssh_con):
 
     if config.test_ops.get("Filter", False) is False:
         config.test_ops["Filter"] = notification.Filter
+
+    if config.test_ops.get("add_acl_config_in_kafka_properties", False):
+        notification.add_acl_authorizer_config_in_kafka_properties()
+        notification.start_stop_kafka_server("stop")
+        notification.start_stop_kafka_server("start")
 
     if config.enable_resharding and config.sharding_type == "dynamic":
         reusable.set_dynamic_reshard_ceph_conf(config, ssh_con)


### PR DESCRIPTION
the issue(rgw crash) is reproduced on the buggy build if I add acl config to the kafka server.properties and upload some objects

hotfix bz: https://bugzilla.redhat.com/show_bug.cgi?id=2337265
polarion: [CEPH-83607419 : segfault in kafka topic name compare operator overload](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83607419)

pass logs:
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_MOD_kafka_topic_name_crash/cephci-run-DOUZYZ/

pass logs for existing config: 
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_MOD_kafka_topic_name_crash/cephci-run-ND4QAA/