### PR TITLE
Add support to read files from ceph-jenkins

### DIFF
--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -2077,9 +2077,7 @@ def prepare_for_bucket_lc_transition(config):
                 )
     else:
         if config.test_ops.get("test_ibm_cloud_transition", False):
-            wget_cmd = "curl -o ibm_cloud.env http://magna002.ceph.redhat.com/cephci-jenkins/ibm_cloud_file"
-            utils.exec_shell_cmd(cmd=f"{wget_cmd}")
-            ibm_config = configobj.ConfigObj("ibm_cloud.env")
+            ibm_config = utils.setup_and_access_rgw_config("ibm_cloud_file")
             target_path = ibm_config["TARGET"]
             access = ibm_config["ACCESS"]
             secret = ibm_config["SECRET"]


### PR DESCRIPTION
To access encrypted files in the rgw-cluster-configs repository, follow these steps:

1. Install the git-crypt Package:
     yum install -y https://cbs.centos.org/kojifiles/packages/git-crypt/0.6.0/1.el7/x86_64/git-crypt-0.6.0-1.el7.x86_64.rpm

2. Clone the Repository
     Clone the rgw-cluster-configs repository using the command:
     git clone https://gitlab.cee.redhat.com/rhcs-qe/rgw-cluster-configs.git

3.  Decrypt and access the encrypted files:
     git crypt unlock
     After decryption, you can access encrypted files in the secret directory

Made changes for the file ibm_cloud_file and verified them in the pass log: http://magna002.ceph.redhat.com/ceph-qe-logs/mreddem/cephci-run-RBX8ZT