### PR TITLE
[Tier-4]: CEPH-83572752 - RGW multisite sync Error log

### DIFF
--- a/rgw/v2/tests/s3cmd/multisite_configs/test_sync_error_list.yaml
+++ b/rgw/v2/tests/s3cmd/multisite_configs/test_sync_error_list.yaml
@@ -1,0 +1,5 @@
+# script: test_s3cmd.py
+# polarion id: CEPH-83572752
+config:
+    test_ops:
+        sync_error_list: true


### PR DESCRIPTION
log : 
    http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/test_sync_error_list.console.log
    http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/test_sync_error_list_pri.console.log
    
    Performing radosgw-admin sync error list in the ceph cluster, if error exist we can trim error using sync error trim. But trimming the error is not recommended as error can be a genuine issue, So in this pr if radosgw-admin sync error list does not have entries as empty that means sync error exist in cluster and failing the testcase. 
    

