### PR TITLE
testing checksum feature with awscli v1 and v2 with defualt checksum enabled/disabled

### DIFF
--- a/rgw/requirements.txt
+++ b/rgw/requirements.txt
@@ -14,6 +14,7 @@ swiftly
 paramiko
 pandas==2.2.3
 pyarrow
+awscrt
 
 # for v1
 #psutil

--- a/rgw/v2/lib/aws/auth.py
+++ b/rgw/v2/lib/aws/auth.py
@@ -73,7 +73,7 @@ def create_aws_file(ssh_con=None):
         raise AWSConfigFileNotFound("AWS sample config file not found")
 
 
-def update_aws_file(user_info, ssh_con=None):
+def update_aws_file(user_info, ssh_con=None, checksum_validation_calculation=None):
     """
     Updates .aws/credentials file with user information
     Args:
@@ -83,8 +83,19 @@ def update_aws_file(user_info, ssh_con=None):
     parser.read(root_path + "credentials")
     parser.set("default", "aws_access_key_id", user_info["access_key"])
     parser.set("default", "aws_secret_access_key", user_info["secret_key"])
+    if checksum_validation_calculation:
+        parser.set(
+            "default", "request_checksum_calculation", checksum_validation_calculation
+        )
+        parser.set(
+            "default", "response_checksum_validation", checksum_validation_calculation
+        )
+    else:
+        parser.remove_option("default", "request_checksum_calculation")
+        parser.remove_option("default", "response_checksum_validation")
     with open(root_path + "credentials", "w") as file:
         parser.write(file)
+    utils.exec_shell_cmd(f'cat {root_path + "credentials"}')
 
 
 def do_auth_aws(user_info, ssh_con=None):

--- a/rgw/v2/lib/aws/resource_op.py
+++ b/rgw/v2/lib/aws/resource_op.py
@@ -9,12 +9,11 @@ log = logging.getLogger()
 
 
 class AWS:
-    def __init__(self, options=None, ssl=None):
+    def __init__(self, options=None, ssl=None, bin_path="/usr/local/bin/"):
         """
         Constructor for aws class
         options(list): Optional options for the command
         """
-        bin_path = "/usr/local/bin/"
         self.prefix = bin_path + "aws s3api"
         if ssl:
             self.prefix = self.prefix + " --no-verify-ssl"

--- a/rgw/v2/tests/aws/configs/test_checksum_awscli_v1_v2_multipart.yaml
+++ b/rgw/v2/tests/aws/configs/test_checksum_awscli_v1_v2_multipart.yaml
@@ -1,0 +1,19 @@
+# BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2355689
+# BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2355038
+# BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2345505
+# BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2349928
+# polarion-id: CEPH-83591679
+# Script: rgw/v2/tests/aws/test_checksum_with_awscli_v1_and_v2.py
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 1
+  local_file_delete: true
+  user_remove: true
+  objects_size_range:
+    min: 6M
+    max: 20M
+  test_ops:
+    upload_type: multipart
+    download_object: true
+    delete_bucket_object: true

--- a/rgw/v2/tests/aws/configs/test_checksum_awscli_v1_v2_non_multipart.yaml
+++ b/rgw/v2/tests/aws/configs/test_checksum_awscli_v1_v2_non_multipart.yaml
@@ -1,0 +1,15 @@
+# polarion-id: CEPH-83591679
+# Script: rgw/v2/tests/aws/test_checksum_with_awscli_v1_and_v2.py
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 1
+  local_file_delete: true
+  user_remove: true
+  objects_size_range:
+    min: 3M
+    max: 20M
+  test_ops:
+    upload_type: normal
+    download_object: true
+    delete_bucket_object: true

--- a/rgw/v2/tests/aws/configs/test_checksum_awscli_v1_v2_small_objects.yaml
+++ b/rgw/v2/tests/aws/configs/test_checksum_awscli_v1_v2_small_objects.yaml
@@ -1,0 +1,16 @@
+# BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2353296
+# polarion-id: CEPH-83591679
+# Script: rgw/v2/tests/aws/test_checksum_with_awscli_v1_and_v2.py
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 1
+  local_file_delete: true
+  user_remove: true
+  objects_size_range:
+    min: 3K
+    max: 10K
+  test_ops:
+    upload_type: normal
+    download_object: true
+    delete_bucket_object: true

--- a/rgw/v2/tests/aws/reusable.py
+++ b/rgw/v2/tests/aws/reusable.py
@@ -3,6 +3,7 @@ Reusable methods for aws
 """
 
 
+import base64
 import glob
 import json
 import logging
@@ -13,6 +14,8 @@ import sys
 import time
 from configparser import RawConfigParser
 from pathlib import Path
+
+import awscrt.checksums
 
 log = logging.getLogger()
 
@@ -40,6 +43,28 @@ def create_bucket(aws_auth, bucket_name, end_point):
         log.info(f"bucket creation response is {create_response}")
         if create_response:
             raise Exception(f"Create bucket failed for {bucket_name}")
+    except Exception as e:
+        raise AWSCommandExecError(message=str(e))
+
+
+def delete_bucket(aws_auth, bucket_name, end_point):
+    """
+    deletes bucket
+    ex: /usr/local/bin/aws s3api delete-bucket --bucket verbkt1 --endpoint-url http://x.x.x.x:xx
+    Args:
+        aws_auth: user auth details
+        bucket_name(str): Name of the bucket to be created
+        end_point(str): endpoint
+    """
+    command = aws_auth.command(
+        operation="delete-bucket",
+        params=[f"--bucket {bucket_name} --endpoint-url {end_point}"],
+    )
+    try:
+        delete_response = utils.exec_shell_cmd(command, return_err=True)
+        log.info(f"bucket deletion response is {delete_response}")
+        if delete_response:
+            raise Exception(f"delete bucket failed for {bucket_name}")
     except Exception as e:
         raise AWSCommandExecError(message=str(e))
 
@@ -195,7 +220,7 @@ def upload_part(
         Response of uplaod_part i.e Etag
     """
     if checksum_algo:
-        if checksum_algo is "crc32c":
+        if checksum_algo == "crc32c":
             algo = "crc32-c"
         else:
             algo = checksum_algo
@@ -264,7 +289,7 @@ def complete_multipart_upload(
         response = utils.exec_shell_cmd(command)
         if not response:
             raise Exception(
-                f"creating multipart upload failed for bucket {bucket_name} with key {key_name} and"
+                f"complete multipart upload failed for bucket {bucket_name} with key {key_name} and"
                 f" upload id {upload_id}"
             )
         return response
@@ -300,7 +325,14 @@ def put_object(aws_auth, bucket_name, object_name, end_point):
 
 
 def put_object_checksum(
-    aws_auth, bucket_name, object_name, end_point, checksum_algorithm, checksum=None
+    aws_auth,
+    bucket_name,
+    object_name,
+    end_point,
+    checksum_algorithm,
+    checksum=None,
+    s3_object_path=None,
+    failure_expected=False,
 ):
     """
     Put/uploads object to the bucket with provided checksum value
@@ -311,29 +343,35 @@ def put_object_checksum(
         end_point(str): endpoint
         checksum_algorithm: one of sha1,sha256,crc32,crc-32c
         checksum
+        s3_object_path
+        failure_expected
     Return:
 
     """
-    if checksum_algorithm is "crc32c":
+    if checksum_algorithm == "crc32c":
         algo = "crc32-c"
+    elif checksum_algorithm == "crc64nvme":
+        algo = "crc64-nvme"
     else:
         algo = checksum_algorithm
     command = aws_auth.command(
         operation="put-object",
         params=[
-            f"--bucket {bucket_name} --key {object_name} --body {object_name} --endpoint-url {end_point} --checksum-algorithm {checksum_algorithm} --checksum-{algo} {checksum}",
+            f"--bucket {bucket_name} --key {object_name} --body {s3_object_path if s3_object_path else object_name} --endpoint-url {end_point} --checksum-algorithm {checksum_algorithm} --checksum-{algo} {checksum}",
         ],
     )
 
-    out = utils.exec_shell_cmd(command, return_err=True)
-    if out:
-        log.info(f"Output : {out}")
-        if "not iterable" in out:
+    out = utils.exec_shell_cmd(command)
+    log.info(f"Output : {out}")
+    if out is False:
+        if failure_expected:
             log.info("Upload failed as expected for wrong checksum")
         else:
-            log.info(f"Upload successful for {algo}")
+            raise Exception(f"put object with checksum failed for {bucket_name}")
+
     else:
-        raise AssertionError("Upload failed")
+        log.info(f"Upload successful for {algo}")
+        return out
 
 
 def delete_object(aws_auth, bucket_name, object_name, end_point, versionid=None):
@@ -365,7 +403,8 @@ def delete_object(aws_auth, bucket_name, object_name, end_point, versionid=None)
         )
     try:
         delete_response = utils.exec_shell_cmd(command)
-        if not delete_response:
+        log.info(f"delete object response: {delete_response}")
+        if delete_response is False:
             raise Exception(f"delete object failed for {bucket_name}")
         return delete_response
     except Exception as e:
@@ -587,7 +626,9 @@ def upload_multipart_aws(
         return complete_multipart_upload_resp
 
 
-def get_object(aws_auth, bucket_name, object_name, end_point):
+def get_object(
+    aws_auth, bucket_name, object_name, end_point, download_path="out_object"
+):
     """
     Does a get object from the bucket
     Args:
@@ -600,7 +641,7 @@ def get_object(aws_auth, bucket_name, object_name, end_point):
     command = aws_auth.command(
         operation="get-object",
         params=[
-            f"--bucket {bucket_name} --key {object_name} out_object --endpoint-url {end_point}",
+            f"--bucket {bucket_name} --key {object_name} {download_path} --endpoint-url {end_point}",
         ],
     )
     try:
@@ -612,24 +653,27 @@ def get_object(aws_auth, bucket_name, object_name, end_point):
         raise AWSCommandExecError(message=str(e))
 
 
-def copy_object(aws_auth, bucket_name, object_name, end_point):
+def copy_object(aws_auth, bucket_name, object_name, end_point, dest_obj_name=None):
     """
     Does a copy object from the bucket
     Args:
         bucket_name(str): Name of the bucket from which object needs to be listed
         object_name(str): Name of the object/file
         end_point(str): endpoint
+        dest_obj_name(str): destination object name
     Return:
         Response of get object operation
     """
     command = aws_auth.command(
         operation="copy-object",
         params=[
-            f"--copy-source {bucket_name}/{object_name} --bucket {bucket_name} --key {object_name}  --metadata-directive 'REPLACE' --content-type 'text/plain' --endpoint-url {end_point}",
+            f"--copy-source {bucket_name}/{object_name} --bucket {bucket_name} --key {dest_obj_name if dest_obj_name else object_name} {'--metadata-directive REPLACE' if dest_obj_name is None else ''} --content-type 'text/plain' --endpoint-url {end_point}",
         ],
     )
     try:
         copy_response = utils.exec_shell_cmd(command)
+        if copy_response is False:
+            raise Exception(f"copy object failed for {object_name}")
         return copy_response
     except Exception as e:
         raise AWSCommandExecError(message=str(e))
@@ -646,13 +690,13 @@ def list_objects(aws_auth, bucket_name, endpoint, marker=None):
         Returns details of every object in the bucket post the marker
     """
     if marker:
-        marker_param = marker
+        marker_param = f"--marker {marker}"
     else:
         marker_param = " "
     command = aws_auth.command(
         operation="list-objects",
         params=[
-            f"--bucket {bucket_name} --marker {marker_param} --endpoint-url {endpoint}",
+            f"--bucket {bucket_name} {marker_param} --endpoint-url {endpoint}",
         ],
     )
     try:
@@ -691,26 +735,29 @@ def calculate_checksum(algo, file):
     """
     Return the base64 encoded checksum for the provided algorithm
     """
-    log.info("Install Rhash program")
-    utils.exec_shell_cmd(
-        "rpm -ivh https://rpmfind.net/linux/epel/9/Everything/x86_64/Packages/r/rhash-1.4.2-1.el9.x86_64.rpm"
-    )
-    time.sleep(2)
-    if algo is "sha1" or "sha256":
-        checksum = utils.exec_shell_cmd(f"rhash --sha1 --base64 {file}").split(" ", 1)[
-            0
-        ]
+
+    if algo == "sha1" or algo == "sha256":
+        checksum = utils.exec_shell_cmd(f"rhash --{algo} --base64 {file}").split(
+            " ", 1
+        )[0]
         return checksum
-    elif algo is "crc32":
-        checksum = utils.exec_shell_cmd(f"rhash --crc32 --base64 {file}").split(" ", 1)[
-            1
-        ]
+    elif algo == "crc32":
+        checksum = (
+            utils.exec_shell_cmd(f"rhash --crc32 --base64 {file}")
+            .strip()
+            .split("\n")[-1]
+            .split(" ")[1]
+        )
         return checksum
-    elif algo is "crc32c":
-        utils.exec_shell_cmd("sudo pip install botocore[crt]")
+    elif algo == "crc32c":
         checksum = utils.exec_shell_cmd(f"rhash --crc32c --base64 {file}").split(
             " ", 1
         )[0]
+        return checksum
+    elif algo == "crc64nvme":
+        checksum = base64.b64encode(
+            awscrt.checksums.crc64nvme(open(file, "rb").read()).to_bytes(8, "big")
+        ).decode()
         return checksum
 
 
@@ -729,9 +776,39 @@ def get_object_attributes(aws_auth, bucket_name, key, endpoint):
         if "Checksum" not in resp:
             raise Exception(f"get object failed for {bucket_name}")
         log.info("Checksum is present in object attributes")
+        resp = json.loads(resp)
         return resp
     except Exception as e:
         raise AWSCommandExecError(message=str(e))
+
+
+def verify_checksum(response, checksum_algo, checksum, upload_type):
+    """
+    verifying checksum fields (checksum and checksum_type) in the response
+    """
+    log.info("verifying checksum fields in the response")
+    checksum_key = f"Checksum{str(checksum_algo).upper()}"
+    checksum_type = response["ChecksumType"]
+
+    checksum_type_expected = "FULL_OBJECT"
+    if checksum_algo == "sha1" or checksum_algo == "sha256":
+        if upload_type == "multipart":
+            checksum_type_expected = "COMPOSITE"
+    if checksum_type != checksum_type_expected:
+        raise AssertionError(
+            f"Checksum not same as expected in the response. Expected {checksum_type_expected}, but received {checksum_type}"
+        )
+    else:
+        log.info("checksum_type verified successfully")
+
+    if response[checksum_key] != checksum:
+        if checksum_type == "COMPOSITE":
+            log.info(
+                f"As it is a COMPOSITE checksum, checksum is different than locally calculated entire object checksum '{checksum}'"
+            )
+        else:
+            raise AssertionError("Checksum not same as expected in the response")
+    log.info(f"{checksum_key} verified successfully")
 
 
 def put_keystone_conf(rgw_service_name, user, passw, project, tenant="true"):

--- a/rgw/v2/tests/aws/test_checksum.py
+++ b/rgw/v2/tests/aws/test_checksum.py
@@ -56,6 +56,15 @@ def test_exec(config, ssh_con):
     else:
         user_info = resource_op.create_users(no_of_users_to_create=config.user_count)
 
+    log.info("installing prerequisite tools")
+    log.info("Install Rhash program")
+    utils.exec_shell_cmd(
+        "rpm -ivh https://rpmfind.net/linux/epel/9/Everything/x86_64/Packages/r/rhash-1.4.2-1.el9.x86_64.rpm"
+    )
+    utils.exec_shell_cmd("sudo pip install botocore[crt]")
+    log.info("sleeping for 10 seconds")
+    time.sleep(10)
+
     for user in user_info:
         user_name = user["user_id"]
         log.info(user_name)
@@ -244,6 +253,7 @@ def test_exec(config, ssh_con):
                     endpoint,
                     checksum_algorithm,
                     checksum_wrong,
+                    failure_expected=True,
                 )
 
                 checksum_algorithm = "sha256"
@@ -257,6 +267,7 @@ def test_exec(config, ssh_con):
                     endpoint,
                     checksum_algorithm,
                     checksum_wrong,
+                    failure_expected=True,
                 )
 
                 checksum_algorithm = "crc32"
@@ -270,6 +281,7 @@ def test_exec(config, ssh_con):
                     endpoint,
                     checksum_algorithm,
                     "randeasdc",
+                    failure_expected=True,
                 )
 
                 utils.exec_shell_cmd("sudo pip install botocore[crt]")
@@ -284,6 +296,7 @@ def test_exec(config, ssh_con):
                     endpoint,
                     checksum_algorithm,
                     checksum_wrong,
+                    failure_expected=True,
                 )
 
     if config.user_remove is True:
@@ -296,7 +309,6 @@ def test_exec(config, ssh_con):
 
 
 if __name__ == "__main__":
-
     test_info = AddTestInfo("Upload wrong checksum with put-object through awscli")
 
     try:

--- a/rgw/v2/tests/aws/test_checksum_with_awscli_v1_and_v2.py
+++ b/rgw/v2/tests/aws/test_checksum_with_awscli_v1_and_v2.py
@@ -1,0 +1,348 @@
+"""
+Usage: test_checksum_with_awscli_v1_and_v2.py -c <input_yaml>
+Polarion ID : CEPH-83591679
+<input_yaml>
+    Note: Following yaml can be used
+    rgw/v2/tests/aws/configs/test_checksum_awscli_v1_v2_small_objects.yaml
+    rgw/v2/tests/aws/configs/test_checksum_awscli_v1_v2_non_multipart.yaml
+    rgw/v2/tests/aws/configs/test_checksum_awscli_v1_v2_multipart.yaml
+
+Operation:
+testing checksum feature with
+with awscli - v1 and v2
+with default checksum enabled and disabled
+with small, non-multipart and multipart objects
+with all supported checksums - "sha1", "sha256", "crc32", "crc32c", "crc64nvme"
+
+operations are put, copy, get, get-object-attributes, delete
+"""
+
+
+import argparse
+import json
+import logging
+import os
+import sys
+import time
+import traceback
+
+sys.path.append(os.path.abspath(os.path.join(__file__, "../../../..")))
+
+
+import v2.lib.manage_data as manage_data
+from v2.lib import resource_op
+from v2.lib.aws import auth as aws_auth
+from v2.lib.aws.resource_op import AWS
+from v2.lib.exceptions import RGWBaseException, TestExecError
+from v2.lib.s3.write_io_info import BasicIOInfoStructure, IOInfoInitialize
+from v2.tests.aws import reusable as aws_reusable
+from v2.tests.s3_swift import reusable as s3_reusable
+from v2.utils import utils
+from v2.utils.log import configure_logging
+from v2.utils.test_desc import AddTestInfo
+
+log = logging.getLogger(__name__)
+TEST_DATA_PATH = None
+
+
+def test_exec(config, ssh_con):
+    """
+    Executes test based on configuration passed
+    Args:
+        config(object): Test configuration
+    """
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+    user_name = (config.test_ops.get("user_name"), None)
+    user_names = [user_name] if type(user_name) != list else user_name
+    if config.test_ops.get("user_name", False):
+        user_info = resource_op.create_users(
+            no_of_users_to_create=config.user_count,
+            user_names=user_names,
+        )
+    else:
+        user_info = resource_op.create_users(no_of_users_to_create=config.user_count)
+
+    log.info("installing prerequisite tools")
+    log.info("Install Rhash program")
+    utils.exec_shell_cmd(
+        "rpm -ivh https://rpmfind.net/linux/epel/9/Everything/x86_64/Packages/r/rhash-1.4.2-1.el9.x86_64.rpm"
+    )
+    utils.exec_shell_cmd("sudo pip install botocore[crt]")
+    utils.exec_shell_cmd(
+        "ls venvawsv1 || (python3 -m venv venvawsv1 && venvawsv1/bin/pip install awscli && venvawsv1/bin/pip install botocore[crt])"
+    )
+    log.info("sleeping for 10 seconds")
+    time.sleep(10)
+
+    for user in user_info:
+        user_name = user["user_id"]
+        log.info(user_name)
+        cli_aws = AWS(ssl=config.ssl, bin_path="/usr/local/bin/")
+        endpoint = aws_reusable.get_endpoint(ssh_con, ssl=config.ssl)
+        aws_auth.do_auth_aws(user)
+
+        for bc in range(config.bucket_count):
+            bucket_name = utils.gen_bucket_name_from_userid(user_name, rand_no=bc)
+            aws_reusable.create_bucket(cli_aws, bucket_name, endpoint)
+            log.info(f"Bucket {bucket_name} created")
+
+            aws_versions = ["v1", "v2"]
+            for aws_version in aws_versions:
+                if aws_version == "v1":
+                    cli_aws = AWS(
+                        ssl=config.ssl, bin_path="/home/cephuser/venvawsv1/bin/"
+                    )
+                    utils.exec_shell_cmd("/home/cephuser/venvawsv1/bin/aws --version")
+                elif aws_version == "v2":
+                    cli_aws = AWS(ssl=config.ssl, bin_path="/usr/local/bin/")
+                    utils.exec_shell_cmd("/usr/local/bin/aws --version")
+
+                default_checksum_flags = [True, False]
+                for default_checksum_flag in default_checksum_flags:
+                    if default_checksum_flag:
+                        aws_auth.do_auth_aws(user)
+                    else:
+                        aws_auth.update_aws_file(
+                            user, checksum_validation_calculation="when_required"
+                        )
+
+                    for oc, size in list(config.mapped_sizes.items()):
+                        algo_list = ["sha1", "sha256", "crc32", "crc32c", "crc64nvme"]
+                        for algo in algo_list:
+                            s3_object_name_prefix = f"{bucket_name}_{aws_version}_{'default_cksm' if default_checksum_flag else 'default_cksm_disabled'}_{algo}"
+                            config.obj_size = size
+                            s3_object_name = utils.gen_s3_object_name(
+                                s3_object_name_prefix, oc
+                            )
+                            log.info(f"s3 object name: {s3_object_name}")
+                            s3_object_path = os.path.join(
+                                TEST_DATA_PATH, s3_object_name
+                            )
+                            log.info(f"s3 object path: {s3_object_path}")
+
+                            if config.test_ops.get("upload_type") == "multipart":
+                                complete_multipart_upload_resp = (
+                                    aws_reusable.upload_multipart_aws(
+                                        cli_aws,
+                                        bucket_name,
+                                        s3_object_name,
+                                        TEST_DATA_PATH,
+                                        endpoint,
+                                        config,
+                                        checksum_algo=algo,
+                                    )
+                                )
+                                checksum = aws_reusable.calculate_checksum(
+                                    algo, s3_object_path
+                                )
+                                aws_reusable.verify_checksum(
+                                    complete_multipart_upload_resp,
+                                    algo,
+                                    checksum,
+                                    config.test_ops.get("upload_type"),
+                                )
+                            else:
+                                log.info("upload type: normal")
+                                data_info = manage_data.io_generator(
+                                    s3_object_path, size
+                                )
+                                checksum = aws_reusable.calculate_checksum(
+                                    algo, s3_object_path
+                                )
+                                aws_reusable.put_object_checksum(
+                                    cli_aws,
+                                    bucket_name,
+                                    s3_object_name,
+                                    endpoint,
+                                    algo,
+                                    checksum,
+                                    s3_object_path,
+                                )
+
+                            # copy object
+                            s3_copy_object_name = f"{s3_object_name}_copy"
+                            log.info(
+                                f"copying object {s3_object_name} to {s3_copy_object_name}"
+                            )
+                            out1 = aws_reusable.copy_object(
+                                cli_aws,
+                                bucket_name,
+                                s3_object_name,
+                                endpoint,
+                                dest_obj_name=s3_copy_object_name,
+                            )
+
+                            # get-object-attributes on objects
+                            attrib_resp = aws_reusable.get_object_attributes(
+                                cli_aws,
+                                bucket_name,
+                                s3_object_name,
+                                endpoint,
+                            )
+                            log.info(
+                                f"Get Object Attributes response for checksum on {s3_object_name}: {attrib_resp}"
+                            )
+                            aws_reusable.verify_checksum(
+                                attrib_resp["Checksum"],
+                                algo,
+                                checksum,
+                                config.test_ops.get("upload_type"),
+                            )
+                            attrib_resp = aws_reusable.get_object_attributes(
+                                cli_aws,
+                                bucket_name,
+                                s3_copy_object_name,
+                                endpoint,
+                            )
+                            log.info(
+                                f"Get Object Attributes response for checksum on {s3_object_name}: {attrib_resp}"
+                            )
+                            aws_reusable.verify_checksum(
+                                attrib_resp["Checksum"],
+                                algo,
+                                checksum,
+                                config.test_ops.get("upload_type"),
+                            )
+
+                            if config.test_ops["download_object"] is True:
+                                # downloading s3 object
+                                s3_object_download_name = (
+                                    s3_object_name + "." + "download"
+                                )
+                                s3_object_download_path = os.path.join(
+                                    TEST_DATA_PATH, s3_object_download_name
+                                )
+                                log.info(
+                                    f"downloading {s3_object_name} to filename: {s3_object_download_name}"
+                                )
+                                aws_reusable.get_object(
+                                    cli_aws,
+                                    bucket_name,
+                                    s3_object_name,
+                                    endpoint,
+                                    download_path=s3_object_download_path,
+                                )
+                                s3_object_downloaded_md5 = utils.get_md5(
+                                    s3_object_download_path
+                                )
+                                s3_object_uploaded_md5 = utils.get_md5(s3_object_path)
+                                # downloading s3 copy object
+                                s3_object_copy_download_name = (
+                                    s3_copy_object_name + "." + "download"
+                                )
+                                s3_object_copy_download_path = os.path.join(
+                                    TEST_DATA_PATH, s3_object_copy_download_name
+                                )
+                                log.info(
+                                    f"downloading {s3_copy_object_name} to filename: {s3_object_copy_download_path}"
+                                )
+                                aws_reusable.get_object(
+                                    cli_aws,
+                                    bucket_name,
+                                    s3_copy_object_name,
+                                    endpoint,
+                                    download_path=s3_object_copy_download_path,
+                                )
+                                s3_object_copy_downloaded_md5 = utils.get_md5(
+                                    s3_object_download_path
+                                )
+                                # verify md5
+                                log.info(
+                                    f"s3_object_uploaded_md5: {s3_object_uploaded_md5}"
+                                )
+                                log.info(
+                                    f"s3_object_downloaded_md5: {s3_object_downloaded_md5}"
+                                )
+                                log.info(
+                                    f"s3_object_copy_downloaded_md5: {s3_object_copy_downloaded_md5}"
+                                )
+                                if str(s3_object_uploaded_md5) == str(
+                                    s3_object_downloaded_md5
+                                ) and str(s3_object_uploaded_md5) == str(
+                                    s3_object_copy_downloaded_md5
+                                ):
+                                    log.info("md5 match")
+                                    utils.exec_shell_cmd(
+                                        f"rm -rf {s3_object_download_path}"
+                                    )
+                                    utils.exec_shell_cmd(
+                                        f"rm -rf {s3_object_copy_download_path}"
+                                    )
+                                else:
+                                    raise TestExecError("md5 mismatch")
+
+            if config.test_ops["delete_bucket_object"] is True:
+                response = aws_reusable.list_objects(cli_aws, bucket_name, endpoint)
+                res_json = json.loads(response)
+                log.info("The list should not have the marker object entry")
+                for obj in res_json["Contents"]:
+                    key = obj["Key"]
+                    log.info(f"deleting object :{key}")
+                    aws_reusable.delete_object(cli_aws, bucket_name, key, endpoint)
+                log.info("sleeping for 10 seconds")
+                time.sleep(10)
+                aws_reusable.delete_bucket(cli_aws, bucket_name, endpoint)
+
+    if config.user_remove is True:
+        s3_reusable.remove_user(user)
+
+    # check for any crashes during the execution
+    crash_info = s3_reusable.check_for_crash()
+    if crash_info:
+        raise TestExecError("ceph daemon crash found!")
+
+
+if __name__ == "__main__":
+    test_info = AddTestInfo(
+        "Upload wrong checksum with put-object through awscli v1 and v2 with default checksum enabled/disabled"
+    )
+
+    try:
+        project_dir = os.path.abspath(os.path.join(__file__, "../../.."))
+        test_data_dir = "test_data"
+        TEST_DATA_PATH = os.path.join(project_dir, test_data_dir)
+        log.info(f"TEST_DATA_PATH: {TEST_DATA_PATH}")
+        if not os.path.exists(TEST_DATA_PATH):
+            log.info("test data dir not exists, creating.. ")
+            os.makedirs(TEST_DATA_PATH)
+        parser = argparse.ArgumentParser(
+            description="Upload wrong checksum with put-object"
+        )
+        parser.add_argument(
+            "-c", dest="config", help="Upload wrong checksum with put-object"
+        )
+        parser.add_argument(
+            "-log_level",
+            dest="log_level",
+            help="Set Log Level [DEBUG, INFO, WARNING, ERROR, CRITICAL]",
+            default="info",
+        )
+        parser.add_argument(
+            "--rgw-node", dest="rgw_node", help="RGW Node", default="127.0.0.1"
+        )
+        args = parser.parse_args()
+        yaml_file = args.config
+        rgw_node = args.rgw_node
+        ssh_con = None
+        if rgw_node != "127.0.0.1":
+            ssh_con = utils.connect_remote(rgw_node)
+        log_f_name = os.path.basename(os.path.splitext(yaml_file)[0])
+        configure_logging(f_name=log_f_name, set_level=args.log_level.upper())
+        config = resource_op.Config(yaml_file)
+        config.read()
+        if config.mapped_sizes is None:
+            config.mapped_sizes = utils.make_mapped_sizes(config)
+        test_exec(config, ssh_con)
+        test_info.success_status("test passed")
+        sys.exit(0)
+
+    except (RGWBaseException, Exception) as e:
+        log.error(e)
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        sys.exit(1)
+
+    finally:
+        utils.cleanup_test_data_path(TEST_DATA_PATH)


### PR DESCRIPTION
this PR is to add support for testing checksum feature with
1. awscli - v1 and v2
2. default checksum enabled and disabled
3. with all 5 supported checksums - "sha1", "sha256", "crc32", "crc32c", "crc64nvme"
4. with small, non-multipart and multipart objects


Bz's automated:


[2353296](https://bugzilla.redhat.com/show_bug.cgi?id=2353296)	[[rgw] small objects download failing with checksum-mismatch error using client aws-cli/2.24.22](https://bugzilla.redhat.com/show_bug.cgi?id=2353296)
[2355689](https://bugzilla.redhat.com/show_bug.cgi?id=2355689)	[rgw][checksum]: complete-multipart-upload is not returning ChecksumType in the response
[2370002](https://bugzilla.redhat.com/show_bug.cgi?id=2370002)	rgw][checksum]: with aws-go-sdk-v2, chunked object upload with trailing checksum of SHA1 or SHA256 is failing with 400 error
[2355038](https://bugzilla.redhat.com/show_bug.cgi?id=2355038)	[rgw][checksum]: get-object-attributes for multipart objects uploaded with SHA1 or SHA256 algorithm is returning FULL_OBJECT for ChecksumType instead of COMPOSITE
[Bug 2349928](https://bugzilla.redhat.com/show_bug.cgi?id=2349928) - [RGW] RGW crashes when performing multipart upload using AWS CLI.
[Bug 2345505](https://bugzilla.redhat.com/show_bug.cgi?id=2345505) - [RGW] RGW crashes when performing multipart upload using AWS CLI

pass logs:
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_checksum_awscli/new_logs/

pass logs for existing configs:
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_checksum_awscli/new_logs/test_tail_deletion_during_copy_object_6m.console.log
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_checksum_awscli/new_logs/test_wrong_checksum.console.log
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_checksum_awscli/new_logs/test_checksum_api.console.log

