### PR TITLE
[TFA] removing awscrt from rgw requirements.txt and installing it in checksum script

### DIFF
--- a/rgw/requirements.txt
+++ b/rgw/requirements.txt
@@ -14,7 +14,6 @@ swiftly
 paramiko
 pandas==2.2.3
 pyarrow
-awscrt
 
 # for v1
 #psutil

--- a/rgw/v2/tests/aws/reusable.py
+++ b/rgw/v2/tests/aws/reusable.py
@@ -3,7 +3,6 @@ Reusable methods for aws
 """
 
 
-import base64
 import glob
 import json
 import logging
@@ -14,8 +13,6 @@ import sys
 import time
 from configparser import RawConfigParser
 from pathlib import Path
-
-import awscrt.checksums
 
 log = logging.getLogger()
 
@@ -805,9 +802,12 @@ def calculate_checksum(algo, file):
         )[0]
         return checksum
     elif algo == "crc64nvme":
-        checksum = base64.b64encode(
-            awscrt.checksums.crc64nvme(open(file, "rb").read()).to_bytes(8, "big")
-        ).decode()
+        out = utils.exec_shell_cmd(
+            f'venvawsv1/bin/python -c \'import awscrt.checksums, base64; print(base64.b64encode(awscrt.checksums.crc64nvme(open("{file}","rb").read()).to_bytes(8,"big")).decode())\''
+        )
+        if out is False:
+            raise Exception("crc64nvme calculation failed")
+        checksum = out.strip()
         return checksum
 
 

--- a/rgw/v2/tests/aws/test_checksum_with_awscli_v1_and_v2.py
+++ b/rgw/v2/tests/aws/test_checksum_with_awscli_v1_and_v2.py
@@ -71,7 +71,7 @@ def test_exec(config, ssh_con):
     )
     utils.exec_shell_cmd("sudo pip install botocore[crt]")
     utils.exec_shell_cmd(
-        "ls venvawsv1 || (python3 -m venv venvawsv1 && venvawsv1/bin/pip install awscli && venvawsv1/bin/pip install botocore[crt])"
+        "ls venvawsv1 || (python3 -m venv venvawsv1 && venvawsv1/bin/pip install awscli && venvawsv1/bin/pip install botocore[crt] && venvawsv1/bin/pip install awscrt)"
     )
     log.info("sleeping for 10 seconds")
     time.sleep(10)


### PR DESCRIPTION
this PR is to fix below TFA issue:
awscrt added in requirements.txt in this PR: https://github.com/red-hat-storage/ceph-qe-scripts/pull/766
may be that is changing the way it handles signing configuration with boto3 and awscli for all the requests.
eg: create bucket is failing with below error
```
2025-08-14 02:17:10,369 - cephci - ceph:1187 - ERROR - 2025-08-14 02:27:18,937 ERROR: 6149 (AWS_AUTH_SIGNING_INVALID_CONFIGURATION): Attempt to sign an http request with an invalid signing configuration
2025-08-14 02:17:10,369 - cephci - ceph:1187 - ERROR - 2025-08-14 02:27:18,937 INFO: bucket creation data: False
2025-08-14 02:17:10,370 - cephci - ceph:1187 - ERROR - 2025-08-14 02:27:18,938 ERROR: Resource execution failed: bucket creation failed
```
pipeline fail logs:
http://magna002.ceph.redhat.com/cephci-jenkins/results/ibmc/IBM/8.1/rhel-9/Regression/19.2.1-245/rgw/22/tier-2_rgw_ms_regression_test/
http://magna002.ceph.redhat.com/cephci-jenkins/results/ibmc/IBM/8.1/rhel-9/Regression/19.2.1-245/rgw/22/tier-4-rgw/


the fix is to remove awscrt from requirements.txt and install it in checksum script at the runtime itself.

pass logs:
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/TFA_remove_awscrt_from_requirements/