### PR TITLE
Fix issue seen with multipart upload with checksum algorithm

### DIFF
--- a/rgw/v2/tests/aws/reusable.py
+++ b/rgw/v2/tests/aws/reusable.py
@@ -177,11 +177,14 @@ def upload_part(
             algo = "crc32-c"
         else:
             algo = checksum_algo
+        cmd = f"--body {body} --endpoint-url {end_point} --checksum-algorithm {checksum_algo}"
+        if checksum:
+            cmd = cmd + f" --checksum-{algo} {checksum}"
         command = aws_auth.command(
             operation="upload-part",
             params=[
                 f"--bucket {bucket_name} --key {key_name} --part-number {part_number} --upload-id {upload_id}"
-                f" --body {body} --endpoint-url {end_point} --checksum-algorithm {checksum_algo} --checksum-{algo} {checksum}",
+                f" {cmd}",
             ],
         )
     else:
@@ -533,6 +536,7 @@ def upload_multipart_aws(
                 upload_id,
                 each_part,
                 endpoint,
+                checksum_algo=checksum_algo,
             )
         )
         part_info = {"PartNumber": part_number, "ETag": upload_part_resp["ETag"]}


### PR DESCRIPTION
Fix issue seen with multipart upload with checksum algorithm

RCA:
since previously we are passing checksum-algorithm during create-multipart upload,
but checksum-algorithm was not passing during upload part (it was taking default algorithm: i.e, ChecksumCRC64NVME)
hence test case was failing when no n default algorithm used for create-multipart-upload.

Fail log: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/checksum/test_checksum_api.console.log
error seen from debug log:

multipart part checksum type mismatch
	complete multipart header=crc64nvme part=sha1
2025-04-29T07:13:05.578+0000 7f7b99295640 16 req 7313948794726157570 0.023000196s s3:complete_multipart ERROR: try_sum_part_cksums failed, obj=:test1[840682e3-a03b-4e28-86df-ec5d0b335155.17075.4]):obj1.2~lKERRYZNkbKSXR_1j8xV7kvOBU4sERp.meta ret=-2021


Pass log post fix:
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/checksum/test_checksum_api.console.log-pass2

Pass log for other config which uses same method(i.e, upload_multipart_aws):
1. http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/checksum/test_complete_multipart_upload_etag_not_empty.console.log
2. http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/checksum/test_wrong_checksum.console.log

