### PR TITLE
[TFA]:Fix failure seen with create_20_bucket_in_primary

### DIFF
--- a/rgw/v2/lib/resource_op.py
+++ b/rgw/v2/lib/resource_op.py
@@ -89,8 +89,8 @@ def create_users(
         for i in range(no_of_users_to_create):
             if user_names:
                 user_details = admin_ops.create_admin_user(
-                    user_id=user_names[i],
-                    displayname=user_names,
+                    user_id=user_names[i][0],
+                    displayname=user_names[i][0],
                     cluster_name=cluster_name,
                 )
                 all_users_details.append(user_details)


### PR DESCRIPTION
Fail log in case of username passed from config: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/fix_create_20_bucket_in_primary/test_aws_buckets_creation.console.log-fail

failure was due to user_name coming as tuple: 
test: ('cosbench01', None)

fix provided to fetch first element of tuple:
pass log after fix:

Pass log in case of username passed from config: after fix
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/fix_create_20_bucket_in_primary/test_aws_buckets_creation.console.log-pass

Pass log in case user name not passed from config:after fix
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/fix_create_20_bucket_in_primary/test_complete_multipart_upload_etag_not_empty.console.log-pass2