### PR TITLE
[TFA][notif] workaround for 8.1 topic list issue and reducing time taken to verify event records

### DIFF
--- a/rgw/v2/tests/s3_swift/test_bucket_notifications.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_notifications.py
@@ -264,7 +264,18 @@ def test_exec(config, ssh_con):
                         )
                         topic_listed = False
                         notif_topic_listed = False
-                        for topic_dict in topics_list["topics"]:
+
+                        # workaround for 8.1 to fetch topics from topic list output.
+                        # see bz: https://bugzilla.redhat.com/show_bug.cgi?id=2360425
+                        if (
+                            float(ceph_version_id[0]) == 19
+                            and float(ceph_version_id[1]) == 2
+                            and float(ceph_version_id[2]) >= 1
+                        ):
+                            topics_list_workaround = topics_list
+                        else:
+                            topics_list_workaround = topics_list["topics"]
+                        for topic_dict in topics_list_workaround:
                             if topic_dict["name"] == topic_name:
                                 topic_listed = True
                             if topic_dict["name"] == bkt_notif_topic_name:


### PR DESCRIPTION
on 8.1 topic list out is changed, its not wrapped with "topics" keyword. 
fail log: http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Regression/19.2.1-167/rgw/103/tier-2_rgw_ms_test_bucket_notifications/notify_copy_events_with_kafka_broker_persistent_0.log
product bz: [Bug 2360425](https://bugzilla.redhat.com/show_bug.cgi?id=2360425) - [8.1][rgw] radosgw-admin topic list output is not wrapped with "topics" keyword
so fixing the failure with a workaround till the bz is fixed

pass logs:
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/TFA_8.1_topics_list_workaround/reduce_test_execution_time/


also reducing the time taken to verify event record by moving bucket stats, zonegroup get and ceph version commands out of for loop, so that they will execute only once instead of executing for every event record. this reduced test execution from 11 min to 7 min (4min reduced per test)
