### PR TITLE
[TFA] to get information of existing user

### DIFF
--- a/rgw/v2/tests/aws/test_aws.py
+++ b/rgw/v2/tests/aws/test_aws.py
@@ -64,10 +64,28 @@ def test_exec(config, ssh_con):
     )
 
     if config.test_ops.get("user_name", False):
-        user_info = resource_op.create_users(
-            no_of_users_to_create=config.user_count,
-            user_names=user_names,
-        )
+        op = json.loads(utils.exec_shell_cmd("radosgw-admin user list"))
+        log.info(f"user {config.test_ops['user_name']} exist in cluster {op}")
+        if config.test_ops["user_name"] not in op:
+            log.info(f"number of user to create is {config.user_count}")
+            user_info = resource_op.create_users(
+                no_of_users_to_create=config.user_count,
+                user_names=user_names,
+            )
+        elif config.user_count == 1:
+            out = json.loads(
+                utils.exec_shell_cmd(
+                    f"radosgw-admin user info --uid={config.test_ops['user_name']}"
+                )
+            )
+            user_info = [
+                {
+                    "user_id": out["user_id"],
+                    "display_name": out["display_name"],
+                    "access_key": out["keys"][0]["access_key"],
+                    "secret_key": out["keys"][0]["secret_key"],
+                }
+            ]
     else:
         user_info = resource_op.create_users(no_of_users_to_create=config.user_count)
 


### PR DESCRIPTION
Issue : http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Regression/19.2.1-242/rgw/126/tier-2_rgw_3_way_multisite/

here issue observed as non-master zone was using other user not user mentioned in conf

pass log  with fix:
with user already exist in cluster : http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-KGTYUU/ 
with out user being present : http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-0CD6VU/ 