### PR TITLE
endpoint reachability for ssl

### DIFF
--- a/rgw/v2/lib/s3cmd/auth.py
+++ b/rgw/v2/lib/s3cmd/auth.py
@@ -47,6 +47,9 @@ def update_s3cfg_file(user_info, ip_and_port):
         user_info(dict): User Information
         ip_and_port(str): RGW ip and port in <ip>:<port> forma
     """
+    if ip_and_port.startswith("http://") or ip_and_port.startswith("https://"):
+        ip_and_port = ip_and_port.split("://", 1)[1]
+
     port = str(ip_and_port).split(":")[1]
     log.info(f"Port  is {port}")
     parser = RawConfigParser()

--- a/rgw/v2/tests/s3_swift/test_LargeObjGet_GC.py
+++ b/rgw/v2/tests/s3_swift/test_LargeObjGet_GC.py
@@ -37,7 +37,7 @@ def test_exec(config, ssh_con):
     io_info_initialize.initialize(basic_io_structure.initial())
     ceph_conf = CephConfOp(ssh_con)
     rgw_service = RGWService()
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
 
     # create user
     user_info = s3lib.create_users(config.user_count)

--- a/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
+++ b/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
@@ -79,7 +79,7 @@ def test_exec(config, ssh_con):
     io_info_initialize.initialize(basic_io_structure.initial())
     ceph_conf = CephConfOp(ssh_con)
     rgw_service = RGWService()
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
 
     # create user
     if config.dbr_scenario == "brownfield":

--- a/rgw/v2/tests/s3_swift/test_bilog_trimming.py
+++ b/rgw/v2/tests/s3_swift/test_bilog_trimming.py
@@ -50,7 +50,7 @@ def test_exec(config, ssh_con):
     io_info_initialize = IOInfoInitialize()
     basic_io_structure = BasicIOInfoStructure()
     io_info_initialize.initialize(basic_io_structure.initial())
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
 
     # create user
     all_users_info = s3lib.create_users(config.user_count)

--- a/rgw/v2/tests/s3_swift/test_bucket_lc_object_exp_multipart.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_lc_object_exp_multipart.py
@@ -48,7 +48,7 @@ def test_exec(config, ssh_con):
     io_info_initialize.initialize(basic_io_structure.initial())
     ceph_conf = CephConfOp(ssh_con)
     rgw_service = RGWService()
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
     log.info("making changes to ceph.conf")
     ceph_conf.set_to_ceph_conf(
         "global",

--- a/rgw/v2/tests/s3_swift/test_bucket_lifecycle_config_ops.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_lifecycle_config_ops.py
@@ -65,7 +65,7 @@ def test_exec(config, ssh_con):
     io_info_initialize.initialize(basic_io_structure.initial())
     ceph_conf = CephConfOp(ssh_con)
     rgw_service = RGWService()
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
     if config.test_ops.get("rgw_lc_debug", False):
         ceph_conf.set_to_ceph_conf(
             "global",

--- a/rgw/v2/tests/s3_swift/test_bucket_lifecycle_object_expiration_transition.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_lifecycle_object_expiration_transition.py
@@ -76,7 +76,7 @@ def test_exec(config, ssh_con):
     io_info_initialize.initialize(basic_io_structure.initial())
     ceph_conf = CephConfOp(ssh_con)
     rgw_service = RGWService()
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
     buckets = []
     log.info("making changes to ceph.conf")
     ceph_conf.set_to_ceph_conf(

--- a/rgw/v2/tests/s3_swift/test_bucket_listing.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_listing.py
@@ -58,7 +58,7 @@ def test_exec(config, ssh_con):
     io_info_initialize.initialize(basic_io_structure.initial())
     ceph_conf = CephConfOp(ssh_con)
     rgw_service = RGWService()
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
 
     # create user
     all_users_info = s3lib.create_users(config.user_count)

--- a/rgw/v2/tests/s3_swift/test_bucket_notifications.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_notifications.py
@@ -77,7 +77,7 @@ def test_exec(config, ssh_con):
     io_info_initialize.initialize(basic_io_structure.initial())
     ceph_conf = CephConfOp(ssh_con)
     rgw_service = RGWService()
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
 
     if config.test_ops.get("Filter", False) is False:
         config.test_ops["Filter"] = notification.Filter

--- a/rgw/v2/tests/s3_swift/test_bucket_policy_ops.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_policy_ops.py
@@ -98,7 +98,7 @@ def test_exec(config, ssh_con):
 
     ceph_config_set = CephConfOp(ssh_con)
     rgw_service = RGWService()
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
     if config.test_ops.get("verify_policy"):
         ceph_config_set.set_to_ceph_conf(
             "global",

--- a/rgw/v2/tests/s3_swift/test_bucket_policy_with_tenant_user.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_policy_with_tenant_user.py
@@ -94,7 +94,7 @@ def test_exec(config, ssh_con):
     basic_io_structure = BasicIOInfoStructure()
     write_bucket_io_info = BucketIoInfo()
     io_info_initialize.initialize(basic_io_structure.initial())
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
     if config.rgw_enable_static_website:
         ceph_conf = CephConfOp(ssh_con)
         rgw_service = RGWService()

--- a/rgw/v2/tests/s3_swift/test_bucket_request_payer.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_request_payer.py
@@ -45,7 +45,7 @@ def test_exec(config, requester, ssh_con):
     basic_io_structure = BasicIOInfoStructure()
     io_info_initialize.initialize(basic_io_structure.initial())
     log.info("requester type: %s" % requester)
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
 
     # create user
     all_users_info = s3lib.create_users(config.user_count)

--- a/rgw/v2/tests/s3_swift/test_byte_range.py
+++ b/rgw/v2/tests/s3_swift/test_byte_range.py
@@ -41,7 +41,7 @@ def test_exec(config, ssh_con):
     io_info_initialize = IOInfoInitialize()
     basic_io_structure = BasicIOInfoStructure()
     io_info_initialize.initialize(basic_io_structure.initial())
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
 
     test_info.started_info()
     # create user

--- a/rgw/v2/tests/s3_swift/test_cloud_transition.py
+++ b/rgw/v2/tests/s3_swift/test_cloud_transition.py
@@ -48,7 +48,7 @@ def test_exec(config, ssh_con):
     io_info_initialize.initialize(basic_io_structure.initial())
     ceph_conf = CephConfOp(ssh_con)
     rgw_service = RGWService()
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
 
     user_info = s3lib.create_users(config.user_count)[0]
     # authenticate

--- a/rgw/v2/tests/s3_swift/test_data_omap_offload.py
+++ b/rgw/v2/tests/s3_swift/test_data_omap_offload.py
@@ -47,7 +47,7 @@ def test_exec(config, ssh_con):
     io_info_initialize.initialize(basic_io_structure.initial())
     ceph_conf = CephConfOp(ssh_con)
     rgw_service = RGWService()
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
 
     # check the default data log backing
     default_data_log = reusable.get_default_datalog_type()

--- a/rgw/v2/tests/s3_swift/test_dynamic_bucket_resharding.py
+++ b/rgw/v2/tests/s3_swift/test_dynamic_bucket_resharding.py
@@ -81,7 +81,7 @@ def test_exec(config, ssh_con):
     io_info_initialize.initialize(basic_io_structure.initial())
     ceph_conf = CephConfOp(ssh_con)
     rgw_service = RGWService()
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
     log.info("starting IO")
     config.user_count = 1
     user_info = s3lib.create_users(config.user_count)

--- a/rgw/v2/tests/s3_swift/test_encrypted_bucket_chown.py
+++ b/rgw/v2/tests/s3_swift/test_encrypted_bucket_chown.py
@@ -53,7 +53,7 @@ def test_exec(config, ssh_con):
     io_info_initialize.initialize(basic_io_structure.initial())
     ceph_conf = CephConfOp(ssh_con)
     rgw_service = RGWService()
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
 
     # create user
     if config.user_count is 2:

--- a/rgw/v2/tests/s3_swift/test_frontends_with_ssl.py
+++ b/rgw/v2/tests/s3_swift/test_frontends_with_ssl.py
@@ -39,7 +39,7 @@ def test_exec(config, ssh_con):
     io_info_initialize = IOInfoInitialize()
     basic_io_structure = BasicIOInfoStructure()
     io_info_initialize.initialize(basic_io_structure.initial())
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
 
     all_users_info = s3lib.create_users(config.user_count)
     for each_user in all_users_info:

--- a/rgw/v2/tests/s3_swift/test_gc_with_resharding.py
+++ b/rgw/v2/tests/s3_swift/test_gc_with_resharding.py
@@ -50,7 +50,7 @@ def test_exec(config, ssh_con):
     io_info_initialize.initialize(basic_io_structure.initial())
     ceph_conf = CephConfOp(ssh_con)
     rgw_service = RGWService()
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
     objects_created_list = []
 
     # create user

--- a/rgw/v2/tests/s3_swift/test_indexless_buckets.py
+++ b/rgw/v2/tests/s3_swift/test_indexless_buckets.py
@@ -41,7 +41,7 @@ def test_exec(config, ssh_con):
     basic_io_structure = BasicIOInfoStructure()
     io_info_initialize.initialize(basic_io_structure.initial())
     rgw_service = RGWService()
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
 
     log.info("adding indexless placement to placement target of default zonegroup")
     zonegroup_set = utils.exec_shell_cmd(

--- a/rgw/v2/tests/s3_swift/test_lc_reshard.py
+++ b/rgw/v2/tests/s3_swift/test_lc_reshard.py
@@ -44,7 +44,7 @@ def test_exec(config, ssh_con):
     io_info_initialize.initialize(basic_io_structure.initial())
     ceph_conf = CephConfOp(ssh_con)
     rgw_service = RGWService()
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
 
     # create user
     all_users_info = s3lib.create_users(config.user_count)

--- a/rgw/v2/tests/s3_swift/test_manual_lc_process_single_bucket.py
+++ b/rgw/v2/tests/s3_swift/test_manual_lc_process_single_bucket.py
@@ -41,7 +41,7 @@ def test_exec(config, ssh_con):
     io_info_initialize = IOInfoInitialize()
     basic_io_structure = BasicIOInfoStructure()
     io_info_initialize.initialize(basic_io_structure.initial())
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
 
     # create user
     user_info = s3lib.create_users(config.user_count)

--- a/rgw/v2/tests/s3_swift/test_multisite_bucket_granular_sync_policy.py
+++ b/rgw/v2/tests/s3_swift/test_multisite_bucket_granular_sync_policy.py
@@ -59,7 +59,7 @@ def test_exec(config, ssh_con):
     io_info_initialize = IOInfoInitialize()
     basic_io_structure = BasicIOInfoStructure()
     io_info_initialize.initialize(basic_io_structure.initial())
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
 
     # create user
     all_users_info = s3lib.create_users(config.user_count)

--- a/rgw/v2/tests/s3_swift/test_multisite_sync_policy.py
+++ b/rgw/v2/tests/s3_swift/test_multisite_sync_policy.py
@@ -49,7 +49,7 @@ def test_exec(config, ssh_con):
     io_info_initialize = IOInfoInitialize()
     basic_io_structure = BasicIOInfoStructure()
     io_info_initialize.initialize(basic_io_structure.initial())
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
 
     # create user
     all_users_info = s3lib.create_users(config.user_count)

--- a/rgw/v2/tests/s3_swift/test_multisite_syncpolicy_prefix_tag.py
+++ b/rgw/v2/tests/s3_swift/test_multisite_syncpolicy_prefix_tag.py
@@ -45,7 +45,7 @@ def test_exec(config, ssh_con):
     basic_io_structure = BasicIOInfoStructure()
     io_info_initialize.initialize(basic_io_structure.initial())
     user_info = s3lib.create_users(config.user_count)
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
 
     # Create Zonegroup policy
     log.info("Creating Zone group policy at Enabled state")

--- a/rgw/v2/tests/s3_swift/test_multitenant_user_access.py
+++ b/rgw/v2/tests/s3_swift/test_multitenant_user_access.py
@@ -59,7 +59,7 @@ def test_exec(config, ssh_con):
     io_info_initialize = IOInfoInitialize()
     basic_io_structure = BasicIOInfoStructure()
     io_info_initialize.initialize(basic_io_structure.initial())
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
 
     # preparing data
     user_names = ["user1", "user2", "user3"]

--- a/rgw/v2/tests/s3_swift/test_policy_torrent.py
+++ b/rgw/v2/tests/s3_swift/test_policy_torrent.py
@@ -56,7 +56,7 @@ def test_exec(config, ssh_con):
     basic_io_structure = BasicIOInfoStructure()
     io_info_initialize.initialize(basic_io_structure.initial())
     rgw_service = RGWService()
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
 
     # create user
     config.user_count = 2

--- a/rgw/v2/tests/s3_swift/test_quota_management.py
+++ b/rgw/v2/tests/s3_swift/test_quota_management.py
@@ -48,7 +48,7 @@ def test_exec(config, ssh_con):
     io_info_initialize = IOInfoInitialize()
     basic_io_structure = BasicIOInfoStructure()
     io_info_initialize.initialize(basic_io_structure.initial())
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
 
     log.info(f"Creating {config.user_count} users")
     all_users_info = s3lib.create_users(config.user_count)

--- a/rgw/v2/tests/s3_swift/test_rgw_account_management.py
+++ b/rgw/v2/tests/s3_swift/test_rgw_account_management.py
@@ -47,7 +47,7 @@ def test_exec(config, ssh_con):
     io_info_initialize = IOInfoInitialize()
     basic_io_structure = BasicIOInfoStructure()
     write_bucket_io_info = BucketIoInfo()
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
 
     io_info_initialize.initialize(basic_io_structure.initial())
 

--- a/rgw/v2/tests/s3_swift/test_rgw_mfa.py
+++ b/rgw/v2/tests/s3_swift/test_rgw_mfa.py
@@ -33,7 +33,7 @@ def test_exec(config, ssh_con):
     io_info_initialize.initialize(basic_io_structure.initial())
     ceph_conf = CephConfOp(ssh_con)
     rgw_service = RGWService()
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
 
     # create user
     all_users_info = s3lib.create_users(config.user_count)

--- a/rgw/v2/tests/s3_swift/test_rgw_restore_index_tool.py
+++ b/rgw/v2/tests/s3_swift/test_rgw_restore_index_tool.py
@@ -52,7 +52,7 @@ def test_exec(config, ssh_con):
     io_info_initialize.initialize(basic_io_structure.initial())
     ceph_conf = CephConfOp(ssh_con)
     rgw_service = RGWService()
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
     log.info("starting IO")
     user_info = s3lib.create_users(config.user_count)
     user_info = user_info[0]

--- a/rgw/v2/tests/s3_swift/test_s3_copy_encryption.py
+++ b/rgw/v2/tests/s3_swift/test_s3_copy_encryption.py
@@ -46,7 +46,7 @@ def test_exec(config, ssh_con):
     io_info_initialize.initialize(basic_io_structure.initial())
     ceph_config_set = CephConfOp(ssh_con)
     rgw_service = RGWService()
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
 
     # create user
     all_users_info = s3lib.create_users(config.user_count)

--- a/rgw/v2/tests/s3_swift/test_server_access_logging.py
+++ b/rgw/v2/tests/s3_swift/test_server_access_logging.py
@@ -58,7 +58,7 @@ def test_exec(config, ssh_con):
     io_info_initialize.initialize(basic_io_structure.initial())
     ceph_conf = CephConfOp(ssh_con)
     rgw_service = RGWService()
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
 
     # add service2 sdk extras so that bucket logging api's and respective fields are supported
     utils.add_service2_sdk_extras(

--- a/rgw/v2/tests/s3_swift/test_sse_s3_kms_with_vault.py
+++ b/rgw/v2/tests/s3_swift/test_sse_s3_kms_with_vault.py
@@ -66,7 +66,7 @@ def test_exec(config, ssh_con):
     io_info_initialize.initialize(basic_io_structure.initial())
     ceph_conf = CephConfOp(ssh_con)
     rgw_service = RGWService()
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
 
     out = utils.exec_shell_cmd("ceph config get client.rgw rgw_crypt_s3_kms_backend")
     rgw_crypt_s3_kms_backend = out.strip()

--- a/rgw/v2/tests/s3_swift/test_storage_policy.py
+++ b/rgw/v2/tests/s3_swift/test_storage_policy.py
@@ -51,7 +51,7 @@ def test_exec(config, ssh_con):
     io_info_initialize.initialize(basic_io_structure.initial())
     ceph_conf = CephConfOp(ssh_con)
     rgw_service = RGWService()
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
 
     # create pool
     pool_name = ".rgw.buckets.special"

--- a/rgw/v2/tests/s3_swift/test_sts_aswi.py
+++ b/rgw/v2/tests/s3_swift/test_sts_aswi.py
@@ -80,7 +80,7 @@ def test_exec(config, ssh_con):
     io_info_initialize.initialize(basic_io_structure.initial())
     ceph_config_set = CephConfOp(ssh_con)
     rgw_service = RGWService()
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
     local_ip_addr = utils.get_localhost_ip_address()
 
     if config.sts is None:

--- a/rgw/v2/tests/s3_swift/test_sts_using_boto.py
+++ b/rgw/v2/tests/s3_swift/test_sts_using_boto.py
@@ -58,7 +58,7 @@ def test_exec(config, ssh_con):
     io_info_initialize.initialize(basic_io_structure.initial())
     ceph_config_set = CephConfOp(ssh_con)
     rgw_service = RGWService()
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
 
     if config.sts is None:
         raise TestExecError("sts policies are missing in yaml config")

--- a/rgw/v2/tests/s3_swift/test_sts_using_boto_server_side_copy.py
+++ b/rgw/v2/tests/s3_swift/test_sts_using_boto_server_side_copy.py
@@ -56,7 +56,7 @@ def test_exec(config, ssh_con):
     io_info_initialize.initialize(basic_io_structure.initial())
     ceph_config_set = CephConfOp(ssh_con)
     rgw_service = RGWService()
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
 
     if config.sts is None:
         raise TestExecError("sts policies are missing in yaml config")

--- a/rgw/v2/tests/s3_swift/test_sts_using_boto_session_policy.py
+++ b/rgw/v2/tests/s3_swift/test_sts_using_boto_session_policy.py
@@ -64,7 +64,7 @@ def test_exec(config, ssh_con):
     io_info_initialize.initialize(basic_io_structure.initial())
     ceph_config_set = CephConfOp(ssh_con)
     rgw_service = RGWService()
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
 
     if config.sts is None:
         raise TestExecError("sts policies are missing in yaml config")

--- a/rgw/v2/tests/s3_swift/test_sts_using_boto_unexisting_object.py
+++ b/rgw/v2/tests/s3_swift/test_sts_using_boto_unexisting_object.py
@@ -55,7 +55,7 @@ def test_exec(config, ssh_con):
     io_info_initialize.initialize(basic_io_structure.initial())
     ceph_config_set = CephConfOp(ssh_con)
     rgw_service = RGWService()
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
 
     if config.sts is None:
         raise TestExecError("sts policies are missing in yaml config")

--- a/rgw/v2/tests/s3_swift/test_swift_basic_ops.py
+++ b/rgw/v2/tests/s3_swift/test_swift_basic_ops.py
@@ -155,7 +155,7 @@ def test_exec(config, ssh_con):
     ceph_conf = CephConfOp(ssh_con)
     log.info(type(ceph_conf))
     rgw_service = RGWService()
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
     # preparing data
     user_name = names.get_first_name() + random.choice(string.ascii_letters)
     if config.user_type == "non-tenanted":

--- a/rgw/v2/tests/s3_swift/test_user_bucket_rename.py
+++ b/rgw/v2/tests/s3_swift/test_user_bucket_rename.py
@@ -49,7 +49,7 @@ def test_exec(config, ssh_con):
     io_info_initialize = IOInfoInitialize()
     basic_io_structure = BasicIOInfoStructure()
     io_info_initialize.initialize(basic_io_structure.initial())
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
 
     non_ten_buckets = {}
     ten_buckets = {}

--- a/rgw/v2/tests/s3_swift/test_versioning_copy_objects.py
+++ b/rgw/v2/tests/s3_swift/test_versioning_copy_objects.py
@@ -55,7 +55,7 @@ def test_exec(config, ssh_con):
     # create user
     s3_user = s3lib.create_users(1)[0]
     # authenticate
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
     auth = Auth(s3_user, ssh_con, ssl=config.ssl)
     rgw_conn = auth.do_auth()
     b1_name = utils.gen_bucket_name_from_userid(s3_user["user_id"], rand_no=1)

--- a/rgw/v2/tests/s3_swift/test_versioning_with_objects.py
+++ b/rgw/v2/tests/s3_swift/test_versioning_with_objects.py
@@ -70,7 +70,7 @@ def test_exec(config, ssh_con):
     write_bucket_io_info = BucketIoInfo()
     write_key_io_info = KeyIoInfo()
     io_info_initialize.initialize(basic_io_structure.initial())
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
 
     # create user
     all_users_info = s3lib.create_users(config.user_count)
@@ -90,9 +90,14 @@ def test_exec(config, ssh_con):
             )
             log.info("creating bucket with name: %s" % bucket_name_to_create)
             # bucket = s3_ops.resource_op(rgw_conn, 'Bucket', bucket_name_to_create)
-            bucket = reusable.create_bucket(
-                bucket_name_to_create, rgw_conn, each_user, ip_and_port
-            )
+            if config.haproxy:
+                bucket = reusable.create_bucket(
+                    bucket_name_to_create, rgw_conn, each_user
+                )
+            else:
+                bucket = reusable.create_bucket(
+                    bucket_name_to_create, rgw_conn, each_user, ip_and_port
+                )
             # getting bucket version object
             if config.test_ops["enable_version"] is True:
                 log.info("bucket versioning test on bucket: %s" % bucket.name)

--- a/rgw/v2/tests/s3cmd/reusable.py
+++ b/rgw/v2/tests/s3cmd/reusable.py
@@ -252,7 +252,7 @@ def get_file_size(file_name):
     return os.path.getsize(file_name)
 
 
-def get_rgw_ip_and_port(ssh_con=None):
+def get_rgw_ip_and_port(ssh_con=None, ssl=None):
     """
     Returns RGW ip and port in <ip>:<port> format
     Returns: RGW ip and port
@@ -268,6 +268,8 @@ def get_rgw_ip_and_port(ssh_con=None):
         ip = socket.gethostbyname(hostname)
         port = utils.get_radosgw_port_no()
     ip_and_port = f"{ip}:{port}"
+    if ssl:
+        ip_and_port = f"https://{ip}:{port}"
     return ip_and_port
 
 

--- a/rgw/v2/tests/s3cmd/test_s3cmd.py
+++ b/rgw/v2/tests/s3cmd/test_s3cmd.py
@@ -71,7 +71,7 @@ def test_exec(config, ssh_con):
     rgw_service = RGWService()
 
     rgw_service_port = reusable.get_rgw_service_port()
-    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con)
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
     if config.haproxy and rgw_service_port != 443:
         hostname = socket.gethostname()
         ip = socket.gethostbyname(hostname)


### PR DESCRIPTION
endpoint reachability for ssl with https

pass log ssl suites: http://magna002.ceph.redhat.com/ceph-qe-logs/mreddem/cephci-run-XTZPGV/

non ssl : http://magna002.ceph.redhat.com/ceph-qe-logs/mreddem/cephci-run-CVLHB5/


ssl logs

1. tier-2_ssl_rgw_ms_ecpool_test.yaml : 
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9.6/Test/19.2.1-265/854/tier-2_ssl_rgw_ms_ecpool_test/

2. tier-2_ssl_rgw_regression_test.yaml : 
http://localhost:8000/regression/index.html
http://localhost:8000/regression-2/index.html

3. tier-2_rgw_ss|_cephadm_gen_cert.yaml : 
http://magna002.ceph.redhat.com/ceph-qe-logs/mreddem/cephci-run-XTZPGV/

4. tier-1_rgw_upgrade_ssl_71GA_to_8x_latest.yaml :
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9.6/Test/19.2.1-265/847/tier-1_rgw_upgrade_ssl_71GA_to_8x_latest/

5. tier-1_rgw_ss|_multisite_test_upgrade_71GA_to_8x_latest.yaml : 
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9.6/Test/19.2.1-265/855/tier-1_rgw_ssl_multisite_test_upgrade_71GA_to_8x_latest/

6. tier-1_rgw_upgrade_ss|_ecpool_81GA_to_8x_latest.yaml : 
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9.6/Test/19.2.1-265/848/tier-1_rgw_upgrade_ssl_ecpool_81GA_to_8x_latest/

7. tier-1_rgw_upgrade_ms_ssl_ecpool_80GA_to_8x_latest.yaml : 
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9.6/Test/19.2.1-265/844/tier-1_rgw_upgrade_ms_ssl_ecpool_80GA_to_8x_latest/

8. tier-1_rgw_upgrade_archive_ssl_ecpool_80GA_to_8x_latest.yaml	:
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9.6/Test/19.2.1-265/849/tier-1_rgw_upgrade_archive_ssl_ecpool_80GA_to_8x_latest/
