### PR TITLE
Include workaround for user reset as per BZ2167475

### DIFF
--- a/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
+++ b/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
@@ -885,6 +885,17 @@ def test_exec(config, ssh_con):
 
         if config.user_reset:
             log.info(f"Verify user reset doesn't throw any error")
+            # Adding work around as per BZ:2167475 i.e: osd_max_write_op_reply_len 128
+
+            out = utils.exec_shell_cmd(
+                "ceph config set global osd_max_write_op_reply_len 128"
+            )
+            out = utils.exec_shell_cmd("ceph config get osd osd_max_write_op_reply_len")
+            if int(out) != 128:
+                raise AssertionError(
+                    f"Config set failed for osd_max_write_op_reply_len"
+                )
+
             bucket_list = utils.exec_shell_cmd(
                 f"radosgw-admin bucket list --uid={each_user['user_id']}"
             )
@@ -897,6 +908,17 @@ def test_exec(config, ssh_con):
             stats_reset = utils.exec_shell_cmd(
                 f"radosgw-admin user stats --uid={each_user['user_id']} --reset-stats"
             )
+            # Reset osd_max_write_op_reply_len back to default
+            log.info(f"Reset back to default value for osd_max_write_op_reply_len")
+            out = utils.exec_shell_cmd(
+                "ceph config rm global osd_max_write_op_reply_len"
+            )
+            out = utils.exec_shell_cmd("ceph config get osd osd_max_write_op_reply_len")
+            if int(out) != 64:
+                raise AssertionError(
+                    f"Config reset to default failed for osd_max_write_op_reply_len"
+                )
+
             if not stats_reset:
                 raise AssertionError(f"user reset failed!!")
 


### PR DESCRIPTION
Include workaround for the failure seen with radosgw-admin user stats --reset-stats
i.e: ERROR: value too large for defined data type

Fail log: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/user_reset_workaround/test_user_stats_reset.console.log-fail-without-workaround

As per BZ2167475 workaround to set osd_max_write_op_reply_len to 128.

Added implementation for:
1. Changing osd_max_write_op_reply_len to 128. and validating config value
2. Performing user stat reset
3. Reset osd_max_write_op_reply_len value back to current default, i.e 64

Note: To fix this issue, we have RFE under rados component: https://bugzilla.redhat.com/show_bug.cgi?id=2349735


Pass log with workaround:
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/user_reset_workaround/test_user_stats_reset.console.log-pass-final1
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/user_reset_workaround/test_user_stats_reset.console.log-pass-final2
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/user_reset_workaround/test_user_stats_reset.console.log-pass-final3