### PR TITLE
LC Expiration of expired-delete-marker for version suspended bucket

### DIFF
--- a/rgw/v2/tests/s3cmd/configs/test_lc_version_suspended_expired_delete_marker.yaml
+++ b/rgw/v2/tests/s3cmd/configs/test_lc_version_suspended_expired_delete_marker.yaml
@@ -1,0 +1,15 @@
+# LC with versioning suspended: enable versioning -> suspend -> put object (null versionId)
+# -> delete object (delete marker with null versionId) -> apply LC ExpiredObjectDeleteMarker
+# Script: ceph-qe-scripts/rgw/v2/tests/s3cmd/test_lifecycle_s3cmd.py
+config:
+  test_ops:
+    lc_version_suspended_expired_delete_marker: true
+    expired_object_delete_marker: true
+    lc_prefix: "lc-suspended"
+    days: 2
+  rgw_lc_debug_interval: 30
+  user_count: 1
+  bucket_count: 1
+  objects_size_range:
+    min: 5
+    max: 15

--- a/rgw/v2/tests/s3cmd/reusable.py
+++ b/rgw/v2/tests/s3cmd/reusable.py
@@ -82,12 +82,20 @@ def set_lc_lifecycle(lifecycle_rule, config, bucket_name):
     """
     log.info("Generate a LC rule xml file")
     Generate_LC_xml(lifecycle_rule, config)
+    try:
+        with open(lifecycle_rule, "r") as f:
+            lc_xml_content = f.read()
+        log.info("Lifecycle rule applied (XML):\n%s", lc_xml_content)
+    except OSError as e:
+        log.warning("Could not read lifecycle rule file to print: %s", e)
     log.info(f"Apply the LC rule via the xml file on bucket {bucket_name}")
     utils.exec_shell_cmd(
         f"{s3cmd_path} setlifecycle {lifecycle_rule} s3://{bucket_name}"
     )
-
-    utils.exec_shell_cmd(f"{s3cmd_path} getlifecycle s3://{bucket_name}")
+    getlifecycle_out = utils.exec_shell_cmd(
+        f"{s3cmd_path} getlifecycle s3://{bucket_name}"
+    )
+    log.info("Lifecycle rule on bucket (getlifecycle):\n%s", getlifecycle_out)
 
 
 def enable_versioning_for_a_bucket(user_info, bucket_name, ip_and_port, ssl=False):
@@ -133,6 +141,29 @@ def create_versioned_bucket(user_info, bucket_name, ip_and_port, ssl=False):
     bucket = s3.create_bucket(Bucket=bucket_name)
     bucket_versioning = bucket.Versioning()
     bucket_versioning.enable()
+
+
+def suspend_versioning_for_a_bucket(user_info, bucket_name, ip_and_port, ssl=False):
+    """
+    Suspend versioning for an existing bucket
+    Args:
+        user_info: User details dict
+        bucket_name(str): Name of the bucket
+        ip_and_port(str): Hostname and port where rgw daemon is running
+        ssl(bool): Use HTTPS if True
+    """
+    protocol = "https" if ssl else "http"
+    endpoint_url = f"{protocol}://{ip_and_port}"
+    s3 = boto3.resource(
+        "s3",
+        aws_access_key_id=user_info["access_key"],
+        aws_secret_access_key=user_info["secret_key"],
+        endpoint_url=endpoint_url,
+        use_ssl=ssl,
+    )
+    bucket = s3.Bucket(bucket_name)
+    versioning = bucket.Versioning()
+    versioning.suspend()
 
 
 def upload_file(bucket_name, file_name=None, file_size=1024, test_data_path=None):
@@ -568,11 +599,18 @@ def Generate_LC_xml(fileName, config):
         and_ObjectSizeGreaterThan.text = "500"
         and_prefix.text = "tax"
     else:
-        filter_prefix = xml.SubElement(rule_filter, "Prefix")
-        filter_prefix.text = "tax"
+        lc_prefix = config.test_ops.get("lc_prefix", "tax")
+        if lc_prefix != "" and lc_prefix is not None:
+            filter_prefix = xml.SubElement(rule_filter, "Prefix")
+            filter_prefix.text = lc_prefix
+        # empty Filter (no Prefix) = rule applies to all objects; empty Prefix causes MalformedXML
     if config.test_ops.get("test_lc_archive_zone"):
         filter_archive_zone = xml.SubElement(rule_filter, "ArchiveZone")
-    if config.test_ops.get("test_current_expiration"):
+    if config.test_ops.get("expired_object_delete_marker"):
+        rule_Expiration = xml.SubElement(lc_rule, "Expiration")
+        expired_dm = xml.SubElement(rule_Expiration, "ExpiredObjectDeleteMarker")
+        expired_dm.text = "true"
+    elif config.test_ops.get("test_current_expiration"):
         rule_Expiration = xml.SubElement(lc_rule, "Expiration")
         Days = xml.SubElement(rule_Expiration, "Days")
         Days.text = str(config.test_ops.get("days"))
@@ -603,7 +641,12 @@ def Generate_LC_xml(fileName, config):
             Noncurrentdays.text = config.test_ops.get["days"]
 
     tree = xml.ElementTree(lifecycle_configuration)
-    tree.write(fileName)
+    tree.write(fileName, xml_declaration=True, encoding="UTF-8", method="xml")
+    try:
+        with open(fileName, "r", encoding="utf-8") as f:
+            log.info("Lifecycle rule file content:\n%s", f.read())
+    except OSError as e:
+        log.warning("Could not read lifecycle rule file to print: %s", e)
 
 
 def lc_validation_at_archive_zone(bucket_name, config):

--- a/rgw/v2/tests/s3cmd/test_lifecycle_s3cmd.py
+++ b/rgw/v2/tests/s3cmd/test_lifecycle_s3cmd.py
@@ -11,6 +11,7 @@ Usage: test_lifecycle_s3cmd.py -c <input_yaml>
     test_s3cmd_lifecycle_archive_object_size.yaml
     test_s3cmd_lifecycle_archive_transition.yaml
     test_lc_expiration_noncurrent_when_current_object_deleted_via_s3cmd.yaml
+    test_lc_version_suspended_expired_delete_marker.yaml
 
 Operation:
     Create a user
@@ -156,6 +157,111 @@ def test_exec(config, ssh_con):
                 object_exist = True
         if object_exist:
             raise AssertionError("Non-current object expiration failed")
+    elif config.test_ops.get("lc_version_suspended_expired_delete_marker", False):
+        log.info(
+            "LC version suspended + ExpiredObjectDeleteMarker: enable versioning -> "
+            "suspend -> put object (null versionId) -> delete (delete marker) -> "
+            "apply LC ExpiredObjectDeleteMarker"
+        )
+        if getattr(config, "rgw_lc_debug_interval", None) is not None:
+            log.info("Making changes to ceph.conf for LC to run frequently")
+            ceph_conf.set_to_ceph_conf(
+                "global",
+                ConfigOpts.rgw_lc_debug_interval,
+                str(config.rgw_lc_debug_interval),
+                ssh_con,
+            )
+            ceph_conf.set_to_ceph_conf(
+                "global", ConfigOpts.rgw_lifecycle_work_time, "00:00-23:59"
+            )
+            s3cmd_reusable.rgw_service_restart(ssh_con)
+        bucket_name = utils.gen_bucket_name_from_userid(
+            user_info[0]["user_id"], rand_no=0
+        )
+        object_name = "lc-suspended-obj"
+        s3cmd_reusable.create_bucket(bucket_name, ip_and_port)
+        log.info(f"Step 1: Enable versioning on bucket {bucket_name}")
+        s3cmd_reusable.enable_versioning_for_a_bucket(
+            user_info[0], bucket_name, ip_and_port, ssl=None
+        )
+        log.info(f"Step 2: Suspend versioning on bucket {bucket_name}")
+        s3cmd_reusable.suspend_versioning_for_a_bucket(
+            user_info[0], bucket_name, ip_and_port, ssl=None
+        )
+        utils.exec_shell_cmd("fallocate -l 1K lc_suspended_1k")
+        log.info(
+            f"Step 3: Write object to bucket (gets null versionId when versioning suspended)"
+        )
+        utils.exec_shell_cmd(
+            f"{s3cmd_path} put lc_suspended_1k s3://{bucket_name}/{object_name}"
+        )
+        head = rgw_conn.meta.client.head_object(Bucket=bucket_name, Key=object_name)
+        version_id = head.get("VersionId")
+        if version_id is not None and version_id != "null":
+            raise AssertionError(
+                f"Expected object to have version-id null (versioning suspended), "
+                f"got: {version_id!r}"
+            )
+        log.info(
+            "Validation: object has version-id null as expected (versioning suspended)"
+        )
+        log.info(f"Step 4: Delete object -> creates delete marker with null versionId")
+        utils.exec_shell_cmd(f"{s3cmd_path} rm s3://{bucket_name}/{object_name}")
+        resp = rgw_conn.meta.client.list_object_versions(
+            Bucket=bucket_name, Prefix=object_name
+        )
+        log.info(f"listing object versions {resp}")
+        delete_markers = resp.get("DeleteMarkers", [])
+        delete_marker_found = False
+        for dm in delete_markers:
+            if dm.get("Key") == object_name:
+                delete_marker_found = True
+                version_id = dm.get("VersionId")
+                if version_id not in (None, "", "null"):
+                    raise AssertionError(
+                        f"Expected delete marker to have version-id null "
+                        f"(list-object-versions), got: {version_id!r}"
+                    )
+                log.info(
+                    "Validation (list-object-versions): delete marker with "
+                    "version-id null is present as expected"
+                )
+                break
+        if not delete_marker_found:
+            raise AssertionError(
+                f"Delete marker for object {object_name} not found in "
+                "list_object_versions response"
+            )
+        bucket_list_out = utils.exec_shell_cmd(
+            f"radosgw-admin bucket list --bucket {bucket_name}"
+        )
+        log.info("Bucket list (before applying LC):\n%s", bucket_list_out)
+        log.info("Step 5: Apply LC rule with ExpiredObjectDeleteMarker: true")
+        s3cmd_reusable.set_lc_lifecycle(lifecycle_rule, config, bucket_name)
+        log.info("LC rule applied; lifecycle will remove expired delete marker")
+        sleep_time = (
+            int(config.rgw_lc_debug_interval) * int(config.test_ops.get("days", 2))
+            if getattr(config, "rgw_lc_debug_interval", None) is not None
+            else 120
+        )
+        log.info(f"Waiting {sleep_time}s for LC to process expired delete marker")
+        time.sleep(sleep_time)
+        out = json.loads(
+            utils.exec_shell_cmd(f"radosgw-admin bucket list --bucket {bucket_name}")
+        )
+        delete_marker_still_present = False
+        for entry in out:
+            if entry.get("name") == object_name and entry.get("tag") == "delete-marker":
+                delete_marker_still_present = True
+                break
+        if delete_marker_still_present:
+            raise AssertionError(
+                "Delete marker with version-id null was not removed by LC "
+                "(ExpiredObjectDeleteMarker); still present in bucket list"
+            )
+        log.info(
+            "Validation: delete marker with version-id null was deleted by LC as expected"
+        )
     else:
         for bc in range(config.bucket_count):
             bucket_name = utils.gen_bucket_name_from_userid(


### PR DESCRIPTION
LC Expiration of expired-delete-marker for version suspended bucket

Pass log: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/test_lc_version_suspended_expired_delete_marker.console.log

Regression pass log for existing config:
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/test_lc_expiration_noncurrent_when_current_object_deleted_via_s3cmd.console.log
