### PR TITLE
Fix Key error: user_name not found

### DIFF
--- a/rgw/v2/tests/aws/test_acl.py
+++ b/rgw/v2/tests/aws/test_acl.py
@@ -45,7 +45,7 @@ def test_exec(config, ssh_con):
     io_info_initialize = IOInfoInitialize()
     basic_io_structure = BasicIOInfoStructure()
     io_info_initialize.initialize(basic_io_structure.initial())
-    user_name = config.test_ops["user_name"]
+    user_name = (config.test_ops.get("user_name"), None)
     user_names = [user_name] if type(user_name) != list else user_name
     if config.test_ops.get("user_name", False):
         user_info = resource_op.create_users(

--- a/rgw/v2/tests/aws/test_aws.py
+++ b/rgw/v2/tests/aws/test_aws.py
@@ -50,7 +50,7 @@ def test_exec(config, ssh_con):
     io_info_initialize = IOInfoInitialize()
     basic_io_structure = BasicIOInfoStructure()
     io_info_initialize.initialize(basic_io_structure.initial())
-    user_name = config.test_ops["user_name"]
+    user_name = (config.test_ops.get("user_name"), None)
     user_names = [user_name] if type(user_name) != list else user_name
 
     if config.test_ops.get("user_name", False):

--- a/rgw/v2/tests/aws/test_checksum.py
+++ b/rgw/v2/tests/aws/test_checksum.py
@@ -46,7 +46,7 @@ def test_exec(config, ssh_con):
     io_info_initialize = IOInfoInitialize()
     basic_io_structure = BasicIOInfoStructure()
     io_info_initialize.initialize(basic_io_structure.initial())
-    user_name = config.test_ops["user_name"]
+    user_name = (config.test_ops.get("user_name"), None)
     user_names = [user_name] if type(user_name) != list else user_name
     if config.test_ops.get("user_name", False):
         user_info = resource_op.create_users(


### PR DESCRIPTION
Fix issue seen with Key error: user_name not found,

as per changes done in PR: https://github.com/red-hat-storage/ceph-qe-scripts/pull/711/files
Failure is seen when user_name is passed from config file,

This PR will fix this scenario.

Pass logs:
1. Test Etag not empty for complete multipart upload in aws
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/fix_user_name_keyerror/test_complete_multipart_upload_etag_not_empty.console.log
    
2. Test S3 PUT requests with non ascii characters in body:
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/fix_user_name_keyerror/test_aws_non_ascii.console.log

3. Test bucket listing with markers on versioned bucket
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/fix_user_name_keyerror/test_versioned_list_marker.console.log

4. Test anonymous PUT to bucket with public-read-write ACL
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/fix_user_name_keyerror/test_public_read_write_acl.console.log


