### PR TITLE
[TFA] tenanted bucket name having duplicate tenantname and bucket prifix

### DIFF
--- a/rgw/v2/tests/s3_swift/reusables/bucket_notification.py
+++ b/rgw/v2/tests/s3_swift/reusables/bucket_notification.py
@@ -361,7 +361,10 @@ def verify_event_record(
             # Determine if the bucket has a tenant
             if "." in bucket and "tenant" in bucket:
                 tenant_name, bucket_short_name = bucket.split(".", 1)
-                bucket_stats_name = f"{tenant_name}/{bucket}"
+                if "/" in bucket:
+                    bucket_stats_name = bucket
+                else:
+                    bucket_stats_name = f"{tenant_name}/{bucket}"
             else:
                 bucket_stats_name = bucket
 


### PR DESCRIPTION
issue seen due to changes in pr: https://github.com/red-hat-storage/ceph-qe-scripts/pull/680/files#diff-402f4702856675497bc0c0dd255457efb8bacbf7dfb6853667c61024db95cbd4R346

From script:
executing cmd: radosgw-admin bucket stats --bucket tenant_x/jeffreyz/tenant_x/jeffreyz.843-bucky-3848-0
cmd execution failed
stderr: failure: (2002) Unknown error 2002: 

In cluster:
[root@ceph-80anraoss-6tg5aq-node5 ~]#  radosgw-admin bucket stats --bucket **tenant_x/jeffreyz/**tenant_x/jeffreyz.843-bucky-3848-0
failure: (2002) Unknown error 2002:
[root@ceph-80anraoss-6tg5aq-node5 ~]#  radosgw-admin bucket stats --bucket tenant_x/jeffreyz.843-bucky-3848-0
{
    "bucket": "jeffreyz.843-bucky-3848-0",
    "tenant": "tenant_x",
.........
}
pass log: http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/test_put_get_bucket_notification_with_tenant_same_and_different_user.console.log 