### PR TITLE
[TFA] replace localhost address with host ip address to connect to kafka

### DIFF
--- a/rgw/v2/tests/s3_swift/reusables/bucket_notification.py
+++ b/rgw/v2/tests/s3_swift/reusables/bucket_notification.py
@@ -83,8 +83,10 @@ def start_kafka_broker_consumer(topic_name, event_record_path):
         t = utils.exec_shell_cmd(cmd)
         print("path exists :", t)
 
+    local_ip = utils.get_localhost_ip_address()
+
     # start kafka consumer
-    cmd = f"sudo {KAFKA_HOME}/bin/kafka-console-consumer.sh --bootstrap-server kafka://localhost:9092 --from-beginning --topic {topic_name} --timeout-ms 30000 >> {event_record_path}"
+    cmd = f"sudo {KAFKA_HOME}/bin/kafka-console-consumer.sh --bootstrap-server kafka://{local_ip}:9092 --from-beginning --topic {topic_name} --timeout-ms 30000 >> {event_record_path}"
     start_consumer_kafka = utils.exec_shell_cmd(cmd)
     return start_consumer_kafka
 
@@ -102,18 +104,19 @@ def create_topic(
     to create topic with specified endpoint , ack_level
     return: topic ARN
     """
+    local_ip = utils.get_localhost_ip_address()
     if security_type == "PLAINTEXT":
         endpoint_args = (
             "push-endpoint="
             + endpoint
-            + "://localhost:9092&use-ssl=false&verify-ssl=false&kafka-ack-level="
+            + f"://{local_ip}:9092&use-ssl=false&verify-ssl=false&kafka-ack-level="
             + ack_type
         )
     elif security_type == "SSL":
         endpoint_args = (
             "push-endpoint="
             + endpoint
-            + "://localhost:9093&use-ssl=true&verify-ssl=false&kafka-ack-level="
+            + f"://{local_ip}:9093&use-ssl=true&verify-ssl=false&kafka-ack-level="
             + ack_type
             + "&ca-location=/usr/local/kafka/y-ca.crt"
         )
@@ -121,7 +124,7 @@ def create_topic(
         endpoint_args = (
             "push-endpoint="
             + endpoint
-            + "://alice:alice-secret@localhost:9094&use-ssl=true&verify-ssl=false&kafka-ack-level="
+            + f"://alice:alice-secret@{local_ip}:9094&use-ssl=true&verify-ssl=false&kafka-ack-level="
             + ack_type
             + "&ca-location=/usr/local/kafka/y-ca.crt&mechanism="
             + mechanism
@@ -130,7 +133,7 @@ def create_topic(
         endpoint_args = (
             "push-endpoint="
             + endpoint
-            + "://alice:alice-secret@localhost:9095&use-ssl=false&verify-ssl=false&kafka-ack-level="
+            + f"://alice:alice-secret@{local_ip}:9095&use-ssl=false&verify-ssl=false&kafka-ack-level="
             + ack_type
             + "&mechanism="
             + mechanism


### PR DESCRIPTION
corresponding cephci PR: https://github.com/red-hat-storage/cephci/pull/4919

according to cephci changes for kafka listener, modifying the kafka endpoint with local_ip_address instead of localhost

pipeline fail logs:
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9/Weekly/19.2.0-137/rgw/29/tier-2_rgw_test_bucket_notifications_kafka_ssl/notify_put,copy,delete_events_with_kafka_broker_persistent_and_SSL_security_0.log



pass logs:
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/TFA_kafka_endpoint_change/