### PR TITLE
Ratelimit division on multiple RGW daemon in the cluster

### DIFF
--- a/rgw/v2/tests/s3cmd/configs/test_ratelimit_split.yaml
+++ b/rgw/v2/tests/s3cmd/configs/test_ratelimit_split.yaml
@@ -1,0 +1,17 @@
+# script: test_rate_limit.py
+# Polarion ID : CEPH-83574917
+config:
+  user_count: 1
+  bucket_count: 1
+  user_type: non-tenanted
+  version_enable: False
+  bucket_max_read_ops: 2
+  bucket_max_read_bytes: 4096
+  bucket_max_write_ops: 2
+  bucket_max_write_bytes: 4096
+  user_max_read_bytes: 4096
+  user_max_read_ops: 2
+  user_max_write_bytes: 4096
+  user_max_write_ops: 2
+  test_ops:
+    daemon_add: true

--- a/rgw/v2/tests/s3cmd/reusable.py
+++ b/rgw/v2/tests/s3cmd/reusable.py
@@ -267,6 +267,23 @@ def rgw_service_restart(ssh_con):
         raise TestExecError("RGW service restart failed")
 
 
+def rgw_daemon_add(ssh_con):
+    """
+    Add a new RGW daemon on the provided node
+    """
+    log.info("Adding a new RGW daemon on the current port +1")
+    ip_port = get_rgw_ip_and_port(ssh_con)
+    rgw_ip = ip_port.split(":")[0]
+    rgw_port = ip_port.split(":")[1]
+    rgw_port = int(rgw_port) + 1
+    _, stdout, _ = ssh_con.exec_command("hostname")
+    hostname = stdout.readline().strip()
+    cmd = f"ceph orch apply rgw foo --placement {str(hostname)} --port {rgw_port}"
+    log.info(cmd)
+    _, stdout, _ = ssh_con.exec_command(cmd)
+    time.sleep(20)
+
+
 def run_subprocess(cmd):
     """
     :param cmd: command to run


### PR DESCRIPTION
Polarion ID : CEPH-83574917

When more than 1 RGW daemon is present in the cluster , the rate limits configured have to be divided between the daemons. We add a RGW and verify that the rate limit is halved.

We have a known issue
BZ : https://bugzilla.redhat.com/show_bug.cgi?id=2349530

Fail log : http://magna002.ceph.redhat.com/cephci-jenkins/tchandra/ratelimit_division.txt