### PR TITLE
[TFA][sts] fix rgw restart causing role create failures

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_sts_using_boto_verify_session_policy_deny_sns_topic_actions.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_using_boto_verify_session_policy_deny_sns_topic_actions.yaml
@@ -57,7 +57,7 @@ config:
                     {
                          "Action": ["sns:CreateTopic", "sns:DeleteTopic"],
                          "Resource": "*",
-                         "Effect": "deny",
+                         "Effect": "Deny",
                          "Sid": "statement1",
                     },
                ]

--- a/rgw/v2/tests/s3_swift/test_sts_using_boto.py
+++ b/rgw/v2/tests/s3_swift/test_sts_using_boto.py
@@ -75,6 +75,8 @@ def test_exec(config, ssh_con):
     )
 
     reusable.restart_and_wait_until_daemons_up(ssh_con)
+    log.info("sleeping for 30 seconds after rgw restart")
+    time.sleep(30)
 
     auth = Auth(user1, ssh_con, ssl=config.ssl)
     iam_client = auth.do_auth_iam_client()


### PR DESCRIPTION
this PR is to add a sleep of 30 seconds after rgw restart in sts test script
fail log: http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Regression/19.2.1-201/rgw/105/tier-2_ssl_rgw_regression_test/STS_Tests_to_perform_assume_role_on_principle_user_and_perform_IOs_0.log

the issue of "connection closed" with role create or assume-role is because the script is not waiting till the restart is triggered and gets completed..
PR that caused the issue:  https://github.com/red-hat-storage/ceph-qe-scripts/pull/722
actually the code is checking if the rgw actual count and running count even before rgw restart is actually triggered after the command.
 
also fixing the typo for Deny action in the config: test_sts_using_boto_verify_session_policy_deny_sns_topic_actions.yaml
even then the test fails because of known issue

pass logs: http://magna002.ceph.redhat.com/cephci-jenkins/hsm/TFA_fix_sts_test_with_sleep_after_restart/cephci-run-RCFC9T/
