### PR TITLE
CEPH-83574448: Verify node reboot during I/O Sync

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_sync_consistent_with_node_reboot.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sync_consistent_with_node_reboot.yaml
@@ -1,0 +1,5 @@
+# Script: test_sync_conistent_with_rgw_node_reboot.py
+# Polarion ID: CEPH-83574448
+config:
+  test_ops:
+    rgw_service_name: "rgw.shared.sec"

--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -3054,9 +3054,9 @@ def node_reboot(node, service_name=None, retry=15, delay=60):
     Node: ssh connection for the node
     service_name: RGW service name
     retry: retry to wait foe node/service to come up post reboot
-    delay: sllep time of 1 min between each try
+    delay: sleep time of 1 min between each try
     """
-    log.debug(f"Peforming reboot of the node : {node}")
+    log.info(f"Peforming reboot of the node : {node}")
     node.exec_command("sudo reboot")
     time.sleep(120)
     log.info(f"checking ceph status")

--- a/rgw/v2/tests/s3_swift/test_sync_conistent_with_rgw_node_reboot.py
+++ b/rgw/v2/tests/s3_swift/test_sync_conistent_with_rgw_node_reboot.py
@@ -1,0 +1,92 @@
+"""
+test_sync_conistent_with_rgw_node_reboot.py
+          - Test sync consistent with the multisite setup post rebooting rgw nodes 
+
+Usage : test_sync_conistent_with_rgw_node_reboot.py -c <input_yaml>
+<input_yaml>
+    test_sync_consistent_with_node_reboot.yaml
+"""
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(__file__, "../../../..")))
+import argparse
+import logging
+import time
+import traceback
+
+import v2.utils.utils as utils
+from v2.lib.exceptions import RGWBaseException, TestExecError
+from v2.lib.resource_op import Config
+from v2.lib.s3.auth import Auth
+from v2.lib.s3.write_io_info import BasicIOInfoStructure, IOInfoInitialize
+from v2.tests.s3_swift import reusable
+from v2.utils.log import configure_logging
+from v2.utils.test_desc import AddTestInfo
+from v2.utils.utils import RGWService
+
+log = logging.getLogger()
+TEST_DATA_PATH = None
+
+
+def test_exec(config, ssh_con):
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    out = reusable.check_sync_status(return_while_sync_inprogress=True)
+    if str(out) != "sync_progress":
+        raise AssertionError("sync status is not in progress!!")
+    reusable.reboot_rgw_nodes()
+    reusable.check_sync_status()
+
+    crash_info = reusable.check_for_crash()
+    if crash_info:
+        raise TestExecError("ceph daemon crash found!")
+
+
+if __name__ == "__main__":
+
+    test_info = AddTestInfo(
+        "Test Sync consistency post stoping and staring rgw services"
+    )
+
+    try:
+        project_dir = os.path.abspath(os.path.join(__file__, "../../.."))
+        test_data_dir = "test_data"
+        TEST_DATA_PATH = os.path.join(project_dir, test_data_dir)
+        log.info("TEST_DATA_PATH: %s" % TEST_DATA_PATH)
+        if not os.path.exists(TEST_DATA_PATH):
+            log.info("test data dir not exists, creating.. ")
+            os.makedirs(TEST_DATA_PATH)
+        parser = argparse.ArgumentParser(
+            description="Test Sync consistency post stoping and staring rgw services"
+        )
+        parser.add_argument("-c", dest="config", help="RGW Test yaml configuration")
+        parser.add_argument(
+            "-log_level",
+            dest="log_level",
+            help="Set Log Level [DEBUG, INFO, WARNING, ERROR, CRITICAL]",
+            default="info",
+        )
+        parser.add_argument(
+            "--rgw-node", dest="rgw_node", help="RGW Node", default="127.0.0.1"
+        )
+        args = parser.parse_args()
+        yaml_file = args.config
+        rgw_node = args.rgw_node
+        ssh_con = None
+        if rgw_node != "127.0.0.1":
+            ssh_con = utils.connect_remote(rgw_node)
+        log_f_name = os.path.basename(os.path.splitext(yaml_file)[0])
+        configure_logging(f_name=log_f_name, set_level=args.log_level.upper())
+        config = Config(yaml_file)
+        config.read(ssh_con)
+        test_exec(config, ssh_con)
+        test_info.success_status("test passed")
+        sys.exit(0)
+    except (RGWBaseException, Exception) as e:
+        log.error(e)
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        sys.exit(1)


### PR DESCRIPTION
CEPH-83574448: Verify node reboot during I/O Sync

log with VM test: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/rgw_node_reboot_ete/pass_log_with_rgw_node_reboot.log

http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/rgw_node_reboot_ete/pass_log_with_rgw_node_reboot_one_by_one.log