### PR TITLE
Deleting an rgw realm and verify 'default_info'

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_realm_deletion.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_realm_deletion.yaml
@@ -1,0 +1,5 @@
+# script: test_check_sharding_enabled.py
+# polarion TC: CEPH-83623614
+config:
+    test_ops:
+        realm_delete: true


### PR DESCRIPTION

Perform default Realm deletion which should clear all its data post deletion 
log : http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/test_realm_deletion.console.log 