### PR TITLE
Add a openstack endpoint cleanup to clear stale swift endpoints

### DIFF
--- a/rgw/v2/tests/aws/test_unified_namespace.py
+++ b/rgw/v2/tests/aws/test_unified_namespace.py
@@ -65,6 +65,9 @@ def test_exec(config, ssh_con):
     rgw_host, rgw_ip = utils.get_hostname_ip(ssh_con)
     aws_auth.install_aws()
 
+    # cleanup any stale swift endpoints
+    aws_reusable.cleanup_keystone()
+
     count = 0
     while count < 2:
         cmd = f"AWS_ACCESS_KEY_ID={access_demo} AWS_SECRET_ACCESS_KEY={secret_demo} /usr/local/bin/aws s3 ls --endpoint http://{rgw_ip}:{rgw_port}"


### PR DESCRIPTION
Issue : We see "swift list" command fail because of stale endpoints , as it tries connecting to non-existent endpoints.

Fix : Clear stale swift endpoints , before we start any keystone swift testing.

Fail log : http://magna002.ceph.redhat.com/cephci-jenkins/tchandra/cephci-run-W5ZCWG/Verify_unified_namespace_for_S3_and_swift_0.log

Pass log : http://magna002.ceph.redhat.com/cephci-jenkins/tchandra/tfa_swift_issue.txt