### PR TITLE
[TFA] Remove validation for pipe remove

### DIFF
--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -1252,10 +1252,6 @@ def period_update_commit(validate_policy=False, pipe_op=None):
             raise TestExecError(
                 "Failed to set policy as period update does not contain details of policy"
             )
-        elif pipe_op == "remove" and len(sync_policy) != 0:
-            raise TestExecError(
-                "Failed to remove policy as period update does contain details of policy"
-            )
         else:
             utils.exec_shell_cmd("radosgw-admin sync policy get")
 


### PR DESCRIPTION
Remove period update validation for pipe remove as it will not remove the group

pass log : http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-CIKB48/Combination_zonegroup_and_bucket_level_group_policy_with_symmetrical_flow_0.log 

remove validation was included as part of https://github.com/red-hat-storage/ceph-qe-scripts/pull/741 