### PR TITLE
[Automate][BZ2338149]: stting public acl to the bucket

### DIFF
--- a/rgw/v2/tests/s3cmd/configs/test_setting_public_acl.yaml
+++ b/rgw/v2/tests/s3cmd/configs/test_setting_public_acl.yaml
@@ -1,0 +1,8 @@
+# script: ceph-qe-scripts/rgw/v2/tests/s3cmd/test_s3cmd.py
+# Polarion ID: CEPH-83619036
+# BZ: BZ2338149, tracker: 69527
+config:
+  user_count: 1
+  bucket_count: 1
+  test_ops:
+    set_public_acl: true


### PR DESCRIPTION
[Automate][BZ2338149]: stting public acl to the bucket 
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2338149
tracker: https://tracker.ceph.com/issues/69527
Unable to grant group permission (ACL) for buckets

fail in 8.0z4:   http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/set_pub_acl/test_setting_public_acl.console.log


pass log 8.1:  http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-OD68LP/Setting_Public_acl_to_the_bucket_0.log