### PR TITLE
Fix failure seen with multipart tagset

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_multipart_upload_with_tagging.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_multipart_upload_with_tagging.yaml
@@ -6,7 +6,6 @@ config:
   user_count: 1
   bucket_count: 1
   objects_count: 1
-  abort_multipart: false
   split_size: 200
   objects_size_range:
     min: 1G

--- a/rgw/v2/tests/s3_swift/test_LargeObjGet_GC.py
+++ b/rgw/v2/tests/s3_swift/test_LargeObjGet_GC.py
@@ -43,7 +43,7 @@ def test_exec(config, ssh_con):
     rgw_conn = auth.do_auth()
     rgw_conn2 = auth.do_auth_using_client()
     log.info("no of buckets to create: %s" % config.bucket_count)
-    abort_multipart = (config.abort_multipart, False)
+    abort_multipart = config.abort_multipart
     # create buckets
     if config.test_ops["create_bucket"] is True:
         for bc in range(config.bucket_count):

--- a/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
+++ b/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
@@ -969,14 +969,13 @@ def test_exec(config, ssh_con):
         if config.test_ops.get("multipart_upload_with_tag", False):
             log.info("Testing tag retrival post multipart upload")
             obj_tag = "mpupload=mpupload"
-            abort_multipart = (config.abort_multipart, False)
             object_parts_info = reusable.upload_mutipart_object(
                 s3_object_name,
                 bucket,
                 TEST_DATA_PATH,
                 config,
                 each_user,
-                abort_multipart=abort_multipart,
+                abort_multipart=config.abort_multipart,
                 obj_tag=obj_tag,
             )
 

--- a/rgw/v2/tests/s3_swift/test_bucket_lifecycle_config_ops.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_lifecycle_config_ops.py
@@ -79,7 +79,7 @@ def test_exec(config, ssh_con):
             log.info("RGW service restarted")
 
     # create user
-    abort_multipart = (config.abort_multipart, False)
+    abort_multipart = config.abort_multipart
     all_users_info = s3lib.create_users(config.user_count)
     for each_user in all_users_info:
         # authenticate


### PR DESCRIPTION
Due to "abort_multipart = (config.abort_multipart, False) " abort_multipart was taking value as tuple (False, False),
which was causing condition check fail "if abort_multipart:" and was entering inside abort_multipart code,
as per abort_multipart logic it will not perform complete_multipart operation which was causing non_availabilty of Tagset,
even though Tagset is available for the object.

Note: since config.abort_multipart by default has a value False in resourse_op hence removing value set from config file.

Fail log: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/BZ2336076/test_multipart_upload_with_tagging.console.log-fail2

Pass log post fix: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/BZ2336076/BZ-Verify/test_multipart_upload_with_tagging.console.log-fixed2


other two places where this line was present:

There are two script file where, abort_multipart = (config.abort_multipart, False) is present.

Analysis:

File: test_LargeObjGet_GC.py

Uses two configs.

test_LargeObjGet_GC.yaml
Which uses upload_type: normal hence this
abort_multipart = (config.abort_multipart, False) this statement did not affect here.

test_bucket_remove_with_multipart_abort.yaml
upload_type: multipart
But here it requires “abort_multipart: true”
Hence: abort_multipart = (config.abort_multipart, False) this statement did not affect here.
I.e in this case, it requires to enter abort_multipart condition.
With: abort_multipart param containing value (True,False) it does enter.

File: Test_bucket_lifecycle_config_ops.py
abort_multipart = (config.abort_multipart, False)
This param is used only when upload_type =Multipart.

config.test_ops.get("upload_type") == "multipart":

Configs:

Test_bucket_lc_enable_object_exp.yaml : upload type not multipart
Test_add_new_lc_to_bucket.yaml : upload type not multipart
Test_bucket_lc_disable_object_exp.yaml : upload type not multipart
Test_bucket_lifecycle_config_modify.yaml : upload type not multipart
Test_bucket_lifecycle_config_disable.yaml : upload type not multipart
Test_bucket_lifecycle_config_versioning.yaml: upload type not multipart
Test_bucket_lifecycle_config_read.yaml : upload type not multipart
Test_bucket_lc_incomplete_multipart.yaml: upload_type: multipart
But here it requires “abort_multipart: true”
Hence: abort_multipart = (config.abort_multipart, False) this statement did not affect here.

Hence this abort_multipart = (config.abort_multipart, False) did not affect any of the testcases till now.
any ways considering future scope, i have made this correction in these two files as well.

Pass logs: with changes to these two files:
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/abort_mp_imple/


