### PR TITLE
TFA FIX : test swift stats command for more than 1000 buckets:

### DIFF
--- a/rgw/v2/tests/s3_swift/swift_stats.py
+++ b/rgw/v2/tests/s3_swift/swift_stats.py
@@ -37,24 +37,30 @@ log = logging.getLogger()
 
 
 def test_exec(config, ssh_con):
+
     io_info_initialize = IOInfoInitialize()
     basic_io_structure = BasicIOInfoStructure()
     io_info_initialize.initialize(basic_io_structure.initial())
     umgmt = UserMgmt()
 
+    # preparing data
     user_names = ["max", "scooby", "tubyst"]
     tenant = "tenant"
-    #added a check if the user already exist, removing and recreating if if its existing
+    # added a check if the user already exist, removing and recreating the user
     try:
         cmd = f"radosgw-admin user info --uid={user_names[0]} --tenant={tenant}"
-        process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        process = subprocess.Popen(
+            cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
         stdout, stderr = process.communicate()
         exit_code = process.returncode
-        user_check = stdout.decode('utf-8')
+        user_check = stdout.decode("utf-8")
         log.info(f"Checking if user exists already:\n{user_check}")
 
         if "user_id" in user_check:  # if User exists
-            log.info(f"User tenant${user_names[0]} already exists, removing and recreating.")
+            log.info(
+                f"User tenant${user_names[0]} already exists, removing and recreating."
+            )
             cmd = f"radosgw-admin user rm --uid={user_names[0]} --tenant={tenant} --purge-data"
             utils.exec_shell_cmd(cmd)
 

--- a/rgw/v2/tests/s3_swift/swift_stats.py
+++ b/rgw/v2/tests/s3_swift/swift_stats.py
@@ -14,14 +14,14 @@ Operation:
 """
 
 import os
-import sys
 import subprocess
+import sys
 
 sys.path.append(os.path.abspath(os.path.join(__file__, "../../../..")))
 import argparse
+import json
 import logging
 import traceback
-import json
 
 import v2.lib.resource_op as swiftlib
 import v2.utils.utils as utils

--- a/rgw/v2/tests/s3_swift/swift_stats.py
+++ b/rgw/v2/tests/s3_swift/swift_stats.py
@@ -15,11 +15,13 @@ Operation:
 
 import os
 import sys
+import subprocess
 
 sys.path.append(os.path.abspath(os.path.join(__file__, "../../../..")))
 import argparse
 import logging
 import traceback
+import json
 
 import v2.lib.resource_op as swiftlib
 import v2.utils.utils as utils
@@ -35,22 +37,33 @@ log = logging.getLogger()
 
 
 def test_exec(config, ssh_con):
-
     io_info_initialize = IOInfoInitialize()
     basic_io_structure = BasicIOInfoStructure()
     io_info_initialize.initialize(basic_io_structure.initial())
     umgmt = UserMgmt()
 
-    # preparing data
-    user_names = ["tuffy", "scooby", "max"]
+    user_names = ["max", "scooby", "tubyst"]
     tenant = "tenant"
-    tenant_user_info = umgmt.create_tenant_user(
-        tenant_name=tenant, user_id=user_names[0], displayname=user_names[0]
-    )
-    user_info = umgmt.create_subuser(tenant_name=tenant, user_id=user_names[0])
-    cmd = "radosgw-admin quota enable --quota-scope=user --uid={uid} --tenant={tenant}".format(
-        uid=user_names[0], tenant=tenant
-    )
+    #added a check if the user already exist, removing and recreating if if its existing
+    try:
+        cmd = f"radosgw-admin user info --uid={user_names[0]} --tenant={tenant}"
+        process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = process.communicate()
+        exit_code = process.returncode
+        user_check = stdout.decode('utf-8')
+        log.info(f"Checking if user exists already:\n{user_check}")
+
+        if "user_id" in user_check:  # if User exists
+            log.info(f"User tenant${user_names[0]} already exists, removing and recreating.")
+            cmd = f"radosgw-admin user rm --uid={user_names[0]} --tenant={tenant} --purge-data"
+            utils.exec_shell_cmd(cmd)
+
+        tenant_user_info = umgmt.create_tenant_user(
+            tenant_name=tenant, user_id=user_names[0], displayname=user_names[0]
+        )
+    except RGWBaseException as e:
+        log.error(f"Failed to create tenant user: {e}")
+        raise e
     enable_user_quota = utils.exec_shell_cmd(cmd)
     cmd = "radosgw-admin quota set --quota-scope=user --uid={uid} --tenant={tenant} --max_buckets=2000".format(
         uid=user_names[0], tenant=tenant

--- a/rgw/v2/tests/s3_swift/swift_stats.py
+++ b/rgw/v2/tests/s3_swift/swift_stats.py
@@ -44,7 +44,7 @@ def test_exec(config, ssh_con):
     umgmt = UserMgmt()
 
     # preparing data
-    user_names = ["max", "scooby", "tubyst"]
+    user_names = ["max", "scooby", "tuffy"]
     tenant = "tenant"
     # added a check if the user already exist, removing and recreating the user
     try:


### PR DESCRIPTION
The test swift stats command for more than 1000 buckets was failing in the baremetal run with the error: could not create `user: unable to parse parameters, user: tenant$tuffy exists because the user already exist`s, causing the test case to fail.

Reason: Previously, the same test case failed after creating the user and buckets, and failed before removing the user along with the buckets, which led to this error.

To resolve this, I added a check that verifies if the user exists. If the user exists, it removes the user and then creates it again.

Reason for removing and creating the user is the bucket quota is already set to 2000. If we bypass the user creation and go directly to bucket creation, there would be another error related to the bucket quota.

**Tested it in a normal VM environment with the below steps [automation script]: [similar to baremetal]**

1.Created a user, uploaded buckets, and did not delete the user [to reproduce the cause of  the same issue as we were seeing on baremetal to check if this script works].

2.Checked if the user existed and then removed it as it was existing from the previous test case. Then, created the user again, created the buckets, and then removed the user along with the buckets [works even if there is already a user with the same name; no more failures with the "user already exists" error on baremetal].

3.As per the previous test, since there is no user, it will normally proceed with user creation and continue [this is for the VM environment].

The failed log: http://magna002.ceph.redhat.com/cephci-jenkins/results/baremetal/RH/8.1/rhel-9/19.2.1-59/rgw/63/tier-2_rgw_sts_aswi/test_swift_stats_command_for_more_than_1000_buckets_0.log

**Log link:** http://magna002.ceph.redhat.com/ceph-qe-logs/yuva/TFArgw_sts_aswi4/
**Complete log link** http://magna002.ceph.redhat.com/ceph-qe-logs/yuva/TFArgw_sts_aswi6/
