### PR TITLE
[TFA]: Fix issue seen with user_name

### DIFF
--- a/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
+++ b/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
@@ -78,7 +78,7 @@ def test_exec(config, ssh_con):
 
     # create user
     if config.dbr_scenario == "brownfield":
-        user_brownfiled = ["brownfield_user"]
+        user_brownfiled = [("brownfield_user", None)]
         all_users_info = s3lib.create_users(config.user_count, user_brownfiled)
     else:
         if config.user_type == "tenanted":


### PR DESCRIPTION
Fix issue seen with user_name,

as per PR: https://github.com/red-hat-storage/ceph-qe-scripts/pull/721/files

username expects input in the format list of tuples.
made the changes accordingly.

fail log before fix:

http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/7.1/rhel-9/Upgrade/18.2.1-327/170/tier-1_rgw_archive_ms_upgrade_61GA_to_7x_latest/Create_bucket_for_Testing_dynamic_resharding_brownfield_scenario_after_upgrade_0.log

http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/7.1/rhel-9/Upgrade/18.2.1-327/170/tier-1_rgw_archive_ms_upgrade_61GA_to_7x_latest/Create_bucket_for_Testing_manual_resharding_brownfield_scenario_after_upgrade_0.log


Pass log for user creation/user info after fix:
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/fix_user_info/test_multisite_dynamic_resharding_brownfield.console.log

http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/fix_user_info/test_multisite_manual_resharding_brownfield.console.log


pass log for other config post fix:
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/fix_user_info/test_aws_buckets_creation.console.log



