### PR TITLE
adding sanity support for testing server-access-logging

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_bucket_logging_journal_mode.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_logging_journal_mode.yaml
@@ -1,0 +1,50 @@
+# upload type: non-multipart
+# script: test_server_access_logging.py
+# polarion: CEPH-83623532
+# bz: https://bugzilla.redhat.com/show_bug.cgi?id=2308169
+# bz: https://bugzilla.redhat.com/show_bug.cgi?id=2370245
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 25
+  objects_size_range:
+    min: 5
+    max: 15
+  enable_resharding: true
+  sharding_type: manual
+  shards: 20
+  test_ops:
+    create_bucket: true
+    create_object: true
+    upload_type: normal
+    copy_object: true
+    download_object: true
+    enable_version: false
+    put_get_bucket_logging: true
+    delete_bucket_object: true
+    logging_type: Journal
+    target_obj_key_format: SimplePrefix
+    rgw_admin_flush: true
+    policy_document:
+     {
+       "Version": "2012-10-17",
+       "Statement": [
+        {
+         "Sid": "AllowLoggingFromSourceBucketPolicy1",
+         "Effect": "Allow",
+         "Principal": {
+          "Service": "logging.s3.amazonaws.com"
+         },
+         "Action": "s3:PutObject",
+         "Resource": "arn:aws:s3:::<dest_bucket_name>/*",
+         "Condition": {
+          "StringEquals": {
+           "aws:SourceAccount": "<source_user_name>"
+          },
+          "ArnLike": {
+           "aws:SourceArn": "arn:aws:s3:::<source_bucket_name>"
+          }
+         }
+        }
+       ]
+     }

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_logging_journal_mode_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_logging_journal_mode_multipart.yaml
@@ -1,0 +1,49 @@
+# upload type: multipart
+# script: test_server_access_logging.py
+# polarion: CEPH-83623532
+# bz: https://bugzilla.redhat.com/show_bug.cgi?id=2345305
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 25
+  objects_size_range:
+    min: 6M
+    max: 8M
+#  enable_resharding: true
+#  sharding_type: dynamic
+#  max_objects_per_shard: 5
+  test_ops:
+    create_bucket: true
+    create_object: true
+    copy_object: true
+    enable_version: false
+    put_get_bucket_logging: true
+    upload_type: multipart
+    download_object: true
+    delete_bucket_object: true
+    logging_type: Journal
+    target_obj_key_format: PartitionedPrefix
+    rest_api_flush: true
+    policy_document:
+     {
+       "Version": "2012-10-17",
+       "Statement": [
+        {
+         "Sid": "AllowLoggingFromSourceBucketPolicy1",
+         "Effect": "Allow",
+         "Principal": {
+          "Service": "logging.s3.amazonaws.com"
+         },
+         "Action": "s3:PutObject",
+         "Resource": "arn:aws:s3:::<dest_bucket_name>/*",
+         "Condition": {
+          "StringEquals": {
+           "aws:SourceAccount": "<source_user_name>"
+          },
+          "ArnLike": {
+           "aws:SourceArn": "arn:aws:s3:::<source_bucket_name>"
+          }
+         }
+        }
+       ]
+     }

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_logging_standard_mode.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_logging_standard_mode.yaml
@@ -1,0 +1,50 @@
+# upload type: non-multipart
+# script: test_server_access_logging.py
+# polarion: CEPH-83623532
+# bz: https://bugzilla.redhat.com/show_bug.cgi?id=2364399
+# bz: https://bugzilla.redhat.com/show_bug.cgi?id=2370241
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 25
+  objects_size_range:
+    min: 5
+    max: 15
+#  enable_resharding: true
+#  sharding_type: dynamic
+#  max_objects_per_shard: 5
+  test_ops:
+    create_bucket: true
+    create_object: true
+    copy_object: true
+    enable_version: false
+    put_get_bucket_logging: true
+    upload_type: normal
+    download_object: true
+    delete_bucket_object: true
+    logging_type: Standard
+    target_obj_key_format: PartitionedPrefix
+    rgw_admin_flush: true
+    policy_document:
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+         {
+          "Sid": "AllowLoggingFromSourceBucketPolicy1",
+          "Effect": "Allow",
+          "Principal": {
+           "Service": "logging.s3.amazonaws.com"
+          },
+          "Action": "s3:PutObject",
+          "Resource": "arn:aws:s3:::<dest_bucket_name>/*",
+          "Condition": {
+           "StringEquals": {
+            "aws:SourceAccount": "<source_user_name>"
+           },
+           "ArnLike": {
+            "aws:SourceArn": "arn:aws:s3:::<source_bucket_name>"
+           }
+          }
+         }
+        ]
+      }

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_logging_standard_mode_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_logging_standard_mode_multipart.yaml
@@ -1,0 +1,51 @@
+# upload type: multipart
+# script: test_server_access_logging.py
+# polarion: CEPH-83623532
+# bz: https://bugzilla.redhat.com/show_bug.cgi?id=2344993
+# bz: https://bugzilla.redhat.com/show_bug.cgi?id=2365697
+# bz: https://bugzilla.redhat.com/show_bug.cgi?id=2365931
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 25
+  objects_size_range:
+    min: 6M
+    max: 8M
+  enable_resharding: true
+  sharding_type: manual
+  shards: 20
+  test_ops:
+    create_bucket: true
+    create_object: true
+    copy_object: true
+    enable_version: false
+    put_get_bucket_logging: true
+    upload_type: multipart
+    download_object: true
+    delete_bucket_object: true
+    logging_type: Standard
+    target_obj_key_format: SimplePrefix
+    rest_api_flush: true
+    policy_document:
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+         {
+          "Sid": "AllowLoggingFromSourceBucketPolicy1",
+          "Effect": "Allow",
+          "Principal": {
+           "Service": "logging.s3.amazonaws.com"
+          },
+          "Action": "s3:PutObject",
+          "Resource": "arn:aws:s3:::<dest_bucket_name>/*",
+          "Condition": {
+           "StringEquals": {
+            "aws:SourceAccount": "<source_user_name>"
+           },
+           "ArnLike": {
+            "aws:SourceArn": "arn:aws:s3:::<source_bucket_name>"
+           }
+          }
+         }
+        ]
+      }

--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -3361,3 +3361,12 @@ def get_auth(user_info, ssh_con, ssl, haproxy):
     rgw_service_port = get_rgw_service_port()
     haproxy = False if rgw_service_port == 443 else haproxy
     return Auth(user_info, ssh_con, ssl=ssl, haproxy=haproxy)
+
+
+def list_bucket_objects(rgw_s3_client, bucket_name):
+    """
+    returns all of the objects in the bucket
+    """
+    resp = rgw_s3_client.list_objects(Bucket=bucket_name)
+    log.info(f"list bucket objects response: {resp}")
+    return resp["Contents"]

--- a/rgw/v2/tests/s3_swift/reusables/server_access_logging.py
+++ b/rgw/v2/tests/s3_swift/reusables/server_access_logging.py
@@ -1,0 +1,454 @@
+import json
+import logging
+import re
+import shlex
+import time
+
+import v2.utils.utils as utils
+from v2.lib.exceptions import EventRecordDataError, TestExecError
+from v2.tests.s3_swift import reusable
+from v2.tests.s3_swift.reusables import rgw_accounts as accounts
+
+log = logging.getLogger()
+
+
+def rgw_admin_logging_info(bucket_name):
+    """
+    Perform radosgw-admin bucket logging info --bucket <bucket_name>
+    """
+    cmd = f"radosgw-admin bucket logging info --bucket {bucket_name}"
+    out = utils.exec_shell_cmd(cmd)
+    log.info(out)
+    if out is False:
+        log.info(f"bucket logging info failed")
+        return False
+    if out:
+        out = json.loads(out)
+    return out
+
+
+def put_bucket_logging(rgw_s3_client, src_bucket, dest_bucket, config):
+    """
+    put bucket logging on a given bucket
+    """
+    target_prefix = config.test_ops.get("target_prefix", f"{src_bucket}-logs")
+    logging_conf = {
+        "LoggingEnabled": {
+            "TargetBucket": dest_bucket,
+            "TargetPrefix": target_prefix,
+            "TargetObjectKeyFormat": {
+                config.test_ops.get("target_obj_key_format", "SimplePrefix"): {}
+            },
+            "ObjectRollTime": config.test_ops.get("obj_roll_time", 300),
+            "LoggingType": config.test_ops.get("logging_type", "Standard"),
+        }
+    }
+
+    log.info(
+        f"put bucket logging for the bucket {src_bucket} with logging conf:{logging_conf}"
+    )
+    put_bkt_logging_response = rgw_s3_client.put_bucket_logging(
+        Bucket=src_bucket, BucketLoggingStatus=logging_conf
+    )
+    log.info(f"put bucket logging response: {put_bkt_logging_response}")
+    return True
+
+
+def get_bucket_logging(rgw_s3_client, bucket_name):
+    """
+    get bucket logging for a given bucket
+    """
+    get_bkt_logging = rgw_s3_client.get_bucket_logging(Bucket=bucket_name)
+    if get_bkt_logging is False:
+        raise TestExecError(f"failed to get bucket logging for bucket : {bucket_name}")
+    get_bucket_logging_json = json.dumps(get_bkt_logging, indent=2)
+    log.info(f"bucket logging for bucket: {bucket_name} is {get_bkt_logging}")
+
+
+def post_bucket_logging(rgw_s3_client, bucket_name):
+    """
+    perform post-bucket-logging for a given bucket to flush out the log records as an object to target bucket
+    """
+    post_bkt_logging = rgw_s3_client.post_bucket_logging(Bucket=bucket_name)
+    log.info(f"post_bucket_logging response: {post_bkt_logging}")
+    if post_bkt_logging is False:
+        raise TestExecError(f"post_bucket_logging failed for bucket : {bucket_name}")
+    log.info(post_bkt_logging)
+    return post_bkt_logging["FlushedLoggingObject"]
+
+
+def rgw_admin_logging_flush(bucket_name):
+    """
+    Perform radosgw-admin bucket logging flush --bucket <bucket_name>
+    """
+    cmd = f"radosgw-admin bucket logging flush --bucket {bucket_name}"
+    out = utils.exec_shell_cmd(cmd)
+    log.info(out)
+    if out is False:
+        log.info(f"bucket logging flush failed")
+        return False
+    strings_list = out.split()
+    log_object_name = strings_list[
+        4
+    ]  # fifth string in the response is the log object name
+    log_object_name = log_object_name[1:-1]  # remove quotes
+    return log_object_name
+
+
+def verify_log_object_name(log_object_name, src_user_name, src_bucket_name, config):
+    """
+    verify if log object name format is correct or not for simple or partitioned prefix
+    """
+    log.info(f"Verifying log object name {log_object_name} format")
+    target_prefix = config.test_ops.get("target_prefix", f"{src_bucket_name}-logs")
+
+    if config.test_ops.get("target_obj_key_format") == "SimplePrefix":
+        if not log_object_name.startswith(target_prefix):
+            raise Exception(
+                f"log object name does not start with expected prefix. expected prefix: {target_prefix}"
+            )
+        simple_prefix_regex = re.compile(
+            rf"{target_prefix}"
+            + r"[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}-0000000000[A-Za-z0-9]{6}"
+        )
+        if not simple_prefix_regex.match(log_object_name):
+            raise Exception(f"log object not matched with simple prefix format")
+    elif config.test_ops.get("target_obj_key_format") == "PartitionedPrefix":
+        out = utils.exec_shell_cmd("radosgw-admin zonegroup get")
+        zonegroup_json = json.loads(out)
+        zonegroup_name = zonegroup_json["name"]
+        if not log_object_name.startswith(
+            f"{target_prefix}{src_user_name}/{zonegroup_name}/{src_bucket_name}"
+        ):
+            raise Exception(
+                f"log object name does not start with expected prefix. expected prefix: {target_prefix}"
+            )
+        partitioned_prefix_regex = re.compile(
+            r".*[0-9]{4}/[0-9]{2}/[0-9]{2}/[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}-0000000000[A-Za-z0-9]{6}"
+        )
+        if not partitioned_prefix_regex.match(log_object_name):
+            raise Exception(f"log object not matched with partitioned prefix format")
+    log.info(
+        f"log object name {log_object_name} matched with {config.test_ops.get('target_obj_key_format')} format"
+    )
+
+
+def verify_journal_logs(log_records, src_user_name, src_bucket_name, config):
+    """
+    verify log records which are in journal mode format
+    """
+    put_count = mpu_count = copy_count = delete_count = 0
+    for record in log_records:
+        log.info(f"verifying record: {record}")
+        fields = record.split(" ")
+        bucket_owner = fields[0]
+        bucket_name = fields[1]
+        timestamp = f"{fields[2]} {fields[3]}"
+        op = fields[4]
+        key = fields[5]
+        size = fields[6]
+        version_id = fields[7]
+        etag = fields[8]
+
+        if op == "REST.PUT.OBJECT":
+            put_count = put_count + 1
+        elif op == "REST.POST.UPLOAD":
+            mpu_count = mpu_count + 1
+        elif op == "REST.DELETE.OBJECT" or op == "REST.POST.DELETE_MULTI_OBJECT":
+            delete_count = delete_count + 1
+        elif op == "REST.COPY.OBJECT_GET":
+            copy_count = copy_count + 1
+        else:
+            raise Exception(
+                f"log record not expected for operation {op} in Journal mode"
+            )
+
+        if key == "-":
+            raise Exception("object name not populated")
+        if bucket_owner != src_user_name:
+            raise Exception("bucket_owner not matched")
+        if bucket_name != src_bucket_name:
+            raise Exception("bucket_name not matched")
+        timestamp_regex = re.compile(
+            r"\[\d{2}/\w{3}/\d{4}:\d{2}:\d{2}:\d{2} [-+]\d{4}\]"
+        )
+        if not timestamp_regex.match(timestamp):
+            raise Exception(f"timestamp {timestamp} format not matched")
+
+        if (size == "-" or int(size) == 0) and op != "REST.POST.UPLOAD":
+            raise Exception("object size not populated")
+        if config.test_ops.get("enable_version") and op != "REST.POST.UPLOAD":
+            if version_id == "-":
+                raise Exception("version id not populated")
+        if etag == "-" and op != "REST.POST.UPLOAD":
+            raise Exception("etag not populated")
+
+    objects_count = config.objects_count
+    log.info(f"delete_count: {delete_count}")
+    log.info(f"put_count: {put_count}")
+    log.info(f"mpu_count: {mpu_count}")
+    # log.info(f"copy_count: {copy_count}")
+    # if copy_count != objects_count:
+    #     raise Exception(
+    #         "expected number of log records not populated for copy operation"
+    #     )
+    if delete_count != (objects_count * 2):
+        raise Exception(
+            "expected number of log records not populated for delete operation"
+        )
+    if config.test_ops.get("upload_type") == "normal":
+        if put_count != (objects_count * 2):
+            raise Exception(
+                "expected number of log records not populated for put object operation"
+            )
+    if config.test_ops.get("upload_type") == "multipart":
+        if mpu_count != objects_count:
+            raise Exception(
+                "expected number of log records not populated for multipart object upload operation"
+            )
+
+
+def verify_standard_logs(log_records, src_user_name, src_bucket_name, config):
+    """
+    verify log records which are in standard mode format
+    """
+    put_count = (
+        create_mpu_count
+    ) = (
+        complete_mpu_count
+    ) = part_upload_count = copy_count = delete_count = other_ops_count = 0
+    _, local_ip = utils.get_hostname_ip()
+    for record in log_records:
+        log.info(f"verifying record: {record}")
+        # fields = record.split(" ")
+        # fields = re.split(r'"([^"]*)"', record)
+        fields = shlex.split(record)
+        log.info(f"fields: {fields}")
+        bucket_owner = fields[0]
+        bucket_name = fields[1]
+        timestamp = f"{fields[2]} {fields[3]}"
+        client_ip = fields[4]
+        user_name_or_account = fields[5]
+        request_id = fields[6]
+        op = fields[7]
+        key = fields[8]
+        request_uri = fields[9]
+        http_status = fields[10]
+        error_code = fields[11]
+        bytes_sent = fields[12]
+        size = fields[13]
+        total_time = fields[14]
+        turnaround_time = fields[15]
+        referer = fields[16]
+        user_agent = fields[17]
+        version_id = fields[18]
+        host_id = fields[19]
+        signature_version = fields[20]
+        cipher_suite = fields[21]
+        authentication_type = fields[22]
+        host_header = fields[23]
+        tls_version = fields[24]
+        access_point_arn = fields[25]
+        acl_flag = fields[26]
+
+        if bucket_owner != src_user_name:
+            raise Exception(
+                f"bucket_owner not matched. Expected {src_user_name}, received {bucket_owner}"
+            )
+        if bucket_name != src_bucket_name:
+            raise Exception(
+                f"bucket_name not matched. Expected {src_bucket_name}, received {bucket_name}"
+            )
+
+        timestamp_regex = re.compile(
+            r"\[\d{2}/\w{3}/\d{4}:\d{2}:\d{2}:\d{2} [-+]\d{4}\]"
+        )
+        if not timestamp_regex.match(timestamp):
+            raise Exception("timestamp format not matched")
+
+        if client_ip != local_ip:
+            raise Exception(
+                f"client_ip not matched. Expected {local_ip}, received {client_ip}"
+            )
+
+        if user_name_or_account != src_user_name:
+            raise Exception(
+                f"user field who performed the operation not matched. . Expected {src_user_name}, received {user_name_or_account}"
+            )
+
+        if request_id == "-":
+            raise Exception("request_id not populated")
+
+        if op == "REST.PUT.OBJECT":
+            put_count = put_count + 1
+        elif op == "REST.POST.UPLOADS":
+            create_mpu_count = create_mpu_count + 1
+        elif op == "REST.PUT.PART":
+            part_upload_count = part_upload_count + 1
+        elif op == "REST.POST.UPLOAD":
+            complete_mpu_count = complete_mpu_count + 1
+        elif op == "REST.DELETE.OBJECT":
+            delete_count = delete_count + 1
+        elif op == "REST.POST.DELETE_MULTI_OBJECT" and key != "-":
+            delete_count = delete_count + 1
+        elif op == "REST.COPY.OBJECT_GET":
+            copy_count = copy_count + 1
+        else:
+            other_ops_count = other_ops_count + 1
+
+        if key == "-" and ("OBJECT" in op or "UPLOAD" in op):
+            if op == "REST.POST.DELETE_MULTI_OBJECT":
+                log.info(
+                    f"one extra log record is sent for REST.POST.DELETE_MULTI_OBJECT operation without object name populated. ignoring it.."
+                )
+            else:
+                raise Exception("object name not populated")
+
+        if request_uri == "-":
+            raise Exception("request_uri not populated")
+
+        if not http_status.startswith("20"):
+            raise Exception(
+                f"http_status received is {http_status}, its not in success range"
+            )
+
+        if (size == "-" or int(size) == 0) and "OBJECT" in op:
+            if op == "REST.POST.DELETE_MULTI_OBJECT":
+                log.info(
+                    f"one extra log record is sent for REST.POST.DELETE_MULTI_OBJECT operation without object size populated. ignoring it.."
+                )
+            else:
+                raise Exception(f"object size not populated for {op}")
+
+        if total_time != "-":
+            raise Exception(f"unsupported field total_time populated with {total_time}")
+
+        if turnaround_time == "-":
+            raise Exception(f"unsupported field total_time populated with {total_time}")
+
+        if user_agent == "-":
+            raise Exception(f"user_agent not populated")
+
+        if config.test_ops.get("enable_version") and ("UPLOAD" in op or "OBJECT" in op):
+            if version_id == "-":
+                raise Exception("version id not populated")
+
+        if signature_version != "SigV4":
+            raise Exception(
+                f"signature_version received {signature_version}, but expected SigV4"
+            )
+
+        if cipher_suite == "TLS_AES_256_GCM_SHA384":
+            log.info(
+                "cipher suite is populated with TLS_AES_256_GCM_SHA384 as the endpoint is ssl"
+            )
+        elif cipher_suite == "-":
+            log.info("cipher suite is not populated as the endpoint is non-ssl")
+        else:
+            raise Exception(
+                f"cipher_suite received {cipher_suite}, but expected TLS_AES_256_GCM_SHA384 or -"
+            )
+
+        if authentication_type != "AuthHeader":
+            raise Exception(
+                f"authentication_type received {authentication_type}, but expected  AuthHeader"
+            )
+
+        # todo: host_header field verification
+
+        if tls_version == "TLSv1.3":
+            log.info(f"tls_version received {tls_version} as the endpoint is ssl")
+        elif cipher_suite == "-":
+            log.info(f"tls_version not populated as the endpoint is non-ssl")
+        else:
+            raise Exception(
+                f"tls_version received {tls_version}, but expected TLSv1.3 or -"
+            )
+
+        if access_point_arn != "-":
+            raise Exception(
+                f"unsupported access_point_arn total_time populated with {access_point_arn}"
+            )
+
+        # if etag == "-" and ("UPLOAD" in op or "OBJECT" in op):
+        #     raise Exception("etag not populated")
+
+        # error_code, bytes_sent, referer, host_id, acl_flag may or may not be populated hence not checking them
+
+    objects_count = config.objects_count
+    log.info(f"copy_count: {copy_count}")
+    log.info(f"delete_count: {delete_count}")
+    log.info(f"put_count: {put_count}")
+    log.info(f"create_mpu_count: {create_mpu_count}")
+    log.info(f"part_upload_count: {part_upload_count}")
+    log.info(f"complete_mpu_count: {complete_mpu_count}")
+    log.info(f"other_ops_count: {other_ops_count}")
+    if copy_count != objects_count:
+        raise Exception(
+            f"expected number of log records not populated for copy operation. expected {objects_count}, received {copy_count}"
+        )
+    if delete_count != (objects_count * 2):
+        raise Exception(
+            f"expected number of log records not populated for delete operation. expected {objects_count * 2}, received {delete_count}"
+        )
+    if config.test_ops.get("upload_type") == "normal":
+        if put_count != (objects_count * 2):
+            raise Exception(
+                f"expected number of log records not populated for put object operation. expected {objects_count * 2}, received {put_count}"
+            )
+    if config.test_ops.get("upload_type") == "multipart":
+        if create_mpu_count != objects_count or complete_mpu_count != objects_count:
+            raise Exception(
+                f"expected number of log records not populated for multipart object upload operation. expected create_mpu_count is {objects_count}, received {create_mpu_count}. expected complete_mpu_count is {objects_count}, received {complete_mpu_count}"
+            )
+        min_parts_for_each_object = int(
+            config.objects_size_range["min"][:-1]
+        ) / config.test_ops.get(
+            "split_size", 5
+        )  # remove M in 6M(for eg in min size) and dividie it by split size
+        expected_part_uploads = objects_count * min_parts_for_each_object
+        if part_upload_count < expected_part_uploads:
+            raise Exception(
+                f"expected number of log records not populated for multipart object upload_part operation. expected upoad_part_count is {expected_part_uploads}, received {part_upload_count}"
+            )
+
+
+def verify_log_records(
+    rgw_s3_client, src_user_name, src_bucket_name, dest_bucket_name, config=None
+):
+    """
+    verify log records
+    """
+    if config.test_ops.get("rest_api_flush"):
+        flushed_log_object_name = post_bucket_logging(rgw_s3_client, src_bucket_name)
+    elif config.test_ops.get("rgw_admin_flush"):
+        flushed_log_object_name = rgw_admin_logging_flush(src_bucket_name)
+
+    verify_log_object_name(
+        flushed_log_object_name, src_user_name, src_bucket_name, config
+    )
+
+    log.info(
+        "sleeping for 5 seconds so that the log object is flushed to target bucket"
+    )
+    time.sleep(5)
+    log.info("sleeping for 5 seconds so that log object is flushed")
+    objects_list = reusable.list_bucket_objects(rgw_s3_client, dest_bucket_name)
+    total_log_records = []
+    log.info("fetching all log objects content")
+    for obj in objects_list:
+        key = obj["Key"]
+        if key != flushed_log_object_name:
+            raise Exception(
+                f"flushed response log object name '{flushed_log_object_name}' not matched with actual log object name '{key}'"
+            )
+        response = rgw_s3_client.get_object(Bucket=dest_bucket_name, Key=key)
+        content = response["Body"].read().decode("utf-8").strip()
+        log.info(f"log object {key} content: {content}")
+        obj_records = content.split("\n")
+        total_log_records.extend(obj_records)
+
+    if config.test_ops.get("logging_type") == "Standard":
+        verify_standard_logs(total_log_records, src_user_name, src_bucket_name, config)
+    elif config.test_ops.get("logging_type") == "Journal":
+        verify_journal_logs(total_log_records, src_user_name, src_bucket_name, config)

--- a/rgw/v2/tests/s3_swift/test_server_access_logging.py
+++ b/rgw/v2/tests/s3_swift/test_server_access_logging.py
@@ -1,0 +1,368 @@
+"""
+test_server_access_logging - Test Server Access Logging feature
+Usage: test_server_access_logging.py -c <input_yaml>
+<input_yaml>
+    Note: any one of these yamls can be used
+    test_bucket_logging_journal_mode.yaml
+    test_bucket_logging_journal_mode_multipart.yaml
+    test_bucket_logging_standard_mode.yaml
+    test_bucket_logging_standard_mode_multipart.yaml
+Operation:
+    create user (tenant/non-tenant)
+    Create src and dest buckets
+    put-bucket-policy on the target bucket to allow logging_service_principal send log objects to it from src bucket
+    put-bucket-logging on the src-bucket
+    perform operations on the src-bucket
+    flush out the log records as log object to target bucket
+    verify the log records for correctness and completeness
+"""
+
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(__file__, "../../../..")))
+import argparse
+import hashlib
+import json
+import logging
+import random
+import time
+import traceback
+import uuid
+
+import v2.lib.manage_data as manage_data
+import v2.lib.resource_op as s3lib
+import v2.utils.utils as utils
+from v2.lib.admin import UserMgmt
+from v2.lib.exceptions import EventRecordDataError, RGWBaseException, TestExecError
+from v2.lib.resource_op import Config
+from v2.lib.rgw_config_opts import CephConfOp, ConfigOpts
+from v2.lib.s3.auth import Auth
+from v2.lib.s3.write_io_info import BasicIOInfoStructure, BucketIoInfo, IOInfoInitialize
+from v2.tests.s3_swift import reusable
+from v2.tests.s3_swift.reusables import rgw_accounts as accounts
+from v2.tests.s3_swift.reusables import server_access_logging as bkt_logging
+from v2.utils.log import configure_logging
+from v2.utils.test_desc import AddTestInfo
+from v2.utils.utils import HttpResponseParser, RGWService
+
+log = logging.getLogger()
+TEST_DATA_PATH = None
+
+
+def test_exec(config, ssh_con):
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    write_bucket_io_info = BucketIoInfo()
+    io_info_initialize.initialize(basic_io_structure.initial())
+    ceph_conf = CephConfOp(ssh_con)
+    rgw_service = RGWService()
+
+    # add service2 sdk extras so that bucket logging api's and respective fields are supported
+    utils.add_service2_sdk_extras(
+        sdk_file_location="https://github.com/ceph/ceph/blob/main/examples/rgw/boto3/service-2.sdk-extras.json?raw=true"
+    )
+
+    if config.enable_resharding and config.sharding_type == "dynamic":
+        reusable.set_dynamic_reshard_ceph_conf(config, ssh_con)
+        log.info("trying to restart services")
+        srv_restarted = rgw_service.restart(ssh_con)
+        time.sleep(30)
+        if srv_restarted is False:
+            raise TestExecError("RGW service restart failed")
+        else:
+            log.info("RGW service restarted")
+
+    if config.user_type is None:
+        config.user_type = "non-tenanted"
+
+    # create user
+    if config.test_ops.get("test_via_rgw_accounts", False) is True:
+        # create rgw account, account root user, iam user and return iam user details
+        tenant_name = config.test_ops.get("tenant_name")
+        region = config.test_ops.get("region")
+        all_users_info = accounts.create_rgw_account_with_iam_user(
+            config,
+            tenant_name,
+            region,
+        )
+
+    # create user
+    elif config.user_type == "non-tenanted":
+        all_users_info = s3lib.create_users(config.user_count)
+    else:
+        umgmt = UserMgmt()
+        all_users_info = []
+        for i in range(config.user_count):
+            user_name = "user" + str(uuid.uuid4().hex[:16])
+            tenant_name = "tenant" + str(i)
+            tenant_user = umgmt.create_tenant_user(
+                tenant_name=tenant_name, user_id=user_name, displayname=user_name
+            )
+            all_users_info.append(tenant_user)
+
+    for each_user in all_users_info:
+        # authenticate
+        auth = Auth(each_user, ssh_con, ssl=config.ssl)
+        rgw_conn = auth.do_auth()
+
+        # authenticate with s3 client
+        rgw_s3_client = auth.do_auth_using_client()
+
+        objects_created_list = []
+        if config.test_ops.get("create_bucket", False):
+            log.info("no of buckets to create: %s" % config.bucket_count)
+            for bc in range(config.bucket_count):
+                src_bucket_name = f"src-bkt{bc}-{each_user['user_id']}"
+                dest_bucket_name = f"dest-bkt{bc}-{each_user['user_id']}"
+                src_bucket = reusable.create_bucket(
+                    src_bucket_name, rgw_conn, each_user
+                )
+                dest_bucket = reusable.create_bucket(
+                    dest_bucket_name, rgw_conn, each_user
+                )
+                if config.test_ops.get("enable_version", False):
+                    log.info("enable bucket version")
+                    reusable.enable_versioning(
+                        src_bucket, rgw_conn, each_user, write_bucket_io_info
+                    )
+
+                # put bucket policy on dest bucket to allow logging service for src bucket
+                bucket_policy_generated = config.test_ops["policy_document"]
+                bucket_policy = json.dumps(bucket_policy_generated)
+                bucket_policy = bucket_policy.replace(
+                    "<dest_bucket_name>", dest_bucket_name
+                )
+                bucket_policy = bucket_policy.replace(
+                    "<source_bucket_name>", src_bucket_name
+                )
+                bucket_policy = bucket_policy.replace(
+                    "<source_user_name>", each_user["user_id"]
+                )
+                bucket_policy_generated = json.loads(bucket_policy)
+                config.test_ops["policy_document"] = bucket_policy_generated
+                log.info(f"jsoned policy: {bucket_policy}")
+                log.info(f"bucket_policy_generated: {bucket_policy_generated}")
+                bucket_policy_obj = s3lib.resource_op(
+                    {
+                        "obj": rgw_conn,
+                        "resource": "BucketPolicy",
+                        "args": [dest_bucket_name],
+                    }
+                )
+                put_policy = s3lib.resource_op(
+                    {
+                        "obj": bucket_policy_obj,
+                        "resource": "put",
+                        "kwargs": dict(
+                            ConfirmRemoveSelfBucketAccess=True, Policy=bucket_policy
+                        ),
+                    }
+                )
+                log.info(f"put policy response on {dest_bucket_name}: {put_policy}")
+                if put_policy is False:
+                    raise TestExecError(
+                        "Resource execution failed: put bucket policy failed"
+                    )
+                else:
+                    if put_policy is not None:
+                        response = HttpResponseParser(put_policy)
+                        if response.status_code == 200 or response.status_code == 204:
+                            log.info("put bucket policy successful")
+                        else:
+                            raise TestExecError("put bucket policy failed")
+                    else:
+                        raise TestExecError("put bucket policy failed")
+
+                # put bucket logging
+                bkt_logging.put_bucket_logging(
+                    rgw_s3_client, src_bucket_name, dest_bucket_name, config
+                )
+
+                # get bucket logging
+                bkt_logging.get_bucket_logging(rgw_s3_client, src_bucket_name)
+
+                # get bucket logging with radosgw-admin command
+                log.info(
+                    f"radosgw-admin bucket logging info on source bucket: {src_bucket_name}"
+                )
+                out = bkt_logging.rgw_admin_logging_info(src_bucket_name)
+                if not out:
+                    raise Exception(
+                        "radosgw-admin bucket logging info on source bucket failed"
+                    )
+
+                log.info(
+                    f"radosgw-admin bucket logging info on target bucket: {dest_bucket_name}"
+                )
+                out = bkt_logging.rgw_admin_logging_info(dest_bucket_name)
+                if not out:
+                    raise Exception(
+                        "radosgw-admin bucket logging info on target bucket failed"
+                    )
+
+                # create objects
+                if config.test_ops.get("create_object", False):
+                    # uploading data
+                    log.info("s3 objects to create: %s" % config.objects_count)
+                    for oc, size in list(config.mapped_sizes.items()):
+                        config.obj_size = size
+                        s3_object_name = utils.gen_s3_object_name(src_bucket_name, oc)
+                        obj_name_temp = s3_object_name
+                        log.info("s3 object name: %s" % s3_object_name)
+                        s3_object_path = os.path.join(TEST_DATA_PATH, s3_object_name)
+                        log.info("s3 object path: %s" % s3_object_path)
+                        if config.test_ops.get("upload_type") == "multipart":
+                            log.info("upload type: multipart")
+                            reusable.upload_mutipart_object(
+                                s3_object_name,
+                                src_bucket,
+                                TEST_DATA_PATH,
+                                config,
+                                each_user,
+                            )
+                        if config.test_ops.get("upload_type") == "normal":
+                            log.info("upload type: normal")
+                            reusable.upload_object(
+                                s3_object_name,
+                                src_bucket,
+                                TEST_DATA_PATH,
+                                config,
+                                each_user,
+                            )
+
+                        objects_created_list.append((s3_object_name, s3_object_path))
+
+                        # copy objects
+                        if config.test_ops.get("copy_object", False):
+                            obj_name = "copy_of_object" + obj_name_temp
+                            log.info(f"copy object {s3_object_name} to {obj_name}")
+                            status = rgw_s3_client.copy_object(
+                                Bucket=src_bucket_name,
+                                Key=obj_name,
+                                CopySource={
+                                    "Bucket": src_bucket_name,
+                                    "Key": s3_object_name,
+                                },
+                            )
+                            if status is None:
+                                raise TestExecError("copy object failed")
+                            objects_created_list.append((obj_name, s3_object_path))
+
+                # verify resharding
+                if config.enable_resharding:
+                    if config.sharding_type == "manual":
+                        reusable.bucket_reshard_manual(src_bucket, config)
+                        reusable.bucket_reshard_manual(dest_bucket, config)
+                    if config.sharding_type == "dynamic":
+                        reusable.bucket_reshard_dynamic(src_bucket, config)
+                        reusable.bucket_reshard_dynamic(dest_bucket, config)
+
+                # download objects
+                if config.test_ops.get("download_object", False):
+                    for name, path in objects_created_list:
+                        reusable.download_object(
+                            name,
+                            src_bucket,
+                            TEST_DATA_PATH,
+                            path,
+                            config,
+                        )
+
+                # delete objects
+                if config.test_ops.get("delete_bucket_object", False):
+                    if config.test_ops.get("enable_version", False):
+                        for name, path in objects_created_list:
+                            reusable.delete_version_object(
+                                src_bucket, name, path, rgw_conn, each_user
+                            )
+                    else:
+                        reusable.delete_objects(src_bucket)
+
+                bkt_logging.verify_log_records(
+                    rgw_s3_client,
+                    each_user["user_id"],
+                    src_bucket_name,
+                    dest_bucket_name,
+                    config,
+                )
+
+                # delete src-bucket and verify if associated logging conf on the dest-bucket is also deleted
+                if config.test_ops.get("delete_bucket_object", False):
+                    reusable.delete_bucket(src_bucket)
+
+                    log.info(
+                        f"test radosgw-admin bucket logging info on target bucket is empty after source bucket deletion"
+                    )
+                    out = bkt_logging.rgw_admin_logging_info(dest_bucket_name)
+                    if out:
+                        raise Exception(
+                            "radosgw-admin bucket logging info on target bucket is not empty after source bucket deletion"
+                        )
+
+                    reusable.delete_objects(dest_bucket)
+                    reusable.delete_bucket(dest_bucket)
+
+    # check sync status if a multisite cluster
+    reusable.check_sync_status()
+
+    # check for any crashes during the execution
+    crash_info = reusable.check_for_crash()
+    if crash_info:
+        raise TestExecError("ceph daemon crash found!")
+
+    if config.user_remove:
+        for i in all_users_info:
+            if config.user_type == "non-tenanted":
+                reusable.remove_user(i)
+            else:
+                reusable.remove_user(i, tenant=i["tenant"])
+
+
+if __name__ == "__main__":
+    test_info = AddTestInfo("test bucket logging")
+    test_info.started_info()
+
+    try:
+        project_dir = os.path.abspath(os.path.join(__file__, "../../.."))
+        test_data_dir = "test_data"
+        rgw_service = RGWService()
+        TEST_DATA_PATH = os.path.join(project_dir, test_data_dir)
+        log.info("TEST_DATA_PATH: %s" % TEST_DATA_PATH)
+        if not os.path.exists(TEST_DATA_PATH):
+            log.info("test data dir not exists, creating.. ")
+            os.makedirs(TEST_DATA_PATH)
+        parser = argparse.ArgumentParser(description="RGW S3 Automation")
+        parser.add_argument("-c", dest="config", help="RGW Test yaml configuration")
+        parser.add_argument(
+            "-log_level",
+            dest="log_level",
+            help="Set Log Level [DEBUG, INFO, WARNING, ERROR, CRITICAL]",
+            default="info",
+        )
+        parser.add_argument(
+            "--rgw-node", dest="rgw_node", help="RGW Node", default="127.0.0.1"
+        )
+        args = parser.parse_args()
+        yaml_file = args.config
+        rgw_node = args.rgw_node
+        ssh_con = None
+        if rgw_node != "127.0.0.1":
+            ssh_con = utils.connect_remote(rgw_node)
+        log_f_name = os.path.basename(os.path.splitext(yaml_file)[0])
+        configure_logging(f_name=log_f_name, set_level=args.log_level.upper())
+        config = Config(yaml_file)
+        ceph_conf = CephConfOp(ssh_con)
+        config.read(ssh_con)
+        if config.mapped_sizes is None:
+            config.mapped_sizes = utils.make_mapped_sizes(config)
+
+        test_exec(config, ssh_con)
+        test_info.success_status("test passed")
+        sys.exit(0)
+
+    except (RGWBaseException, Exception) as e:
+        log.error(e)
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        sys.exit(1)

--- a/rgw/v2/utils/utils.py
+++ b/rgw/v2/utils/utils.py
@@ -898,7 +898,7 @@ def disable_async_data_notifications():
     return False
 
 
-def add_service2_sdk_extras():
+def add_service2_sdk_extras(sdk_file_location=None):
     """
     download service-2.sdk-extras.json into botocore python module path
     """
@@ -910,11 +910,12 @@ def add_service2_sdk_extras():
     extras_json_path = (
         f"{botocore_paths[0]}/data/s3/2006-03-01/service-2.sdk-extras.json"
     )
-    exec_shell_cmd(
-        f"sudo curl -o {extras_json_path} -L https://github.com/boto/botocore/blob/develop/botocore/data/s3/2006-03-01/service-2.json?raw=true"
-    )
+    if sdk_file_location is None:
+        sdk_file_location = "https://github.com/boto/botocore/blob/develop/botocore/data/s3/2006-03-01/service-2.json?raw=true"
+    exec_shell_cmd(f"sudo curl -o {extras_json_path} -L {sdk_file_location}")
     log.info(f"service-2.sdk-extras.json is downloaded to {extras_json_path}")
-    time.sleep(10)
+    log.info("sleeping for 5 seconds")
+    time.sleep(5)
     return True
 
 


### PR DESCRIPTION
this PR is to add support for testing rgw feature server-access-logging
tested the feature for:
1. Journal mode and standard mode
2. simple prefix and partitioned prefix
3. rgw_admin flush and rest_api flush

also added support for testing below bz's:


[2308169](https://bugzilla.redhat.com/show_bug.cgi?id=2308169)	[RFE] add partial bucket logging support to the RGW
[2344993](https://bugzilla.redhat.com/show_bug.cgi?id=2344993)	[rgw][server-access-logging]: radosgw-admin bucket logging flush command is returning next log object name instead of current log object name
[2365697](https://bugzilla.redhat.com/show_bug.cgi?id=2365697)	[rgw][server-access-logging]: REST.POST.UPLOAD (complete multipart) log record is not populated with object size even in the Standard mode
[2345305](https://bugzilla.redhat.com/show_bug.cgi?id=2345305)	[rgw][server-access-logging][RFE]: add support for configuring permission for a bucket to be used as a target bucket for log object delivery
[2365931](https://bugzilla.redhat.com/show_bug.cgi?id=2365931)	[rgw][server-access-logging]: please modify the operation name for multipart upload_part to REST.PUT.PART in the Standard mode
[2364399](https://bugzilla.redhat.com/show_bug.cgi?id=2364399)	[RFE][rgw][server-access-logging] send flushed object name in API reply
[2370241](https://bugzilla.redhat.com/show_bug.cgi?id=2370241)	[rgw][server-access-logging]: partitioned key format does not follow the spec
[2370245](https://bugzilla.redhat.com/show_bug.cgi?id=2370245)	[rgw][server-access-logging][RFE]: make the unique portion of the log object name ordered




pass logs: http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_bucket_logging/


dynamic_resharding is actually causing issue with old buckets
need to fix the script as fixed in this PR https://github.com/red-hat-storage/ceph-qe-scripts/pull/701/files
will take it up in the coming PR's
thats why commented dynamic_resharding params in the config.