### PR TITLE
Reduce object creation

### DIFF
--- a/rgw/v2/tests/aws/configs/test_s3copyObj_admin_user.yaml
+++ b/rgw/v2/tests/aws/configs/test_s3copyObj_admin_user.yaml
@@ -2,7 +2,7 @@
 # Script: test_sts_rename_large_object.py
 config:
      s3_copy_obj: true
-     objects_count: 100
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/aws/configs/test_sts_rename_large_object.yaml
+++ b/rgw/v2/tests/aws/configs/test_sts_rename_large_object.yaml
@@ -1,7 +1,7 @@
 # polarion test case id: 83575419
 # Script: test_sts_rename_large_object.py
 config:
-     objects_count: 100
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/curl/configs/test_cors_presigned_put_url_using_curl.yaml
+++ b/rgw/v2/tests/curl/configs/test_cors_presigned_put_url_using_curl.yaml
@@ -4,7 +4,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 25
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/curl/configs/test_cors_using_curl.yaml
+++ b/rgw/v2/tests/curl/configs/test_cors_using_curl.yaml
@@ -3,7 +3,7 @@
 config:
   user_count: 1
   bucket_count: 1
-  objects_count: 25
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/curl/configs/test_crlf_injection_curl.yaml
+++ b/rgw/v2/tests/curl/configs/test_crlf_injection_curl.yaml
@@ -3,7 +3,7 @@
 config:
   user_count: 1
   bucket_count: 1
-  objects_count: 25
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/curl/configs/test_quota_mgmt_bucket_quota_using_curl.yaml
+++ b/rgw/v2/tests/curl/configs/test_quota_mgmt_bucket_quota_using_curl.yaml
@@ -3,7 +3,7 @@
 config:
   user_count: 1
   bucket_count: 1
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 10
     max: 10

--- a/rgw/v2/tests/curl/configs/test_quota_mgmt_conflict_bucket_quota_using_curl.yaml
+++ b/rgw/v2/tests/curl/configs/test_quota_mgmt_conflict_bucket_quota_using_curl.yaml
@@ -3,7 +3,7 @@
 config:
   user_count: 1
   bucket_count: 1
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 10
     max: 10

--- a/rgw/v2/tests/curl/configs/test_quota_mgmt_user_quota_using_curl.yaml
+++ b/rgw/v2/tests/curl/configs/test_quota_mgmt_user_quota_using_curl.yaml
@@ -3,7 +3,7 @@
 config:
   user_count: 1
   bucket_count: 4
-  objects_count: 25
+  objects_count: 20
   objects_size_range:
     min: 10
     max: 10

--- a/rgw/v2/tests/curl/configs/test_rgw_curl_multipart_upload.yaml
+++ b/rgw/v2/tests/curl/configs/test_rgw_curl_multipart_upload.yaml
@@ -3,7 +3,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 50
+  objects_count: 10
   objects_size_range:
     min: 10M
     max: 20M

--- a/rgw/v2/tests/curl/configs/test_rgw_using_curl.yaml
+++ b/rgw/v2/tests/curl/configs/test_rgw_using_curl.yaml
@@ -3,7 +3,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 50
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/get_object_and_its_versions_tenat_user.yaml
+++ b/rgw/v2/tests/s3_swift/configs/get_object_and_its_versions_tenat_user.yaml
@@ -1,6 +1,6 @@
 # test case id: CEPH-11516
 config:
-    objects_count: 100
+    objects_count: 20
     bucket_count: 2
     version_count: 2
     objects_size_range:

--- a/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects.yaml
@@ -3,7 +3,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_aws4.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_aws4.yaml
@@ -4,7 +4,7 @@ config:
   use_aws4: true
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_compression.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_compression.yaml
@@ -3,7 +3,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_compression_snappy.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_compression_snappy.yaml
@@ -3,7 +3,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_compression_zstd.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_compression_zstd.yaml
@@ -3,7 +3,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_delete.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_delete.yaml
@@ -3,7 +3,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_download.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_download.yaml
@@ -3,7 +3,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_enc.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_enc.yaml
@@ -3,7 +3,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_get_object_attributes.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_get_object_attributes.yaml
@@ -4,7 +4,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 25
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_get_object_attributes_checksum_sha256.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_get_object_attributes_checksum_sha256.yaml
@@ -4,7 +4,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 25
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_get_object_attributes_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_get_object_attributes_multipart.yaml
@@ -4,7 +4,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 20
+  objects_count: 10
   objects_size_range:
     min: 30M
     max: 50M

--- a/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_multipart_upload_complete_abort_race.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_multipart_upload_complete_abort_race.yaml
@@ -5,7 +5,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 50
+  objects_count: 10
   split_size: 5
   objects_size_range:
     min: 10M

--- a/rgw/v2/tests/s3_swift/configs/test_bi_purge.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bi_purge.yaml
@@ -4,7 +4,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_lc_disable_object_exp.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_lc_disable_object_exp.yaml
@@ -3,7 +3,7 @@
 config:
   user_count: 1
   bucket_count: 1
-  objects_count: 100
+  objects_count: 20
   rgw_lc_debug_interval: 60
   objects_size_range:
     min: 5

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_lc_enable_object_exp.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_lc_enable_object_exp.yaml
@@ -3,7 +3,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   rgw_lc_debug_interval: 1
   objects_size_range:
     min: 5

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_lc_multipart_object_expiration.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_lc_multipart_object_expiration.yaml
@@ -2,7 +2,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 500
+  objects_count: 10
   rgw_lc_debug_interval: 600
   objects_size_range:
     min: 16M

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_lc_object_exp_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_lc_object_exp_multipart.yaml
@@ -2,7 +2,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 10
   rgw_lc_debug_interval: 1
   objects_size_range:
     min: 16M

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_lc_object_exp_multipart_notifications.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_lc_object_exp_multipart_notifications.yaml
@@ -2,7 +2,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 10
   rgw_lc_debug_interval: 1
   objects_size_range:
     min: 16M

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_lifecycle_config_disable.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_lifecycle_config_disable.yaml
@@ -3,7 +3,7 @@
 config:
      user_count: 1
      bucket_count: 2
-     objects_count: 100
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_lifecycle_config_modify.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_lifecycle_config_modify.yaml
@@ -3,7 +3,7 @@
 config:
      user_count: 1
      bucket_count: 2
-     objects_count: 100
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_lifecycle_config_read.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_lifecycle_config_read.yaml
@@ -3,7 +3,7 @@
 config:
      user_count: 1
      bucket_count: 2
-     objects_count: 100
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_lifecycle_config_versioning.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_lifecycle_config_versioning.yaml
@@ -3,7 +3,7 @@
 config:
      user_count: 1
      bucket_count: 2
-     objects_count: 100
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_listing_fake_mp.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_listing_fake_mp.yaml
@@ -4,7 +4,7 @@ config:
      user_count: 1
      user_remove: false
      bucket_count: 1
-     objects_count: 100
+     objects_count: 20
      objects_size_range:
           min: 10
           max: 10

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_listing_flat_ordered.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_listing_flat_ordered.yaml
@@ -1,7 +1,7 @@
 config:
      user_count: 1
      bucket_count: 2
-     objects_count: 100
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_listing_flat_ordered_versionsing.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_listing_flat_ordered_versionsing.yaml
@@ -1,7 +1,7 @@
 config:
      user_count: 1
      bucket_count: 2
-     objects_count: 100
+     objects_count: 20
      version_count: 3
      objects_size_range:
           min: 5

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_listing_flat_unordered.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_listing_flat_unordered.yaml
@@ -1,7 +1,7 @@
 config:
      user_count: 1
      bucket_count: 2
-     objects_count: 100
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_listing_pseudo_ordered.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_listing_pseudo_ordered.yaml
@@ -1,7 +1,7 @@
 config:
      user_count: 1
      bucket_count: 2
-     objects_count: 100
+     objects_count: 20
      pseudo_dir_count: 5
      objects_size_range:
           min: 10

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_notification_with_tenant_user.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_notification_with_tenant_user.yaml
@@ -3,7 +3,7 @@
 config:
     user_count: 2
     bucket_count: 2
-    objects_count: 25
+    objects_count: 20
     user_type: tenanted
     objects_size_range:
         min: 5

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_policy_condition.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_policy_condition.yaml
@@ -2,7 +2,7 @@
 # bucket policy with condition blocks
 # polarion id: CEPH-11589
 config:
-  objects_count: 25
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_policy_condition_explicit_deny.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_policy_condition_explicit_deny.yaml
@@ -2,7 +2,7 @@
 # bucket policy condition block with explicit deny
 # polarion id: CEPH-11590
 config:
-  objects_count: 25
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_policy_deny_actions.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_policy_deny_actions.yaml
@@ -2,7 +2,7 @@
 # bucket policy deny actions
 # polarion id: CEPH-11216
 config:
-  objects_count: 25
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_policy_invalid_action.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_policy_invalid_action.yaml
@@ -2,7 +2,7 @@
 # bucket policy with invalid action
 # polarion id: CEPH-83572755
 config:
-  objects_count: 25
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_policy_invalid_condition_key.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_policy_invalid_condition_key.yaml
@@ -2,7 +2,7 @@
 # bucket policy with invalid conditional in condition blocks
 # polarion id: CEPH-83572755
 config:
-  objects_count: 25
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_policy_invalid_effect.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_policy_invalid_effect.yaml
@@ -2,7 +2,7 @@
 # bucket policy with invalid effect
 # polarion id: CEPH-83572755
 config:
-  objects_count: 25
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_policy_invalid_key.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_policy_invalid_key.yaml
@@ -2,7 +2,7 @@
 # bucket policy with invalid key
 # polarion id: CEPH-83572755
 config:
-  objects_count: 25
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_policy_invalid_principal.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_policy_invalid_principal.yaml
@@ -2,7 +2,7 @@
 # bucket policy with invalid principal
 # polarion id: CEPH-83572755
 config:
-  objects_count: 25
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_policy_invalid_resource.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_policy_invalid_resource.yaml
@@ -2,7 +2,7 @@
 # bucket policy with invalid resource
 # polarion id: CEPH-83572755
 config:
-  objects_count: 25
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_policy_invalid_version.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_policy_invalid_version.yaml
@@ -2,7 +2,7 @@
 # bucket policy with invalid version
 # polarion id: CEPH-83572755
 config:
-  objects_count: 25
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_policy_multiple_conflicting_statements.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_policy_multiple_conflicting_statements.yaml
@@ -2,7 +2,7 @@
 # bucket policy with conflicting statements
 # polarion id: CEPH-11217
 config:
-  objects_count: 25
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_policy_multiple_statements.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_policy_multiple_statements.yaml
@@ -2,7 +2,7 @@
 # bucket policy with conflicting statements
 # polarion id: CEPH-11216
 config:
-  objects_count: 25
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_radoslist.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_radoslist.yaml
@@ -1,7 +1,7 @@
 config:
      user_count: 1
      bucket_count: 2
-     objects_count: 100
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_request_payer_download.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_request_payer_download.yaml
@@ -2,7 +2,7 @@
 config:
    user_count: 1
    bucket_count: 10
-   objects_count: 100
+   objects_count: 20
    objects_size_range:
       min: 5
       max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_byte_range.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_byte_range.yaml
@@ -2,7 +2,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 10
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_cloud_transition_headobject_false.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_cloud_transition_headobject_false.yaml
@@ -3,7 +3,7 @@
 config:
   user_count: 1
   bucket_count: 1
-  objects_count: 100
+  objects_count: 20
   etag_verification: true
   objects_size_range:
     min: 5

--- a/rgw/v2/tests/s3_swift/configs/test_cloud_transition_headobject_true.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_cloud_transition_headobject_true.yaml
@@ -3,7 +3,7 @@
 config:
   user_count: 1
   bucket_count: 1
-  objects_count: 100
+  objects_count: 20
   etag_verification: true
   objects_size_range:
     min: 5

--- a/rgw/v2/tests/s3_swift/configs/test_delete_container_from_user_of_diff_tenant.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_delete_container_from_user_of_diff_tenant.yaml
@@ -1,6 +1,6 @@
 # test case id: CEPH-9749
 config:
-    objects_count: 100
+    objects_count: 20
     container_count: 2
     objects_size_range:
         min: 5

--- a/rgw/v2/tests/s3_swift/configs/test_get_bucket_website_with_tenant_same_and_different_user.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_get_bucket_website_with_tenant_same_and_different_user.yaml
@@ -2,7 +2,7 @@
 # script: test_bucket_policy_with_tenant_user.py
 config:
     bucket_count: 2
-    objects_count: 100
+    objects_count: 20
     rgw_enable_static_website: true
     version_enable: true
     objects_size_range:

--- a/rgw/v2/tests/s3_swift/configs/test_indexless_buckets_s3.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_indexless_buckets_s3.yaml
@@ -1,7 +1,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_lc_current_version_object_expiration.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_current_version_object_expiration.yaml
@@ -1,6 +1,6 @@
 # script: test_bucket_lifecycle_object_expiration_transition.py
 config:
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_lc_date_expire_header.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_date_expire_header.yaml
@@ -1,7 +1,7 @@
 # script: test_bucket_lifecycle_object_expiration_transition.py
 # polarion ID: CEPH-83573254
 config:
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_lc_days_expire_header.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_days_expire_header.yaml
@@ -1,7 +1,7 @@
 # script: test_bucket_lifecycle_object_expiration_transition.py
 # polarion ID: CEPH-83573254
 config:
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_lc_invalid_date.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_invalid_date.yaml
@@ -2,7 +2,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   invalid_date: true
   objects_size_range:
     min: 5

--- a/rgw/v2/tests/s3_swift/configs/test_lc_multiple_delete_marker.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_multiple_delete_marker.yaml
@@ -1,5 +1,5 @@
 config:
-  objects_count: 100
+  objects_count: 20
   rgw_lc_debug_interval: 1
   objects_size_range:
     min: 5

--- a/rgw/v2/tests/s3_swift/configs/test_lc_multiple_rule_prefix_current_days.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_multiple_rule_prefix_current_days.yaml
@@ -1,6 +1,6 @@
 # script: test_lc_multiple_rule_prefix_current_days.yaml
 config:
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_lc_process_single_bucket_expired.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_process_single_bucket_expired.yaml
@@ -1,7 +1,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   object_expire: true
   objects_size_range:
     min: 5

--- a/rgw/v2/tests/s3_swift/configs/test_lc_process_single_bucket_nonexpired.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_process_single_bucket_nonexpired.yaml
@@ -1,7 +1,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   object_expire: false
   objects_size_range:
     min: 5

--- a/rgw/v2/tests/s3_swift/configs/test_lc_rule_conflict_btw_exp_transition.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_rule_conflict_btw_exp_transition.yaml
@@ -3,7 +3,7 @@
 config:
   user_count: 1
   bucket_count: 1
-  objects_count: 25
+  objects_count: 20
   parallel_lc: False
   test_lc_transition: True
   pool_name: data.cold

--- a/rgw/v2/tests/s3_swift/configs/test_lc_rule_conflict_exp_days.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_rule_conflict_exp_days.yaml
@@ -1,7 +1,7 @@
 #test_bucket_lifecycle_object_expiration_transition.py
 #polarion-id: CEPH-11184
 config:
-  objects_count: 25
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_lc_rule_delete_marker.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_rule_delete_marker.yaml
@@ -1,6 +1,6 @@
 # test_bucket_lifecycle_object_expiration_transition.py
 config:
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_lc_rule_delete_marker_notifications.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_rule_delete_marker_notifications.yaml
@@ -1,6 +1,6 @@
 # script test_bucket_lifecycle_object_expiration_transition.py
 config:
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_lc_rule_expiration_notifications.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_rule_expiration_notifications.yaml
@@ -1,6 +1,6 @@
 # test_bucket_lifecycle_object_expiration_transition.py
 config:
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_lc_rule_expiration_parallel_notifications.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_rule_expiration_parallel_notifications.yaml
@@ -1,7 +1,7 @@
 # test_bucket_lifecycle_object_expiration_transition.py
 config:
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   parallel_lc: True
   objects_size_range:
     min: 5

--- a/rgw/v2/tests/s3_swift/configs/test_lc_rule_multipart_transition_notifications.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_rule_multipart_transition_notifications.yaml
@@ -2,7 +2,7 @@
 # bz: https://bugzilla.redhat.com/show_bug.cgi?id=2166576
 # polarion_id: CEPH-83591037
 config:
-  objects_count: 20
+  objects_count: 10
   objects_size_range:
     min: 200M
     max: 300M

--- a/rgw/v2/tests/s3_swift/configs/test_lc_rule_prefix_and_tag.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_rule_prefix_and_tag.yaml
@@ -1,6 +1,6 @@
 #test_bucket_lifecycle_object_expiration_transition.py
 config:
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_lc_rule_prefix_non_current_days.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_rule_prefix_non_current_days.yaml
@@ -1,6 +1,6 @@
 # script: test_bucket_lifecycle_object_expiration_transition.py
 config:
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_lc_rule_prefix_non_current_days_notifications.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_rule_prefix_non_current_days_notifications.yaml
@@ -1,6 +1,6 @@
 # script: test_bucket_lifecycle_object_expiration_transition.py
 config:
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_lc_rule_same_rule_id_diff_rules.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_rule_same_rule_id_diff_rules.yaml
@@ -2,7 +2,7 @@
 #polarion-id: CEPH-11183
 config:
   bucket_count: 2
-  objects_count: 25
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_lc_transition_2_pools.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_transition_2_pools.yaml
@@ -2,7 +2,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   parallel_lc: False
   test_lc_transition: True
   pool_name: data.cold

--- a/rgw/v2/tests/s3_swift/configs/test_lc_with_prefix_dot.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_with_prefix_dot.yaml
@@ -2,7 +2,7 @@
 # CEPH-11192 - Test object prefixes with delimiter '/', '_', '-', '.'
 config:
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_lc_with_prefix_hyphen.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_with_prefix_hyphen.yaml
@@ -2,7 +2,7 @@
 # CEPH-11192 - Test object prefixes with delimiter '/', '_', '-', '.'
 config:
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_lc_with_prefix_slash.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_with_prefix_slash.yaml
@@ -2,7 +2,7 @@
 # CEPH-11192 - Test object prefixes with delimiter '/', '_', '-', '.'
 config:
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_lc_with_prefix_underscore.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_with_prefix_underscore.yaml
@@ -2,7 +2,7 @@
 # CEPH-11192 - Test object prefixes with delimiter '/', '_', '-', '.'
 config:
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_object_level_compliance.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_object_level_compliance.yaml
@@ -5,7 +5,7 @@
 config:
   user_count: 1
   bucket_count: 1
-  objects_count: 30
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_object_level_governance.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_object_level_governance.yaml
@@ -5,7 +5,7 @@
 config:
   user_count: 1
   bucket_count: 1
-  objects_count: 30
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_object_lock_compliance.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_object_lock_compliance.yaml
@@ -4,7 +4,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_object_lock_governance.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_object_lock_governance.yaml
@@ -5,7 +5,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_public_access_block_acl.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_public_access_block_acl.yaml
@@ -2,7 +2,7 @@
 # customer bz: https://bugzilla.redhat.com/show_bug.cgi?id=2064260
 # polarion id: CEPH-83575582
 config:
-  objects_count: 25
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_public_access_block_ignore_acl.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_public_access_block_ignore_acl.yaml
@@ -2,7 +2,7 @@
 # customer bz: https://bugzilla.redhat.com/show_bug.cgi?id=2064260
 # polarion id: CEPH-83575582
 config:
-  objects_count: 25
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_public_access_block_post_bucket_policy.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_public_access_block_post_bucket_policy.yaml
@@ -2,7 +2,7 @@
 # customer bz: https://bugzilla.redhat.com/show_bug.cgi?id=2064260
 # polarion id: CEPH-83575582
 config:
-  objects_count: 25
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_public_access_block_pre_bucket_policy.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_public_access_block_pre_bucket_policy.yaml
@@ -2,7 +2,7 @@
 # customer bz: https://bugzilla.redhat.com/show_bug.cgi?id=2064260
 # polarion id: CEPH-83575582
 config:
-  objects_count: 25
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_public_access_block_restricted_public_buckets.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_public_access_block_restricted_public_buckets.yaml
@@ -2,7 +2,7 @@
 # customer bz: https://bugzilla.redhat.com/show_bug.cgi?id=2064260
 # polarion id: CEPH-83575582
 config:
-  objects_count: 25
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_put_bucket_website_with_tenant_same_and_different_user.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_put_bucket_website_with_tenant_same_and_different_user.yaml
@@ -2,7 +2,7 @@
 # script: test_bucket_policy_with_tenant_user.py
 config:
     bucket_count: 2
-    objects_count: 100
+    objects_count: 20
     rgw_enable_static_website: true
     version_enable: true
     objects_size_range:

--- a/rgw/v2/tests/s3_swift/configs/test_put_get_bucket_notification_with_tenant_same_and_different_user.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_put_get_bucket_notification_with_tenant_same_and_different_user.yaml
@@ -4,7 +4,7 @@
 config:
     user_count: 2
     bucket_count: 2
-    objects_count: 100
+    objects_count: 20
     user_type: tenanted
     objects_size_range:
         min: 5

--- a/rgw/v2/tests/s3_swift/configs/test_rgw_enable_lc_threads.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_rgw_enable_lc_threads.yaml
@@ -3,7 +3,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   rgw_lc_debug_interval: 1
   rgw_lifecycle_work_time: "00:00-23:59"
   rgw_enable_lc_threads: false

--- a/rgw/v2/tests/s3_swift/configs/test_rgw_mfa.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_rgw_mfa.yaml
@@ -1,7 +1,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   version_count: 1
   objects_size_range:
     min: 5

--- a/rgw/v2/tests/s3_swift/configs/test_rgw_mfa_incorrect_syntax.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_rgw_mfa_incorrect_syntax.yaml
@@ -1,7 +1,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   version_count: 1
   objects_size_range:
     min: 5

--- a/rgw/v2/tests/s3_swift/configs/test_rgw_mfa_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_rgw_mfa_multipart.yaml
@@ -1,7 +1,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 10
   version_count: 2
   objects_size_range:
     min: 6M

--- a/rgw/v2/tests/s3_swift/configs/test_s3_and_swift_versioning.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_s3_and_swift_versioning.yaml
@@ -3,7 +3,7 @@
 config:
     user_type: non-tenanted
     container_count: 3
-    objects_count: 100
+    objects_count: 20
     version_count: 4
     objects_size_range:
         min: 5

--- a/rgw/v2/tests/s3_swift/configs/test_sse_kms_kmip_gklm_per_bucket_encryption_multipart_object_upload.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_kms_kmip_gklm_per_bucket_encryption_multipart_object_upload.yaml
@@ -4,7 +4,7 @@ config:
  user_count: 1
  encryption_keys: kms
  bucket_count: 2
- objects_count: 25
+ objects_count: 10
  local_file_delete: true
  objects_size_range:
   min: 6M

--- a/rgw/v2/tests/s3_swift/configs/test_sse_kms_kmip_gklm_per_bucket_encryption_normal_object_upload.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_kms_kmip_gklm_per_bucket_encryption_normal_object_upload.yaml
@@ -4,7 +4,7 @@ config:
  user_count: 1
  encryption_keys: kms
  bucket_count: 2
- objects_count: 25
+ objects_count: 20
  objects_size_range:
   min: 5
   max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sse_kms_kmip_gklm_per_bucket_encryption_version_enabled.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_kms_kmip_gklm_per_bucket_encryption_version_enabled.yaml
@@ -4,7 +4,7 @@ config:
  user_count: 1
  encryption_keys: kms
  bucket_count: 2
- objects_count: 25
+ objects_count: 20
  objects_size_range:
   min: 5
   max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sse_kms_kmip_gklm_per_object.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_kms_kmip_gklm_per_object.yaml
@@ -4,7 +4,7 @@ config:
  user_count: 1
  encryption_keys: kms
  bucket_count: 2
- objects_count: 25
+ objects_count: 20
  objects_size_range:
   min: 5
   max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sse_kms_kmip_gklm_per_object_versioninig_enabled.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_kms_kmip_gklm_per_object_versioninig_enabled.yaml
@@ -4,7 +4,7 @@ config:
  user_count: 1
  encryption_keys: kms
  bucket_count: 2
- objects_count: 25
+ objects_count: 20
  objects_size_range:
   min: 5
   max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sse_kms_per_bucket_encryption_multipart_object_upload.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_kms_per_bucket_encryption_multipart_object_upload.yaml
@@ -2,7 +2,7 @@ config:
  user_count: 1
  encryption_keys: kms
  bucket_count: 2
- objects_count: 50
+ objects_count: 10
  local_file_delete: true
  objects_size_range:
   min: 6M

--- a/rgw/v2/tests/s3_swift/configs/test_sse_kms_per_bucket_encryption_normal_object_upload.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_kms_per_bucket_encryption_normal_object_upload.yaml
@@ -2,7 +2,7 @@ config:
  user_count: 1
  encryption_keys: kms
  bucket_count: 2
- objects_count: 50
+ objects_count: 20
  objects_size_range:
   min: 5
   max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sse_kms_per_bucket_encryption_version_enabled.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_kms_per_bucket_encryption_version_enabled.yaml
@@ -2,7 +2,7 @@ config:
  user_count: 1
  encryption_keys: kms
  bucket_count: 2
- objects_count: 50
+ objects_count: 20
  objects_size_range:
   min: 5
   max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sse_kms_per_bucket_with_bucket_policy.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_kms_per_bucket_with_bucket_policy.yaml
@@ -2,7 +2,7 @@
 # bucket policy with server side encryption
 # polarion id: CEPH-83586489
 config:
-  objects_count: 25
+  objects_count: 20
   encryption_keys: kms
   objects_size_range:
     min: 5

--- a/rgw/v2/tests/s3_swift/configs/test_sse_kms_per_object.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_kms_per_object.yaml
@@ -2,7 +2,7 @@ config:
  user_count: 1
  encryption_keys: kms
  bucket_count: 2
- objects_count: 50
+ objects_count: 20
  objects_size_range:
   min: 5
   max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sse_kms_per_object_versioninig_enabled.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_kms_per_object_versioninig_enabled.yaml
@@ -2,7 +2,7 @@ config:
  user_count: 1
  encryption_keys: kms
  bucket_count: 2
- objects_count: 50
+ objects_count: 20
  objects_size_range:
   min: 5
   max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sse_s3_per_bucket_encryption_multipart_object_upload.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_s3_per_bucket_encryption_multipart_object_upload.yaml
@@ -2,7 +2,7 @@ config:
  user_count: 1
  encryption_keys: s3
  bucket_count: 2
- objects_count: 50
+ objects_count: 10
  local_file_delete: true
  objects_size_range:
   min: 6M

--- a/rgw/v2/tests/s3_swift/configs/test_sse_s3_per_bucket_encryption_normal_object_upload.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_s3_per_bucket_encryption_normal_object_upload.yaml
@@ -2,7 +2,7 @@ config:
  user_count: 1
  encryption_keys: s3
  bucket_count: 2
- objects_count: 50
+ objects_count: 20
  objects_size_range:
   min: 5
   max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sse_s3_per_bucket_encryption_version_enabled.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_s3_per_bucket_encryption_version_enabled.yaml
@@ -2,7 +2,7 @@ config:
  user_count: 1
  encryption_keys: s3
  bucket_count: 2
- objects_count: 50
+ objects_count: 20
  objects_size_range:
   min: 5
   max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sse_s3_per_object.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_s3_per_object.yaml
@@ -2,7 +2,7 @@ config:
  user_count: 1
  encryption_keys: s3
  bucket_count: 2
- objects_count: 100
+ objects_count: 20
  objects_size_range:
   min: 5
   max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sse_s3_per_object_versioninig_enabled.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_s3_per_object_versioninig_enabled.yaml
@@ -2,7 +2,7 @@ config:
  user_count: 1
  encryption_keys: s3
  bucket_count: 2
- objects_count: 50
+ objects_count: 20
  objects_size_range:
   min: 5
   max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sse_s3_per_object_with_sts.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sse_s3_per_object_with_sts.yaml
@@ -2,7 +2,7 @@
 # test scripts : test_sts_using_boto.py
 config:
      bucket_count: 2
-     objects_count: 50
+     objects_count: 20
      encryption_keys: s3
      objects_size_range:
           min: 5

--- a/rgw/v2/tests/s3_swift/configs/test_storage_policy_s3.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_storage_policy_s3.yaml
@@ -1,7 +1,7 @@
 # script: test_storage_policy.py
 # polarion id: CEPH-9337
 config:
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_storage_policy_swift.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_storage_policy_swift.yaml
@@ -1,7 +1,7 @@
 # script: test_storage_policy.py
 # polarion id: CEPH-9336
 config:
-  objects_count: 100
+  objects_count: 20
   test_ops:
     rgw_client: swift
   objects_size_range:

--- a/rgw/v2/tests/s3_swift/configs/test_sts_aswi.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_aswi.yaml
@@ -2,7 +2,7 @@
 # test scripts : test_sts_aswi.py
 config:
      bucket_count: 2
-     objects_count: 50
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sts_aswi_aud_claim.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_aswi_aud_claim.yaml
@@ -3,7 +3,7 @@
 # The "aud" (audience) claim identifies the recipients that the JWT is intended for
 config:
      bucket_count: 2
-     objects_count: 50
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sts_aswi_aws_principal_tag_role_policy.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_aswi_aws_principal_tag_role_policy.yaml
@@ -2,7 +2,7 @@
 # test scripts : test_sts_aswi.py
 config:
      bucket_count: 2
-     objects_count: 50
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sts_aswi_aws_request_tag_trust_policy.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_aswi_aws_request_tag_trust_policy.yaml
@@ -2,7 +2,7 @@
 # test scripts : test_sts_aswi.py
 config:
      bucket_count: 2
-     objects_count: 50
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sts_aswi_aws_tagkeys_role_policy.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_aswi_aws_tagkeys_role_policy.yaml
@@ -2,7 +2,7 @@
 # test scripts : test_sts_aswi.py
 config:
      bucket_count: 2
-     objects_count: 50
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sts_aswi_aws_tagkeys_trust_policy.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_aswi_aws_tagkeys_trust_policy.yaml
@@ -2,7 +2,7 @@
 # test scripts : test_sts_aswi.py
 config:
      bucket_count: 2
-     objects_count: 50
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sts_aswi_azp_claim.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_aswi_azp_claim.yaml
@@ -3,7 +3,7 @@
 # azp - Authorized party - the party to which the ID Token was issued
 config:
      bucket_count: 2
-     objects_count: 50
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sts_aswi_iam_resource_tag_trust_policy.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_aswi_iam_resource_tag_trust_policy.yaml
@@ -2,7 +2,7 @@
 # test scripts : test_sts_aswi.py
 config:
      bucket_count: 2
-     objects_count: 50
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sts_aswi_isv.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_aswi_isv.yaml
@@ -2,7 +2,7 @@
 # test scripts : test_sts_aswi.py
 config:
      bucket_count: 2
-     objects_count: 50
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sts_aswi_isv_verify_role_policy_allow_actions.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_aswi_isv_verify_role_policy_allow_actions.yaml
@@ -2,7 +2,7 @@
 # test scripts : test_sts_aswi.py
 config:
      bucket_count: 2
-     objects_count: 50
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sts_aswi_isv_verify_role_policy_deny_actions.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_aswi_isv_verify_role_policy_deny_actions.yaml
@@ -2,7 +2,7 @@
 # test scripts : test_sts_aswi.py
 config:
      bucket_count: 2
-     objects_count: 50
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sts_aswi_s3_res_equals_aws_princ_tag_role_policy.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_aswi_s3_res_equals_aws_princ_tag_role_policy.yaml
@@ -2,7 +2,7 @@
 # test scripts : test_sts_aswi.py
 config:
      bucket_count: 2
-     objects_count: 50
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sts_aswi_s3_resource_tag_role_policy.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_aswi_s3_resource_tag_role_policy.yaml
@@ -2,7 +2,7 @@
 # test scripts : test_sts_aswi.py
 config:
      bucket_count: 2
-     objects_count: 50
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sts_aswi_sub_claim.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_aswi_sub_claim.yaml
@@ -3,7 +3,7 @@
 # sub - subject claim is a string that identifies the principal that is the subject of the JWT
 config:
      bucket_count: 2
-     objects_count: 50
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sts_aswi_verify_role_policy_allow_actions.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_aswi_verify_role_policy_allow_actions.yaml
@@ -2,7 +2,7 @@
 # test scripts : test_sts_aswi.py
 config:
      bucket_count: 2
-     objects_count: 50
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sts_aswi_verify_role_policy_deny_actions.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_aswi_verify_role_policy_deny_actions.yaml
@@ -2,7 +2,7 @@
 # test scripts : test_sts_aswi.py
 config:
      bucket_count: 2
-     objects_count: 50
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sts_invalid_principal.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_invalid_principal.yaml
@@ -2,7 +2,7 @@
 # test scripts : test_sts_using_boto.py
 config:
      bucket_count: 2
-     objects_count: 100
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sts_using_boto.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_using_boto.yaml
@@ -2,7 +2,7 @@
 # test scripts : test_sts_using_boto.py , test_sts_using_boto_unexisting_object.py
 config:
      bucket_count: 2
-     objects_count: 100
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sts_using_boto_invalid_arn_policy.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_using_boto_invalid_arn_policy.yaml
@@ -1,7 +1,7 @@
 # polarion test case id: CEPH-83572938
 config:
      bucket_count: 2
-     objects_count: 100
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sts_using_boto_permissive_session_policy.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_using_boto_permissive_session_policy.yaml
@@ -1,7 +1,7 @@
 # polarion test case id: CEPH-83572938
 config:
      bucket_count: 2
-     objects_count: 100
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sts_using_boto_restricted_session_policy.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_using_boto_restricted_session_policy.yaml
@@ -1,7 +1,7 @@
 # polarion test case id: CEPH-83572938
 config:
      bucket_count: 2
-     objects_count: 100
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sts_using_boto_server_side_copy.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_using_boto_server_side_copy.yaml
@@ -1,7 +1,7 @@
 # polarion test case id: CEPH-83574522
 config:
      bucket_count: 2
-     objects_count: 100
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sts_using_boto_verify_session_policy_allow_actions.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_using_boto_verify_session_policy_allow_actions.yaml
@@ -2,7 +2,7 @@
 # test scripts : test_sts_using_boto_session_policy.py
 config:
      bucket_count: 2
-     objects_count: 25
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sts_using_boto_verify_session_policy_allow_put_object_and_deny_abort_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_using_boto_verify_session_policy_allow_put_object_and_deny_abort_multipart.yaml
@@ -3,7 +3,7 @@
 # test scripts : test_sts_using_boto_session_policy.py
 config:
      bucket_count: 2
-     objects_count: 25
+     objects_count: 10
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sts_using_boto_verify_session_policy_deny_actions.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_using_boto_verify_session_policy_deny_actions.yaml
@@ -2,7 +2,7 @@
 # test scripts : test_sts_using_boto_session_policy.py
 config:
      bucket_count: 2
-     objects_count: 25
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_sts_using_boto_verify_session_policy_deny_sns_topic_actions.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_using_boto_verify_session_policy_deny_sns_topic_actions.yaml
@@ -3,7 +3,7 @@
 # test scripts : test_sts_using_boto_session_policy.py
 config:
      bucket_count: 2
-     objects_count: 25
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_swift_basic_ops.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_swift_basic_ops.yaml
@@ -1,7 +1,7 @@
 # test case id: CEPH-11019
 config:
   container_count: 3
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_swift_object_expire_op.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_swift_object_expire_op.yaml
@@ -1,7 +1,7 @@
 # test case id: CEPH-9718
 config:
   container_count: 2
-  objects_count: 100
+  objects_count: 20
   object_expire: true
   objects_size_range:
     min: 5

--- a/rgw/v2/tests/s3_swift/configs/test_swift_version_copy_op.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_swift_version_copy_op.yaml
@@ -1,7 +1,7 @@
 # test case id: CEPH-10646
 config:
   container_count: 2
-  objects_count: 100
+  objects_count: 20
   version_count: 4
   version_enable: true
   copy_version_object: true

--- a/rgw/v2/tests/s3_swift/configs/test_swift_versioning.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_swift_versioning.yaml
@@ -1,7 +1,7 @@
 # test case id: CEPH-10640
 config:
   container_count: 3
-  objects_count: 100
+  objects_count: 20
   version_count: 4
   version_enable: true
   objects_size_range:

--- a/rgw/v2/tests/s3_swift/configs/test_tenantuser_secretkey_gen.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_tenantuser_secretkey_gen.yaml
@@ -1,7 +1,7 @@
 # test case id: CEPH-9739
 config:
   container_count: 3
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/configs/test_versioning_objects_acls.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_versioning_objects_acls.yaml
@@ -4,7 +4,7 @@
 config:
      user_count: 1
      bucket_count: 2
-     objects_count: 100
+     objects_count: 20
      version_count: 2
      objects_size_range:
           min: 5

--- a/rgw/v2/tests/s3_swift/configs/test_versioning_objects_copy.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_versioning_objects_copy.yaml
@@ -3,7 +3,7 @@
 config:
      user_count: 1
      bucket_count: 2
-     objects_count: 100
+     objects_count: 20
      version_count: 4
      objects_size_range:
           min: 5

--- a/rgw/v2/tests/s3_swift/configs/test_versioning_objects_delete.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_versioning_objects_delete.yaml
@@ -3,7 +3,7 @@
 config:
      user_count: 1
      bucket_count: 2
-     objects_count: 100
+     objects_count: 20
      version_count: 4
      objects_size_range:
           min: 5

--- a/rgw/v2/tests/s3_swift/configs/test_versioning_objects_delete_from_another_user.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_versioning_objects_delete_from_another_user.yaml
@@ -4,7 +4,7 @@
 config:
      user_count: 1
      bucket_count: 2
-     objects_count: 100
+     objects_count: 20
      version_count: 4
      objects_size_range:
           min: 5

--- a/rgw/v2/tests/s3_swift/configs/test_versioning_objects_enable.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_versioning_objects_enable.yaml
@@ -3,7 +3,7 @@
 config:
      user_count: 1
      bucket_count: 2
-     objects_count: 100
+     objects_count: 20
      version_count: 4
      objects_size_range:
           min: 5

--- a/rgw/v2/tests/s3_swift/configs/test_versioning_objects_suspend.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_versioning_objects_suspend.yaml
@@ -3,7 +3,7 @@
 config:
      user_count: 1
      bucket_count: 2
-     objects_count: 100
+     objects_count: 20
      version_count: 4
      objects_size_range:
           min: 5

--- a/rgw/v2/tests/s3_swift/configs/test_versioning_objects_suspend_from_another_user.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_versioning_objects_suspend_from_another_user.yaml
@@ -3,7 +3,7 @@
 config:
      user_count: 1
      bucket_count: 2
-     objects_count: 100
+     objects_count: 20
      version_count: 4
      objects_size_range:
           min: 5

--- a/rgw/v2/tests/s3_swift/configs/test_versioning_objects_suspend_re-upload.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_versioning_objects_suspend_re-upload.yaml
@@ -4,7 +4,7 @@
 config:
      user_count: 1
      bucket_count: 2
-     objects_count: 100
+     objects_count: 20
      version_count: 4
      objects_size_range:
           min: 5

--- a/rgw/v2/tests/s3_swift/configs/test_versioning_objects_suspended_delete.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_versioning_objects_suspended_delete.yaml
@@ -3,7 +3,7 @@
 config:
      user_count: 1
      bucket_count: 2
-     objects_count: 100
+     objects_count: 20
      version_count: 4
      objects_size_range:
           min: 5

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects.yaml
@@ -3,7 +3,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5K
     max: 5M

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_0_shards_sync_test_haproxy.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_0_shards_sync_test_haproxy.yaml
@@ -6,7 +6,7 @@ config:
   test_sync_consistency_bucket_stats: true
   user_count: 1
   bucket_count: 2
-  objects_count: 150
+  objects_count: 20
   objects_size_range:
     min: 5K
     max: 5M

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_aws4.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_aws4.yaml
@@ -4,7 +4,7 @@ config:
   use_aws4: true
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_bucket_pol_retain.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_bucket_pol_retain.yaml
@@ -7,7 +7,7 @@ config:
   retain_bucket_pol: true
   user_count: 1
   bucket_count: 2
-  objects_count: 40
+  objects_count: 20
   objects_size_range:
     min: 5K
     max: 5M

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_compression.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_compression.yaml
@@ -3,7 +3,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_compression_haproxy.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_compression_haproxy.yaml
@@ -4,7 +4,7 @@ config:
   haproxy: true
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_delete.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_delete.yaml
@@ -3,7 +3,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_download.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_download.yaml
@@ -3,7 +3,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_enc.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_enc.yaml
@@ -3,7 +3,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_failed.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_failed.yaml
@@ -3,7 +3,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_no_reshard_haproxy.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_no_reshard_haproxy.yaml
@@ -6,7 +6,7 @@ config:
   haproxy: true
   user_count: 1
   bucket_count: 2
-  objects_count: 40
+  objects_count: 20
   objects_size_range:
     min: 5K
     max: 5M

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_reshard_cancel_cmd.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_Mbuckets_with_Nobjects_reshard_cancel_cmd.yaml
@@ -2,7 +2,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   reshard_cancel_cmd: true
   objects_size_range:
     min: 5K

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bilog_trim_archive.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bilog_trim_archive.yaml
@@ -7,7 +7,7 @@ config:
   test_bilog_trim_on_non_existent_bucket: true
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bilog_trimming.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bilog_trimming.yaml
@@ -6,7 +6,7 @@ config:
   test_bilog_trim_on_non_existent_bucket: true
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_granularsync_owner_translation_direc.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_granularsync_owner_translation_direc.yaml
@@ -3,7 +3,7 @@
 config:
     user_count: 1
     bucket_count: 1
-    objects_count: 100
+    objects_count: 20
     objects_size_range:
         min: 5K
         max: 2M

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_granularsync_owner_translation_symm.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_granularsync_owner_translation_symm.yaml
@@ -3,7 +3,7 @@
 config:
     user_count: 1
     bucket_count: 1
-    objects_count: 100
+    objects_count: 20
     objects_size_range:
         min: 5K
         max: 2M

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_granularsync_storage_class_direc.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_granularsync_storage_class_direc.yaml
@@ -3,7 +3,7 @@
 config:
     user_count: 1
     bucket_count: 1
-    objects_count: 100
+    objects_count: 20
     pool_name: data.cold
     storage_class: cold
     objects_size_range:

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_granularsync_storage_class_symm.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_granularsync_storage_class_symm.yaml
@@ -3,7 +3,7 @@
 config:
     user_count: 1
     bucket_count: 1
-    objects_count: 100
+    objects_count: 20
     pool_name: data.glacier
     storage_class: glacier
     objects_size_range:

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_granularsync_user_mode_direc.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_granularsync_user_mode_direc.yaml
@@ -3,7 +3,7 @@
 config:
     user_count: 1
     bucket_count: 1
-    objects_count: 100
+    objects_count: 20
     objects_size_range:
         min: 5K
         max: 2M

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_granularsync_user_mode_symm.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_granularsync_user_mode_symm.yaml
@@ -3,7 +3,7 @@
 config:
     user_count: 1
     bucket_count: 1
-    objects_count: 100
+    objects_count: 20
     objects_size_range:
         min: 5K
         max: 2M

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_list_not_truncated.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_list_not_truncated.yaml
@@ -2,7 +2,7 @@
 # Polarion ID : CEPH-83575816
 config:
    user_count: 1
-   bucket_count: 1200
+   bucket_count: 20
    objects_count: 1
    objects_size_range:
         min: 4

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_listing_flat_ordered.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_listing_flat_ordered.yaml
@@ -1,7 +1,7 @@
 config:
      user_count: 1
      bucket_count: 2
-     objects_count: 100
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_listing_flat_ordered_versionsing.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_listing_flat_ordered_versionsing.yaml
@@ -1,7 +1,7 @@
 config:
      user_count: 1
      bucket_count: 2
-     objects_count: 100
+     objects_count: 20
      version_count: 3
      objects_size_range:
           min: 5

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_listing_flat_unordered.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_listing_flat_unordered.yaml
@@ -1,7 +1,7 @@
 config:
      user_count: 1
      bucket_count: 2
-     objects_count: 100
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_listing_pseudo_ordered.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_listing_pseudo_ordered.yaml
@@ -1,7 +1,7 @@
 config:
      user_count: 1
      bucket_count: 2
-     objects_count: 100
+     objects_count: 20
      pseudo_dir_count: 5
      objects_size_range:
           min: 5

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_listing_pseudo_ordered_dir_only.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_listing_pseudo_ordered_dir_only.yaml
@@ -1,7 +1,7 @@
 config:
      user_count: 1
      bucket_count: 2
-     pseudo_dir_count: 50
+     pseudo_dir_count: 20
      objects_count: 0
      objects_size_range:
           min: 1

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_sync_command_with_disable_sync_thread.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_sync_command_with_disable_sync_thread.yaml
@@ -3,7 +3,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 50
+  objects_count: 20
   objects_size_range:
     min: 10M
     max: 20M

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_sync_status.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_sync_status.yaml
@@ -3,7 +3,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5K
     max: 5M

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_chown_before_encrypt.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_chown_before_encrypt.yaml
@@ -5,7 +5,7 @@ config:
  haproxy: true
  encryption_keys: s3
  bucket_count: 1
- objects_count: 50
+ objects_count: 20
  local_file_delete: true
  objects_size_range:
   min: 1M

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_data_omap_offload.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_data_omap_offload.yaml
@@ -1,7 +1,7 @@
 config:
     user_count: 1
     bucket_count: 2
-    objects_count: 100
+    objects_count: 20
     objects_size_range:
         min: 5
         max: 10

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_data_omap_offload_change_datatype_fifo.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_data_omap_offload_change_datatype_fifo.yaml
@@ -1,7 +1,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 10

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_data_omap_offload_change_datatype_omap.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_data_omap_offload_change_datatype_omap.yaml
@@ -1,7 +1,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 10

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_data_omap_offload_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_data_omap_offload_multipart.yaml
@@ -1,7 +1,7 @@
 config:
    user_count: 1
    bucket_count: 2
-   objects_count: 100
+   objects_count: 10
    objects_size_range:
       min: 20M
       max: 30M

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_data_omap_offload_versioned_bucket.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_data_omap_offload_versioned_bucket.yaml
@@ -1,7 +1,7 @@
 config:
     user_count: 1
     bucket_count: 2
-    objects_count: 100
+    objects_count: 20
     version_count: 2
     objects_size_range:
         min: 5

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_datalog_trim_command.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_datalog_trim_command.yaml
@@ -4,7 +4,7 @@
 config:
  user_count: 1
  bucket_count: 2
- objects_count: 100
+ objects_count: 20
  test_datalog_trim_command: true
  objects_size_range:
   min: 5K

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_datalog_trimming.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_datalog_trimming.yaml
@@ -5,7 +5,7 @@ config:
   log_trimming: datalog
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_datalog_trimming_post_rgw_restart.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_datalog_trimming_post_rgw_restart.yaml
@@ -5,7 +5,7 @@ config:
   log_trimming: datalog
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_encrypted_bucket_chown.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_encrypted_bucket_chown.yaml
@@ -5,7 +5,7 @@ config:
  haproxy: true
  encryption_keys: s3
  bucket_count: 2
- objects_count: 50
+ objects_count: 20
  local_file_delete: true
  objects_size_range:
   min: 1M

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_lc_date.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_lc_date.yaml
@@ -1,6 +1,6 @@
 # script: test_bucket_lifecycle_object_expiration_transition.py
 config:
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_lc_date_rgw_accounts.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_lc_date_rgw_accounts.yaml
@@ -1,7 +1,7 @@
 # script: test_bucket_lifecycle_object_expiration_transition.py
 # CEPH-CEPH-83591673, CEPH-83591686
 config:
-  objects_count: 200
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_lc_multiple_rule_prefix_current_days.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_lc_multiple_rule_prefix_current_days.yaml
@@ -1,6 +1,6 @@
 # script: test_bucket_lifecycle_object_expiration_transition.py
 config:
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_lc_rule_delete_marker.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_lc_rule_delete_marker.yaml
@@ -1,6 +1,6 @@
 # test_bucket_lifecycle_object_expiration_transition.py
 config:
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_lc_rule_prefix_and_tag.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_lc_rule_prefix_and_tag.yaml
@@ -1,6 +1,6 @@
 # test_bucket_lifecycle_object_expiration_transition.py
 config:
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_lc_rule_prefix_non_current_days.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_lc_rule_prefix_non_current_days.yaml
@@ -1,6 +1,6 @@
 # script: test_bucket_lifecycle_object_expiration_transition.py
 config:
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_lc_rule_prefix_non_current_days_haproxy.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_lc_rule_prefix_non_current_days_haproxy.yaml
@@ -1,7 +1,7 @@
 # script: test_bucket_lifecycle_object_expiration_transition.py
 config:
   haproxy: true
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_mdlog_trimming.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_mdlog_trimming.yaml
@@ -5,7 +5,7 @@ config:
   log_trimming: mdlog
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_async_data_notifications.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_async_data_notifications.yaml
@@ -3,7 +3,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 15K
     max: 5M

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_bucket_mirror_sync_policy.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_bucket_mirror_sync_policy.yaml
@@ -2,7 +2,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 25
+  objects_count: 20
   objects_size_range:
     min: 5K
     max: 2M

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucket_sync_policy.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucket_sync_policy.yaml
@@ -4,7 +4,7 @@
 config:
     user_count: 1
     bucket_count: 1
-    objects_count: 100
+    objects_count: 20
     objects_size_range:
         min: 5K
         max: 2M

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucketsync_allowed_forbidden.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucketsync_allowed_forbidden.yaml
@@ -3,7 +3,7 @@
 config:
     user_count: 1
     bucket_count: 2
-    objects_count: 100
+    objects_count: 20
     objects_size_range:
         min: 5K
         max: 2M

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucketsync_archive_directional.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucketsync_archive_directional.yaml
@@ -3,7 +3,7 @@
 config:
     user_count: 1
     bucket_count: 1
-    objects_count: 100
+    objects_count: 20
     objects_size_range:
         min: 5K
         max: 2M

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucketsync_archive_symmetrical.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucketsync_archive_symmetrical.yaml
@@ -3,7 +3,7 @@
 config:
     user_count: 1
     bucket_count: 1
-    objects_count: 100
+    objects_count: 20
     objects_size_range:
         min: 5K
         max: 2M

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucketsync_enable_enable.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucketsync_enable_enable.yaml
@@ -3,7 +3,7 @@
 config:
     user_count: 1
     bucket_count: 1
-    objects_count: 100
+    objects_count: 20
     objects_size_range:
         min: 5K
         max: 2M

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucketsync_enabled_forbidden.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucketsync_enabled_forbidden.yaml
@@ -3,7 +3,7 @@
 config:
     user_count: 1
     bucket_count: 1
-    objects_count: 100
+    objects_count: 20
     objects_size_range:
         min: 5K
         max: 2M

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucketsync_forbidden_allowed.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucketsync_forbidden_allowed.yaml
@@ -3,7 +3,7 @@
 config:
     user_count: 1
     bucket_count: 1
-    objects_count: 100
+    objects_count: 20
     objects_size_range:
         min: 5K
         max: 2M

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucketsync_forbidden_enabled.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucketsync_forbidden_enabled.yaml
@@ -4,7 +4,7 @@
 config:
     user_count: 1
     bucket_count: 1
-    objects_count: 100
+    objects_count: 20
     objects_size_range:
         min: 5K
         max: 2M

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucketsync_forbidden_forbidden.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucketsync_forbidden_forbidden.yaml
@@ -3,7 +3,7 @@
 config:
     user_count: 1
     bucket_count: 1
-    objects_count: 100
+    objects_count: 20
     objects_size_range:
         min: 5K
         max: 2M

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucketsync_sync_from_diff_bucket.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucketsync_sync_from_diff_bucket.yaml
@@ -3,7 +3,7 @@
 config:
     user_count: 1
     bucket_count: 1
-    objects_count: 100
+    objects_count: 20
     objects_size_range:
         min: 5K
         max: 2M

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucketsync_sync_to_diff_bucket.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucketsync_sync_to_diff_bucket.yaml
@@ -3,7 +3,7 @@
 config:
     user_count: 1
     bucket_count: 1
-    objects_count: 100
+    objects_count: 20
     objects_size_range:
         min: 5K
         max: 2M

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_mirror_sync_policy.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_mirror_sync_policy.yaml
@@ -2,7 +2,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 25
+  objects_count: 20
   objects_size_range:
     min: 5K
     max: 2M

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_sync_policy_extended.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_sync_policy_extended.yaml
@@ -4,7 +4,7 @@
 config:
     user_count: 1
     bucket_count: 1
-    objects_count: 25
+    objects_count: 20
     objects_size_range:
         min: 5K
         max: 2M

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_rgw_restore_index_versioned_buckets.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_rgw_restore_index_versioned_buckets.yaml
@@ -4,7 +4,7 @@ config:
   user_count: 1
   bucket_count: 1
   local_zone: primary
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 15
     max: 20

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_server_side_copy_object_via_encryption.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_server_side_copy_object_via_encryption.yaml
@@ -4,7 +4,7 @@ config:
      user_count: 1
      haproxy: true
      bucket_count: 2
-     objects_count: 50
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_sse_s3_bucket_enc_multipart_download_archive_site.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_sse_s3_bucket_enc_multipart_download_archive_site.yaml
@@ -6,7 +6,7 @@ config:
  remote_zone: archive
  encryption_keys: s3
  bucket_count: 1
- objects_count: 20
+ objects_count: 10
  local_file_delete: true
  objects_size_range:
   min: 6M

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_sts_multisite.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_sts_multisite.yaml
@@ -2,7 +2,7 @@
 # test scripts : test_sts_using_boto.py
 config:
      bucket_count: 2
-     objects_count: 100
+     objects_count: 20
      objects_size_range:
           min: 5
           max: 15

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_versioning_objects_acls.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_versioning_objects_acls.yaml
@@ -4,7 +4,7 @@
 config:
      user_count: 1
      bucket_count: 2
-     objects_count: 100
+     objects_count: 20
      version_count: 2
      objects_size_range:
           min: 5

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_versioning_objects_copy.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_versioning_objects_copy.yaml
@@ -3,7 +3,7 @@
 config:
      user_count: 1
      bucket_count: 2
-     objects_count: 100
+     objects_count: 20
      version_count: 4
      objects_size_range:
           min: 5

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_versioning_objects_delete.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_versioning_objects_delete.yaml
@@ -3,7 +3,7 @@
 config:
      user_count: 1
      bucket_count: 2
-     objects_count: 100
+     objects_count: 20
      version_count: 4
      objects_size_range:
           min: 5

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_versioning_objects_enable.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_versioning_objects_enable.yaml
@@ -3,7 +3,7 @@
 config:
      user_count: 1
      bucket_count: 2
-     objects_count: 100
+     objects_count: 20
      version_count: 4
      objects_size_range:
           min: 5

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_versioning_objects_suspend.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_versioning_objects_suspend.yaml
@@ -3,7 +3,7 @@
 config:
      user_count: 1
      bucket_count: 2
-     objects_count: 100
+     objects_count: 20
      version_count: 4
      objects_size_range:
           min: 5

--- a/rgw/v2/tests/s3cmd/configs/test_bucket_stats.yaml
+++ b/rgw/v2/tests/s3cmd/configs/test_bucket_stats.yaml
@@ -2,5 +2,5 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 200
+  objects_count: 20
   bucket_stats: true

--- a/rgw/v2/tests/s3cmd/configs/test_get_s3cmd.yaml
+++ b/rgw/v2/tests/s3cmd/configs/test_get_s3cmd.yaml
@@ -3,6 +3,6 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   test_ops:
     s3cmd_get_objects: true

--- a/rgw/v2/tests/s3cmd/configs/test_large_object_gc.yaml
+++ b/rgw/v2/tests/s3cmd/configs/test_large_object_gc.yaml
@@ -3,6 +3,6 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   gc_verification: true
   local_file_delete: false

--- a/rgw/v2/tests/s3cmd/configs/test_multipart_upload_with_failed_parts_using_s3cmd_and_boto3.yaml
+++ b/rgw/v2/tests/s3cmd/configs/test_multipart_upload_with_failed_parts_using_s3cmd_and_boto3.yaml
@@ -5,7 +5,7 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 10
   objects_size_range:
     min: 108M
     max: 108M

--- a/rgw/v2/tests/s3cmd/configs/test_rgw_log_details.yaml
+++ b/rgw/v2/tests/s3cmd/configs/test_rgw_log_details.yaml
@@ -4,6 +4,6 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   test_ops:
     rgw_log_detail: true

--- a/rgw/v2/tests/s3cmd/configs/test_rgw_opslog.yaml
+++ b/rgw/v2/tests/s3cmd/configs/test_rgw_opslog.yaml
@@ -5,5 +5,5 @@
 config:
   user_count: 1
   bucket_count: 2
-  objects_count: 100
+  objects_count: 20
   rgw_ops_log: true

--- a/rgw/v2/tests/s3cmd/configs/test_s3cmd.yaml
+++ b/rgw/v2/tests/s3cmd/configs/test_s3cmd.yaml
@@ -1,7 +1,7 @@
 # test case id: CEPH-83573244
 config:
   container_count: 2
-  objects_count: 100
+  objects_count: 20
   objects_size_range:
     min: 5
     max: 15

--- a/rgw/v2/tests/s3cmd/multisite_configs/test_s3cmd_lifecycle_archive_noncurrent_expiration.yaml
+++ b/rgw/v2/tests/s3cmd/multisite_configs/test_s3cmd_lifecycle_archive_noncurrent_expiration.yaml
@@ -5,7 +5,7 @@ config:
   remote_zone: archive
   local_zone: primary
   container_count: 1
-  objects_count: 100
+  objects_count: 20
   version_enable: true
   version_count: 5
   test_ops:


### PR DESCRIPTION
Reduce object creation on all config files of ceph-qe-script
https://issues.redhat.com/browse/RHCEPHQE-18661

normal uploads - 20 objects
multi part upload - 10 objects
DBR and resharding tests are left at 100 objects as earlier