### PR TITLE
adding support to use corressponding gklm key_id for openstack and ibmc environments

### DIFF
--- a/rgw/v2/tests/s3_swift/test_sse_s3_kms_with_vault.py
+++ b/rgw/v2/tests/s3_swift/test_sse_s3_kms_with_vault.py
@@ -66,6 +66,15 @@ def test_exec(config, ssh_con):
     ceph_conf = CephConfOp(ssh_con)
     rgw_service = RGWService()
 
+    out = utils.exec_shell_cmd("ceph config get client.rgw rgw_crypt_s3_kms_backend")
+    rgw_crypt_s3_kms_backend = out.strip()
+    if rgw_crypt_s3_kms_backend == "kmip":
+        out = utils.exec_shell_cmd("ceph config get client.rgw rgw_crypt_kmip_addr")
+        rgw_crypt_kmip_addr = out.strip()
+        if rgw_crypt_kmip_addr == "10.245.64.16:5696":
+            config.test_ops[
+                "encrypt_decrypt_key"
+            ] = "ibm000ee6a57000000000"  # use corresponding key id for ibmc env
     # create user
     all_users_info = s3lib.create_users(config.user_count)
     for each_user in all_users_info:


### PR DESCRIPTION
this PR is to replace gklm key_id of ibmc environment if the environment is ibmc where the test is running on.
added logic to identity if the env is ibmc or openstack based on the kmip_addr if it is corresponding to ibmc env GKLM server address or not.

pass logs on openstack env: http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_gklm_ibmc_changes/cephci-run-F568DN/