### PR TITLE
[TFA-fix] dynamic resharding post upgrade - tfa fix 

### DIFF
--- a/rgw/v2/lib/rgw_config_opts.py
+++ b/rgw/v2/lib/rgw_config_opts.py
@@ -141,7 +141,7 @@ class CephConfigSet:
         out = json.loads(out_ps)
         daemon_name_list = []
         for node in out:
-            daemon_name = node.get("daemon_name")
+            daemon_name = node.get("service_name")
             daemon_name_list.append(daemon_name)
 
         for daemon in daemon_name_list:


### PR DESCRIPTION
Dynamic resharding after the upgrade was failing because we had multiple RGW daemons deployed, but the rgw_dynamic_resharding, rgw_max_objs_per_shard, rgw_max_dynamic_shards, and rgw_reshard_thread_interval settings in the Ceph config were applied only to the first RGW daemon when the script do **`ceph orch ps --demon-type rgw  -f json`**, as shown below:                        

client.rgw.rgw.1.ceph-yuva8-1-singlesite-6799d1-node3.pphmtl        basic     rgw_dynamic_resharding                 true
client.rgw.rgw.1.ceph-yuva8-1-singlesite-6799d1-node3.pphmtl        basic     rgw_frontends                          beast port=80
client.rgw.rgw.1.ceph-yuva8-1-singlesite-6799d1-node3.pphmtl        advanced  rgw_max_dynamic_shards                 1999
client.rgw.rgw.1.ceph-yuva8-1-singlesite-6799d1-node3.pphmtl        basic     rgw_max_objs_per_shard                 5
client.rgw.rgw.1.ceph-yuva8-1-singlesite-6799d1-node3.pphmtl        advanced  rgw_reshard_thread_interval            180
client.rgw.rgw.1.ceph-yuva8-1-singlesite-6799d1-node4.qtzgso        basic     rgw_frontends                          beast port=80
client.rgw.rgw.1.ceph-yuva8-1-singlesite-6799d1-node5.ersdop        basic     rgw_frontends                          beast port=80

To resolve this, I made changes to script that takes service name and update config like below 


client.rgw.rgw.1                                                    basic     rgw_dynamic_resharding                 true                                                                                                                            
client.rgw.rgw.1                                                    advanced  rgw_max_dynamic_shards                 1999                                                                                                                            
client.rgw.rgw.1                                                    basic     rgw_max_objs_per_shard                 5                                                                                                                               
client.rgw.rgw.1                                                    advanced  rgw_reshard_thread_interval            180 

failed log: http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Upgrade/19.2.1-167/96/tier-1_rgw_upgrade_71GA_to_8x_latest/Dynamic_Resharding_tests_with_version_post_upgrade_0.log
pass log: http://magna002.ceph.redhat.com/ceph-qe-logs/yuva/logtfaupgrade61upgrade11/Dynamic_Resharding_tests_post_upgrade_0.log 
