### PR TITLE
ssl swift bulk with curl

### DIFF
--- a/rgw/v2/tests/s3_swift/test_swift_bulk_upload.py
+++ b/rgw/v2/tests/s3_swift/test_swift_bulk_upload.py
@@ -105,6 +105,9 @@ def test_exec(config, ssh_con):
     url = f"{proto}://{ip_and_port}/swift/v1/{container_name}?extract-archive=tar"
 
     curl_cmd = f"curl -i {url} -X PUT -H 'X-Auth-Token: {token}' --data-binary @{tar_file_name}"
+    if config.ssl:
+        curl_cmd = curl_cmd + " --insecure"
+
     utils.exec_shell_cmd(curl_cmd)
 
     ls = rgw.get_container(container_name)


### PR DESCRIPTION
ssl swift bulk with curl.

ERROR:
curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.

include no ssl verify to curl command,


Fail log:
http://magna002.ceph.redhat.com/cephci-jenkins/results/ibmc/IBM/8.1/rhel-9/Regression/19.2.1-242/rgw/20/tier-2_ssl_rgw_ecpool_test/Test_swift_bulk_upload_with_tar_format_0.log

pass log: 
IBMC env:
http://magna002.ceph.redhat.com/cephci-jenkins/results/ibmc/IBM/8.1/rhel-9.5/Test/19.2.1-245/43/tier-2_ssl_rgw_ecpool_test/

RH env: 
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-E3H7EJ/