### PR TITLE
GC Enhancement - phase1

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_delete.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_Mbuckets_with_Nobjects_delete.yaml
@@ -5,8 +5,8 @@ config:
   bucket_count: 2
   objects_count: 20
   objects_size_range:
-    min: 5
-    max: 15
+    min: 5M
+    max: 10M
   test_ops:
     create_bucket: true
     create_object: true

--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -1328,7 +1328,7 @@ def link_chown_nontenant_to_nontenant(new_uid, bucket):
     return
 
 
-def delete_objects(bucket):
+def delete_objects(bucket, gc_verification=True):
     """
     deletes the objects in a given bucket
     :param bucket: S3Bucket object
@@ -1340,6 +1340,12 @@ def delete_objects(bucket):
     log.info("all objects: %s" % all_objects)
     for obj in all_objects:
         log.info("object_name: %s" % obj.key)
+        log.info("object_size: %s" % obj.size)
+        gc_verify_list = []
+        if obj.size < 4194304:
+            gc_verify_list.append("No")
+            if "No" in gc_verify_list:
+                gc_verification = False
     log.info("deleting all objects in bucket")
     objects_deleted = s3lib.resource_op(
         {"obj": objects, "resource": "delete", "args": None}
@@ -1355,6 +1361,19 @@ def delete_objects(bucket):
             for obj in all_objects:
                 log.info(f"writing log for delete object {obj.key}")
                 write_key_info.set_key_deleted(obj.bucket_name, obj.key)
+            if gc_verification:
+                log.info("Verify GC Process")
+                cmd1 = f"radosgw-admin gc list --include-all"
+                gc_list = utils.exec_shell_cmd(cmd1)
+                gc_list_json = json.loads(gc_list)
+                if len(gc_list_json) == 0:
+                    raise AssertionError("GC list not generated for deleted objects")
+                utils.exec_shell_cmd("radosgw-admin gc process --include-all")
+                gc_list = utils.exec_shell_cmd(cmd1)
+                gc_list_json = json.loads(gc_list)
+                if len(gc_list_json) != 0:
+                    raise AssertionError("GC process is not successful!")
+
         else:
             raise TestExecError("objects deletion failed")
     else:


### PR DESCRIPTION
Add GC list check post deletion of object > 4m.
Post delete object, check GC list --> Should be non-empty
Perform GC process
check GC list --> Should be empty

for boto delete_object()


PASS sanity suite with:
8.1z2(PASS: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-VNUF8M/
8.1z3(FAIL): GC is empty: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-BBGCAR/

