### PR TITLE
[TFA]:REmove validation of default header from 8.1 onwards

### DIFF
--- a/rgw/v2/tests/curl/test_quota_using_curl.py
+++ b/rgw/v2/tests/curl/test_quota_using_curl.py
@@ -93,8 +93,33 @@ def test_exec(config, ssh_con):
                 )
 
             if config.test_ops.get("verify_quota_head_bucket") is True:
+                expected_header = config.test_ops.get("head_bucket")
+                ceph_version_id, ceph_version_name = utils.get_ceph_version()
+                ceph_version_id = ceph_version_id.split("-")
+                ceph_version_id = ceph_version_id[0].split(".")
+                if (
+                    (float(ceph_version_id[0]) >= 19)
+                    and (float(ceph_version_id[1]) >= 2)
+                    and (float(ceph_version_id[2]) >= 1)
+                ):
+                    log.info("Remove default headers from expected headers")
+                    log.info(f"expected_header : {expected_header}")
+                    if config.test_ops.get("bucket_quota", False):
+                        key_to_remove = [
+                            "X-RGW-Quota-User-Size",
+                            "X-RGW-Quota-User-Objects",
+                            "X-RGW-Quota-Max-Buckets",
+                        ]
+                    if config.test_ops.get("user_quota", False):
+                        key_to_remove = [
+                            "X-RGW-Quota-Bucket-Size",
+                            "X-RGW-Quota-Bucket-Objects",
+                            "X-RGW-Quota-Max-Buckets",
+                        ]
+                    for key in key_to_remove:
+                        expected_header.pop(key, None)
                 curl_reusable.verify_quota_head_bucket(
-                    curl_auth, bucket_name, config.test_ops.get("head_bucket")
+                    curl_auth, bucket_name, expected_header
                 )
 
             # create objects


### PR DESCRIPTION
[TFA]:REmove validation of default header from 8.1 onwards

as per BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2361821
HeadBucket no longer include response headers for quotas that are disabled, which they are by default. this is expected behavior


7.1:
<img width="1705" alt="Screenshot 2025-06-16 at 6 17 37 PM" src="https://github.com/user-attachments/assets/d28250fd-b401-45a0-8c87-12a29f963915" />

8.1:
<img width="1584" alt="Screenshot 2025-06-16 at 7 09 39 PM" src="https://github.com/user-attachments/assets/410a1bf3-79c8-4a06-bc8d-ac3d18670650" />

8.0:
![Uploading Screenshot 2025-06-17 at 11.21.06 AM.png…]()

