### PR TITLE
Include client tool version capture

### DIFF
--- a/rgw/v2/lib/aws/auth.py
+++ b/rgw/v2/lib/aws/auth.py
@@ -46,6 +46,8 @@ def install_aws(ssh_con=None):
                 ssh_con.exec_command("unzip awscliv2.zip")
                 ssh_con.exec_command("sudo aws/./install")
                 ssh_con.exec_command(f"mkdir {root_path}")
+                log.info(f"AWS version:")
+                ssh_con.exec_command("sudo /usr/local/bin/aws --version")
             else:
                 utils.exec_shell_cmd(
                     "curl 'https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip' -o 'awscliv2.zip'"
@@ -54,6 +56,8 @@ def install_aws(ssh_con=None):
                 utils.exec_shell_cmd("unzip awscliv2.zip")
                 utils.exec_shell_cmd("sudo aws/./install")
                 utils.exec_shell_cmd(f"mkdir {root_path}")
+                log.info(f"AWS version:")
+                utils.exec_shell_cmd("sudo /usr/local/bin/aws --version")
     except:
         raise AssertionError("AWS Installation Failed")
 

--- a/rgw/v2/lib/s3/auth.py
+++ b/rgw/v2/lib/s3/auth.py
@@ -59,6 +59,7 @@ class Auth(object):
         log.info("endpoint url: %s" % self.endpoint_url)
         log.info("ssl: %s" % self.ssl)
         log.info("session_token: %s" % self.session_token)
+        log.info(f"boto version is {boto3.__version__}")
 
     def do_auth(self, **config):
         """

--- a/rgw/v2/lib/s3cmd/auth.py
+++ b/rgw/v2/lib/s3cmd/auth.py
@@ -83,3 +83,5 @@ def do_auth(user_info, ip_and_port):
     create_s3cfg_file()
     update_s3cfg_file(user_info, ip_and_port)
     copy_to_home_directory()
+    log.info("S3CMD Version:")
+    utils.exec_shell_cmd(f"{home_path}/venv/bin/s3cmd --version")

--- a/rgw/v2/lib/s5cmd/auth.py
+++ b/rgw/v2/lib/s5cmd/auth.py
@@ -69,3 +69,5 @@ def do_auth_s5cmd(user_info, ssh_con=None):
     """
     create_s5cmd_file(ssh_con)
     update_s5cmd_file(user_info, ssh_con)
+    log.info("S5CMD Version:")
+    utils.exec_shell_cmd(f"{home_path}/venv/bin/s5cmd version")

--- a/rgw/v2/tests/s5cmd/reusable.py
+++ b/rgw/v2/tests/s5cmd/reusable.py
@@ -22,6 +22,8 @@ import v2.utils.utils as utils
 from v2.lib.exceptions import S5CMDCommandExecError, TestExecError
 from v2.lib.manage_data import io_generator
 
+s5cmd = "/home/cephuser/venv/bin/s5cmd"
+
 
 def create_bucket(bucket_name, end_point):
     """
@@ -31,7 +33,7 @@ def create_bucket(bucket_name, end_point):
         bucket_name(str): Name of the bucket to be created
         end_point(str): endpoint
     """
-    cmd = f"s5cmd --endpoint-url {end_point} mb s3://{bucket_name}"
+    cmd = f"{s5cmd} --endpoint-url {end_point} mb s3://{bucket_name}"
     try:
         create_response = utils.exec_shell_cmd(cmd)
         log.info(f"bucket creation response is {create_response}")
@@ -75,7 +77,7 @@ def put_object_via_copy(bucket_name, end_point, object_name, local_file_path):
     Return:
         Response of put-object operation
     """
-    cmd = f"s5cmd --endpoint-url {end_point} cp {local_file_path} s3://{bucket_name}/{object_name}"
+    cmd = f"{s5cmd} --endpoint-url {end_point} cp {local_file_path} s3://{bucket_name}/{object_name}"
     try:
         copy_response = utils.exec_shell_cmd(cmd)
         log.info(copy_response)
@@ -98,7 +100,7 @@ def list_objects(end_point, bucket_name=None):
         Returns details of every object in the bucket post the marker
     """
     bucket_param = f" s3://{bucket_name}" if bucket_name else ""
-    cmd = f"s5cmd --endpoint-url {end_point} ls{bucket_param}"
+    cmd = f"{s5cmd} --endpoint-url {end_point} ls{bucket_param}"
     try:
         list_response = utils.exec_shell_cmd(cmd)
     except Exception as e:
@@ -137,7 +139,7 @@ def delete_bucket(bucket_name, end_point):
     Return:
         Response of delete-object operation
     """
-    cmd = f"s5cmd --endpoint-url {end_point} rb s3://{bucket_name}"
+    cmd = f"{s5cmd} --endpoint-url {end_point} rb s3://{bucket_name}"
     try:
         delete_response = utils.exec_shell_cmd(cmd)
         log.info(f"bucket removal response is {create_response}")


### PR DESCRIPTION
1. Include client tool version capture

which help during any product issue observed, we can identify client version from automation run.
without depending on manual effort.

since most of the time it's been seen that few product issues has a dependency on client versions.

Logs:
AWS: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/tool_version/test_aws_non_ascii.console.log
Boto3: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/tool_version/test_Mbuckets.console.log
S3CMD: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/tool_version/test_s3cmd.console.log
S5CMD: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/tool_version/test_s5cmd_basic_op.console.log
Curl: already present


2. Fix issue seen with s5cmd command not found
    Fail log: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/tool_version/test_s5cmd_basic_op.console.log-fail
    pass log: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/tool_version/test_s5cmd_basic_op.console.log

