### PR TITLE
[TFA]: fix failure seen with X-RGW-Quota-Max-Buckets

### DIFF
--- a/rgw/v2/tests/curl/configs/test_quota_mgmt_conflict_bucket_quota_using_curl.yaml
+++ b/rgw/v2/tests/curl/configs/test_quota_mgmt_conflict_bucket_quota_using_curl.yaml
@@ -32,6 +32,6 @@ config:
     head_bucket:
       X-RGW-Quota-User-Size: -1
       X-RGW-Quota-User-Objects: -1
-      X-RGW-Quota-Max-Buckets: 200
+      X-RGW-Quota-Max-Buckets: 1000
       X-RGW-Quota-Bucket-Size: 204800
       X-RGW-Quota-Bucket-Objects: 20


### PR DESCRIPTION
X-RGW-Quota-Max-Buckets is suppose to be 1000,
since default max_bucket per user is 1000, and we are not changing this value anywhere in the script.

this changes was done by mistakenly in PR: https://github.com/red-hat-storage/ceph-qe-scripts/pull/723

Fail log: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/fix_quota_conflict/test_quota_mgmt_conflict_bucket_quota_using_curl.console.log

pass log post fix: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/fix_quota_conflict/test_quota_mgmt_conflict_bucket_quota_using_curl.console.log-pass
