### PR TITLE
[kafka-cluster] adding support for testing bucket notification with partitioned kafka topic

### DIFF
--- a/rgw/v2/tests/s3_swift/test_bucket_notifications.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_notifications.py
@@ -204,6 +204,9 @@ def test_exec(config, ssh_con):
                     if config.test_ops.get("persistent_flag", False):
                         log.info("topic with peristent flag enabled")
                         persistent = config.test_ops.get("persistent_flag")
+                    # create topic at kafka side
+                    notification.create_topic_from_kafka_broker(topic_name)
+                    # create topic at rgw side
                     topic = notification.create_topic(
                         rgw_sns_conn,
                         endpoint,


### PR DESCRIPTION
this PR is to add support for crating a partitioned topic on kafka side and create an rgw topic with kafka-brokers as a list of kafka brokers.

RFE bz: https://bugzilla.redhat.com/show_bug.cgi?id=2348395

pass logs for kafka cluster:
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_kafka_cluster/cephci-run-3BQPDQ/ (failure for the first test is on sec site because the node went down, deployment and notif test passed on pri site)
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_kafka_cluster/cephci-run-GKOZ0O/ (pass logs for last 2 tests failed in above run which are intermittent)


sample pass logs for existing deployments:

single node kafka without security:
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_kafka_cluster/cephci-run-4DIVJU/

single node kafka with security:
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_kafka_cluster/cephci-run-PJRSH7/