### PR TITLE
[Lua] Test object lock using lua script

### DIFF
--- a/rgw/v2/tests/aws/configs/test_aws_lua_object_lock.yaml
+++ b/rgw/v2/tests/aws/configs/test_aws_lua_object_lock.yaml
@@ -1,0 +1,18 @@
+# Test: obj lock LUA - Object lock enabled on bucket creation via Lua prerequest script.
+# polarion id: CEPH-83632330
+# Script: test_lua_script_prerequest.py
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 2
+  local_file_delete: true
+  objects_size_range:
+    min: 5K
+    max: 10M
+  user_remove: false
+  test_ops:
+    lua_object_lock: true
+    put_default_retention: true
+    retention_days: 5
+    lock_mode: "COMPLIANCE"
+    test_multipart: true

--- a/rgw/v2/tests/aws/configs/test_aws_lua_object_lock_governance.yaml
+++ b/rgw/v2/tests/aws/configs/test_aws_lua_object_lock_governance.yaml
@@ -1,0 +1,18 @@
+# Test: obj lock LUA with GOVERNANCE mode (retention can be modified with BypassGovernanceRetention).
+# polarion id: CEPH-83632330
+# Script: test_lua_script_prerequest.py
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 2
+  local_file_delete: true
+  objects_size_range:
+    min: 5K
+    max: 10M
+  user_remove: false
+  test_ops:
+    lua_object_lock: true
+    put_default_retention: true
+    retention_days: 5
+    lock_mode: "GOVERNANCE"
+    test_multipart: true

--- a/rgw/v2/tests/aws/configs/test_aws_lua_object_lock_minimal.yaml
+++ b/rgw/v2/tests/aws/configs/test_aws_lua_object_lock_minimal.yaml
@@ -1,0 +1,14 @@
+# Test: obj lock LUA (minimal) - Only verify Lua enables object lock on bucket creation.
+# polarion id: CEPH-83632330
+# Script: test_lua_script_prerequest.py
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 2
+  local_file_delete: true
+  objects_size_range:
+    min: 5K
+    max: 5K
+  user_remove: false
+  test_ops:
+    lua_object_lock: true


### PR DESCRIPTION
Logs : https://magna002.ceph.redhat.com/cephci-jenkins/ibm-cos/RH/9.0/rhel-9/executor/20.1.0-155/rgw/828/logs/tier_2_rgw_ms_lua/ 


Lua script prerequest basic test with object lock | Test Lua script prerequest basic test with object lock | 0:00:39.610310 | Pass |  
-- | -- | -- | -- | --
Lua script prerequest test with object lock | Test Lua script prerequest test with object lock | 0:01:24.505028 | Pass |  
Lua script prerequest test with object lock governance | Test Lua script prerequest test with object lock governance | 0:01:24.075938 | Pass |  

<br class="Apple-interchange-newline">[Lua script prerequest basic test with object lock](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83623450)	Test Lua script prerequest basic test with object lock	0:00:39.610310	[Pass](https://magna002.ceph.redhat.com/cephci-jenkins/ibm-cos/RH/9.0/rhel-9/executor/20.1.0-155/rgw/828/logs/tier_2_rgw_ms_lua/Lua_script_prerequest_basic_test_with_object_lock_0.log)	
[Lua script prerequest test with object lock](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83623450)	Test Lua script prerequest test with object lock	0:01:24.505028	[Pass](https://magna002.ceph.redhat.com/cephci-jenkins/ibm-cos/RH/9.0/rhel-9/executor/20.1.0-155/rgw/828/logs/tier_2_rgw_ms_lua/Lua_script_prerequest_test_with_object_lock_0.log)	
[Lua script prerequest test with object lock governance](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83623450)	Test Lua script prerequest test with object lock governance	0:01:24.075938	[Pass](https://magna002.ceph.redhat.com/cephci-jenkins/ibm-cos/RH/9.0/rhel-9/executor/20.1.0-155/rgw/828/logs/tier_2_rgw_ms_lua/Lua_script_prerequest_test_with_object_lock_governance_0.log)