### PR TITLE
[TFA]: Issue seen with user info get

### DIFF
--- a/rgw/v2/tests/aws/test_acl.py
+++ b/rgw/v2/tests/aws/test_acl.py
@@ -45,10 +45,12 @@ def test_exec(config, ssh_con):
     io_info_initialize = IOInfoInitialize()
     basic_io_structure = BasicIOInfoStructure()
     io_info_initialize.initialize(basic_io_structure.initial())
+    user_name = config.test_ops["user_name"]
+    user_names = [user_name] if type(user_name) != list else user_name
     if config.test_ops.get("user_name", False):
         user_info = resource_op.create_users(
             no_of_users_to_create=config.user_count,
-            user_names=config.test_ops["user_name"],
+            user_names=user_names,
         )
     else:
         user_info = resource_op.create_users(no_of_users_to_create=config.user_count)

--- a/rgw/v2/tests/aws/test_aws.py
+++ b/rgw/v2/tests/aws/test_aws.py
@@ -50,10 +50,13 @@ def test_exec(config, ssh_con):
     io_info_initialize = IOInfoInitialize()
     basic_io_structure = BasicIOInfoStructure()
     io_info_initialize.initialize(basic_io_structure.initial())
+    user_name = config.test_ops["user_name"]
+    user_names = [user_name] if type(user_name) != list else user_name
+
     if config.test_ops.get("user_name", False):
         user_info = resource_op.create_users(
             no_of_users_to_create=config.user_count,
-            user_names=config.test_ops["user_name"],
+            user_names=user_names,
         )
     else:
         user_info = resource_op.create_users(no_of_users_to_create=config.user_count)

--- a/rgw/v2/tests/aws/test_checksum.py
+++ b/rgw/v2/tests/aws/test_checksum.py
@@ -46,10 +46,12 @@ def test_exec(config, ssh_con):
     io_info_initialize = IOInfoInitialize()
     basic_io_structure = BasicIOInfoStructure()
     io_info_initialize.initialize(basic_io_structure.initial())
+    user_name = config.test_ops["user_name"]
+    user_names = [user_name] if type(user_name) != list else user_name
     if config.test_ops.get("user_name", False):
         user_info = resource_op.create_users(
             no_of_users_to_create=config.user_count,
-            user_names=config.test_ops["user_name"],
+            user_names=user_names,
         )
     else:
         user_info = resource_op.create_users(no_of_users_to_create=config.user_count)

--- a/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
+++ b/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
@@ -78,7 +78,7 @@ def test_exec(config, ssh_con):
 
     # create user
     if config.dbr_scenario == "brownfield":
-        user_brownfiled = "brownfield_user"
+        user_brownfiled = ["brownfield_user"]
         all_users_info = s3lib.create_users(config.user_count, user_brownfiled)
     else:
         if config.user_type == "tenanted":


### PR DESCRIPTION
This failure is due to https://github.com/ckulal/ceph-qe-scripts/blob/master/rgw/v2/lib/resource_op.py#L92
here usernames we are expecting as list, but in some places we are passing usernames as string.
example: https://github.com/red-hat-storage/ceph-qe-scripts/blob/master/rgw/v2/tests/aws/test_aws.py#L56


log after fix:
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/user_info/test_aws_buckets_creation.console.log2


http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-RFS9L5/create_regular_and_versioned_bucket_in_primary_0.log

2025-04-01 11:51:13,334 INFO: cluster is primary
2025-04-01 17:21:13,409 - cephci - ceph:1186 - ERROR - 2025-04-01 11:51:13,334 INFO: cluster name: ceph
2025-04-01 17:21:13,409 - cephci - ceph:1186 - ERROR - 2025-04-01 11:51:13,334 INFO: executing cmd: radosgw-admin user list
2025-04-01 17:21:13,702 - cephci - ceph:1186 - ERROR - 2025-04-01 11:51:13,634 INFO: cmd excuted
2025-04-01 17:21:13,703 - cephci - ceph:1186 - ERROR - 2025-04-01 11:51:13,635 INFO: [
2025-04-01 17:21:13,703 - cephci - ceph:1186 - ERROR -     "richardd.406",
2025-04-01 17:21:13,703 - cephci - ceph:1186 - ERROR -     "dashboard",
2025-04-01 17:21:13,703 - cephci - ceph:1186 - ERROR -     "cosbench01",
2025-04-01 17:21:13,703 - cephci - ceph:1186 - ERROR -     "repuser"
2025-04-01 17:21:13,703 - cephci - ceph:1186 - ERROR - ]
2025-04-01 17:21:13,703 - cephci - ceph:1186 - ERROR - 
2025-04-01 17:21:13,703 - cephci - ceph:1186 - ERROR - 2025-04-01 11:51:13,635 INFO: cmd to execute:
2025-04-01 17:21:13,703 - cephci - ceph:1186 - ERROR - radosgw-admin user info --uid='cosbench01' --cluster ceph
2025-04-01 17:21:13,979 - cephci - ceph:1186 - ERROR - 2025-04-01 11:51:13,908 INFO: {'user_id': 'cosbench01', 'display_name': 'cosbench01', 'email': 'cosbench01@noreply.com', 'suspended': 0, 'max_buckets': 1000, 'subusers': [], 'keys': [{'user': 'cosbench01', 'access_key': '7QGIKET8F6PDWTPZX83X', 'secret_key': 'kywsWeYbTFPPMCQPOhj8OLfGGhexLH7aN9HvsPy0', 'active': True, 'create_date': '2025-03-20T06:09:06.538896Z'}], 'swift_keys': [], 'caps': [], 'op_mask': 'read, write, delete', 'default_placement': '', 'default_storage_class': '', 'placement_tags': [], 'bucket_quota': {'enabled': False, 'check_on_raw': False, 'max_size': -1, 'max_size_kb': 0, 'max_objects': -1}, 'user_quota': {'enabled': False, 'check_on_raw': False, 'max_size': -1, 'max_size_kb': 0, 'max_objects': -1}, 'temp_url_keys': [], 'type': 'rgw', 'mfa_ids': [], 'account_id': '', 'path': '/', 'create_date': '2025-03-20T06:09:06.538348Z', 'tags': [], 'group_ids': []}
2025-04-01 17:21:13,981 - cephci - ceph:1186 - ERROR - 2025-04-01 11:51:13,908 INFO: got user info structure: {'user_id': 'cosbench01', 'access_key': '7QGIKET8F6PDWTPZX83X', 'secret_key': 'kywsWeYbTFPPMCQPOhj8OLfGGhexLH7aN9HvsPy0', 'bucket': [], 'deleted': False}
2025-04-01 17:21:13,981 - cephci - ceph:1186 - ERROR - 2025-04-01 11:51:13,909 INFO: got yaml data {'users': []}
2025-04-01 17:21:13,982 - cephci - ceph:1186 - ERROR - 2025-04-01 11:51:13,909 INFO: data to add: {'users': [{'user_id': 'cosbench01', 'access_key': '7QGIKET8F6PDWTPZX83X', 'secret_key': 'kywsWeYbTFPPMCQPOhj8OLfGGhexLH7aN9HvsPy0', 'bucket': [], 'deleted': False}]}
2025-04-01 17:21:13,982 - cephci - ceph:1186 - ERROR - 2025-04-01 11:51:13,910 INFO: access_key <masked>
2025-04-01 17:21:13,982 - cephci - ceph:1186 - ERROR - 2025-04-01 11:51:13,910 INFO: secret_key: kywsWeYbTFPPMCQPOhj8OLfGGhexLH7aN9HvsPy0
2025-04-01 17:21:13,982 - cephci - ceph:1186 - ERROR - 2025-04-01 11:51:13,910 INFO: user_id: cosbench01
2025-04-01 17:21:13,983 - cephci - ceph:1186 - ERROR - 2025-04-01 11:51:13,911 INFO: cosbench01

