### PR TITLE
[RGW-MS][Automation][Tier-3]: CEPH-83574448: Verify node reboot durin…

### DIFF
--- a/rgw/v2/tests/s3_swift/multisite_configs/test_sync_consistent_with_node_reboot.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_sync_consistent_with_node_reboot.yaml
@@ -1,0 +1,8 @@
+# Script: test_sync_post_destruptive_services.py
+# Polarion ID: CEPH-83574448
+config:
+  test_ops:
+    rgw_service_name: "rgw.shared.sec.sync"
+    sync_retry: 24
+    sync_delay: 900
+    test_node_reboot: True

--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -3028,7 +3028,7 @@ def put_get_bucket_acl(rgw_client, bucket_name, acl):
     log.info(f"get bucket acl response: {get_bkt_acl_json}")
 
 
-def reboot_rgw_nodes():
+def reboot_rgw_nodes(rgw_service_name):
     """
     Method to fetch all the rgw nodes to proceed with reboot
     """
@@ -3051,8 +3051,11 @@ def reboot_rgw_nodes():
                 log.info(f"hostname is {host}")
                 cmd = f"ceph orch ps|grep rgw|grep {host}"
                 out = utils.exec_shell_cmd(cmd)
-                log.info(f"service name is {out.split()[0]}")
-                node_reboot(ssh_con, service_name=out.split()[0])
+                service_name = out.split()[0]
+                log.info(f"service name is {service_name}")
+                if rgw_service_name in service_name:
+                    log.info(f"Performing reboot of the node :{ip}")
+                    node_reboot(ssh_con, service_name=out.split()[0])
 
 
 def node_reboot(node, service_name=None, retry=15, delay=60):
@@ -3061,9 +3064,9 @@ def node_reboot(node, service_name=None, retry=15, delay=60):
     Node: ssh connection for the node
     service_name: RGW service name
     retry: retry to wait foe node/service to come up post reboot
-    delay: sllep time of 1 min between each try
+    delay: sleep time of 1 min between each try
     """
-    log.debug(f"Peforming reboot of the node : {node}")
+    log.info(f"Peforming reboot of the node : {node}")
     node.exec_command("sudo reboot")
     time.sleep(120)
     log.info(f"checking ceph status")

--- a/rgw/v2/tests/s3_swift/test_sync_post_destruptive_services.py
+++ b/rgw/v2/tests/s3_swift/test_sync_post_destruptive_services.py
@@ -5,6 +5,7 @@ test_sync_post_destruptive_services.py
 Usage : test_sync_post_destruptive_services.py -c <input_yaml>
 <input_yaml>
     test_sync_consisitent_post_service_down_up.yaml
+    test_sync_consistent_with_node_reboot.yaml
 """
 
 import os
@@ -41,10 +42,14 @@ def test_exec(config, ssh_con):
         if str(out) != "sync_progress":
             raise AssertionError("sync status is not in progress!!")
         rgw_service_name = config.test_ops.get("rgw_service_name")
-        reusable.bring_down_all_rgws_in_the_site(rgw_service_name)
-        log.info(f"Waiting for 10 min")
-        time.sleep(600)
-        reusable.bring_up_all_rgws_in_the_site(rgw_service_name)
+
+        if config.test_ops.get("test_node_reboot", False):
+            reusable.reboot_rgw_nodes(rgw_service_name)
+        else:
+            reusable.bring_down_all_rgws_in_the_site(rgw_service_name)
+            log.info(f"Waiting for 10 min")
+            time.sleep(600)
+            reusable.bring_up_all_rgws_in_the_site(rgw_service_name)
         retry = config.test_ops.get("sync_retry", 25)
         delay = config.test_ops.get("sync_delay", 60)
         reusable.check_sync_status(retry, delay)


### PR DESCRIPTION
…g I/O Sync

CEPH-83574448: Verify node reboot during I/O Sync

log with VM test: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/rgw_node_reboot_ete/pass_log_with_rgw_node_reboot.log

http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/rgw_node_reboot_ete/pass_log_with_rgw_node_reboot_one_by_one.log

Log with extensa baremetal setup: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-NTVBEZ/