### PR TITLE
[TFA] swift command not found as it installed inside virtual environment

### DIFF
--- a/rgw/v2/tests/s3_swift/swift_stats.py
+++ b/rgw/v2/tests/s3_swift/swift_stats.py
@@ -66,12 +66,12 @@ def test_exec(config, ssh_con):
             {"obj": rgw, "resource": "put_container", "args": [container_name]}
         )
         if container is False:
-            raise TestExecError("Resource execution failed: container creation faield")
+            raise TestExecError("Resource execution failed: container creation failed")
 
     host, ip = utils.get_hostname_ip(ssh_con)
     port = utils.get_radosgw_port_no(ssh_con)
     hostname = str(ip) + ":" + str(port)
-    cmd = "swift -A http://{hostname}/auth/1.0 -U '{uid}' -K '{key}' stat".format(
+    cmd = "venv/bin/swift -A http://{hostname}/auth/1.0 -U '{uid}' -K '{key}' stat".format(
         hostname=hostname, uid=user_info["user_id"], key=user_info["key"]
     )
     swift_cmd = utils.exec_shell_cmd(cmd)


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCEPHQE-18349

issue not seen while triggered in node: http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/swift_stats.console.log
issue observed in 8.1, 8.0, 7.1

seeing issue only when triggered as testcase in cephci

**Reason**:
swift is installed within the virtual environment, but called outside virtual environment so issue is seen

log from cephci: http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-2KHPB9/test_swift_stats_command_for_more_than_1000_buckets_0.log

http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/swift_stats.console.log 
