### PR TITLE
[T1] Verify the bucket instance shard deletion behaviour

### DIFF
--- a/rgw/v2/tests/aws/test_unified_namespace.py
+++ b/rgw/v2/tests/aws/test_unified_namespace.py
@@ -70,7 +70,7 @@ def test_exec(config, ssh_con):
     aws_auth.install_aws()
 
     # cleanup any stale swift endpoints
-    aws_reusable.cleanup_keystone()
+    aws_reusable.cleanup_keystone(keystone_server)
 
     count = 0
     while count < 2:

--- a/rgw/v2/tests/s3_swift/configs/test_bucket_instance_delete.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_bucket_instance_delete.yaml
@@ -1,0 +1,22 @@
+# Polarion ID : CEPH-83591444 - Greenfield: Post bucket delete instance shard deletion
+# script : test_Mbuckets_with_Nobject.py
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 20
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    create_bucket: true
+    create_object: true
+    delete_bucket_object: false
+    delete_bucket: true
+    instance_shard_verify: true
+    download_object: false
+    sharding:
+      enable: false
+      max_shards: 0
+    compression:
+      enable: false
+      type: zlib


### PR DESCRIPTION
Polarion ID : CEPH-83591444

On deletion of bucket , the bucket instance shards should get deleted automatically from the index pool.

Pass log : http://magna002.ceph.redhat.com/cephci-jenkins/tchandra/bucket_instance_shard.txt

Also , a minor change to keystone script where I had to pass the keystone_server to the cleanup function.