### PR TITLE
TFA-fix  Rgw daemons check after restart failing In multisite setup with sync and io rgw's

### DIFF
--- a/rgw/v2/utils/utils.py
+++ b/rgw/v2/utils/utils.py
@@ -360,7 +360,7 @@ class CephOrchRGWSrv:
         return cmd
 
 
-def rgw_daemons_status(retry_attempts=8, retry_delay=15):
+def rgw_daemons_status(retry_attempts=10, retry_delay=15):
     for attempt in range(retry_attempts):
         try:
             # Step 1: Check RGW daemons via 'ceph orch ps'

--- a/rgw/v2/utils/utils.py
+++ b/rgw/v2/utils/utils.py
@@ -431,7 +431,7 @@ def rgw_daemons_status(retry_attempts=10, retry_delay=15):
             )
             log.info(f"Daemon IDs: {ceph_s_daemons_list}")
 
-            # Final verification
+            # Verify that the number of running daemons matches the expected count
             if (
                 running_daemons == expected_daemons
                 and running_daemons_from_ls == expected_daemons


### PR DESCRIPTION

Jira: https://issues.redhat.com/browse/RHCEPHQE-20594 
end to end pass log:
 http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9.5/Test/19.2.1-232/665/tier-2_rgw_3_way_ms_failover
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9.5/Test/19.2.1-232/666/tier-1_rgw 


Description: These changes fixes an issue where the number of RGW daemons  was being counted incorrectly, causing service restart failures. The code now adds up the "size" field from all RGW services to get the correct expected count, instead of just checking the first one. This ensures that the reported and actual number of running daemons match, making RGW status checks and restarts more reliable.