### PR TITLE
Inlcude changes needed for bug bz2324153 and bz2237854

### DIFF
--- a/rgw/v2/lib/rgw_config_opts.py
+++ b/rgw/v2/lib/rgw_config_opts.py
@@ -69,7 +69,17 @@ class CephConfFileOP(FileOps, ConfigParse):
             self.ceph_conf_path = ceph_conf_path
             self.ceph_conf_path_tmp = ceph_conf_path + ".rgw.tmp"
             FileOps.__init__(self, self.ceph_conf_path_tmp, type="ceph.conf")
-            ConfigParse.__init__(self, self.ceph_conf_path, ssh_con)
+            version_id, version_name = utils.get_ceph_version()
+            if version_name in ["luminous", "nautilus"]:
+                ConfigParse.__init__(self, self.ceph_conf_path, ssh_con)
+            else:
+                log.info(
+                    "Skipping remote ceph.conf parse (%s); ceph config set only",
+                    version_name,
+                )
+                ConfigParse.__init__(
+                    self, self.ceph_conf_path, ssh_con=None, no_remote_read=True
+                )
         else:
             self.ceph_conf_path = ceph_conf_path
             FileOps.__init__(self, self.ceph_conf_path, type="ceph.conf")

--- a/rgw/v2/tests/s3_swift/configs/test_sts_aswi_wrong_thumbprint.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_sts_aswi_wrong_thumbprint.yaml
@@ -1,0 +1,32 @@
+# Bug 2324153 - [8.0][rgw][sts] with incorrect thumbprints in the OIDC provider, sts aswi request is successful bypassing thumbprint verification.
+# test scripts : test_sts_aswi.py
+config:
+     bucket_count: 1
+     objects_count: 2
+     objects_size_range:
+          min: 5
+          max: 15
+     test_ops:
+          create_bucket: true
+          create_object: true
+          use_dummy_thumbprint: true
+     sts:
+          policy_document:
+                "Version": "2012-10-17"
+                "Statement": [
+                    {
+                         "Effect": "Allow",
+                         "Principal": {
+                           "Federated": ["arn:aws:iam:::oidc-provider/ip_addr:8180/realms/master"]
+                         },
+                         "Action": ["sts:AssumeRoleWithWebIdentity"],
+                    }
+                ]
+          role_policy:
+               "Version": "2012-10-17"
+               "Statement":
+                    {
+                         "Effect": "Allow",
+                         "Action": "s3:*",
+                         "Resource": "arn:aws:s3:::*",
+                    }

--- a/rgw/v2/tests/s3_swift/reusables/sts.py
+++ b/rgw/v2/tests/s3_swift/reusables/sts.py
@@ -180,10 +180,13 @@ def delete_open_id_connect_provider(iam_client):
         log.info("No openid connect providers exists to delete")
 
 
+# BZ 2324153: wrong OIDC thumbprint negative test
+DUMMY_THUMBPRINT = "0000000000000000000000000000000000000000"
+
+
 def create_open_id_connect_provider(
-    iam_client, identity_provider="Keycloak", keycloak=None
+    iam_client, identity_provider="Keycloak", keycloak=None, use_dummy_thumbprint=False
 ):
-    # obtain oidc idp thumbprint
     global obtain_oidc_thumbprint_sh
     if identity_provider == "Keycloak":
         with open("obtain_oidc_thumbprint.sh", "w") as rsh:
@@ -197,9 +200,13 @@ def create_open_id_connect_provider(
         out = utils.exec_shell_cmd("cat /home/cephuser/configs/rgw/ibm_isv/oidc_url")
         url = out.strip()
         client_id_list = []
-    utils.exec_shell_cmd("chmod +rwx obtain_oidc_thumbprint.sh")
-    thumbprints = utils.exec_shell_cmd("./obtain_oidc_thumbprint.sh")
-    thumbprints = thumbprints.strip().split("\n")
+    if use_dummy_thumbprint:
+        thumbprints = [DUMMY_THUMBPRINT]
+        log.info("OIDC provider using dummy thumbprint (BZ 2324153)")
+    else:
+        utils.exec_shell_cmd("chmod +rwx obtain_oidc_thumbprint.sh")
+        thumbprints = utils.exec_shell_cmd("./obtain_oidc_thumbprint.sh")
+        thumbprints = thumbprints.strip().split("\n")
     # create openid connect provider
     oidc_response = iam_client.create_open_id_connect_provider(
         Url=url,
@@ -249,7 +256,8 @@ class Keycloak:
                 client_name=self.client_id, client_scope_name=set_audience_scope_name
             )
             self.set_session_tags_in_token(self.client_id)
-            self.realm_keys_workaround()
+            # Commenting this as its fixed as part of https://bugzilla.redhat.com/show_bug.cgi?id=2237854
+            # self.realm_keys_workaround()
         if attributes is None:
             self.remove_user_attributes(username=f"service-account-{self.client_id}")
         else:

--- a/rgw/v2/tests/s3_swift/test_sts_aswi.py
+++ b/rgw/v2/tests/s3_swift/test_sts_aswi.py
@@ -20,6 +20,7 @@ Usage: test_sts_aswi.py -c <input_yaml>
     test_sts_aswi_isv.yaml
     test_sts_aswi_isv_verify_role_policy_allow_actions.yaml
     test_sts_aswi_isv_verify_role_policy_deny_actions.yaml
+    test_sts_aswi_wrong_thumbprint.yaml
 
 Operation:
     s1: Create 2 Users.
@@ -113,7 +114,12 @@ def test_exec(config, ssh_con):
         )
         ceph_config_set.set_to_ceph_conf("global", "log_to_file", "true", ssh_con)
 
-    srv_restarted = rgw_service.restart(ssh_con)
+    _, ceph_version_name = utils.get_ceph_version()
+    if ceph_version_name in ["luminous", "nautilus"]:
+        srv_restarted = rgw_service.restart(ssh_con)
+    else:
+        srv_restarted = rgw_service.restart(None)
+
     time.sleep(30)
     if srv_restarted is False:
         raise TestExecError("RGW service restart failed")
@@ -177,7 +183,12 @@ def test_exec(config, ssh_con):
         policy_document = policy_document.replace("ip_addr", local_ip_addr)
         policy_document = policy_document.replace("azp_claim", jwt["azp"])
         policy_document = policy_document.replace("sub_claim", jwt["sub"])
-        stsaswi.create_open_id_connect_provider(iam_client, identity_provider, keycloak)
+        stsaswi.create_open_id_connect_provider(
+            iam_client,
+            identity_provider,
+            keycloak,
+            use_dummy_thumbprint=config.test_ops.get("use_dummy_thumbprint", False),
+        )
     elif identity_provider == "IBM_Security_Verify":
         utils.exec_shell_cmd(
             "cp /home/cephuser/configs/rgw/ibm_isv/get_isv_web_token.sh /home/cephuser/get_isv_web_token.sh"
@@ -190,7 +201,11 @@ def test_exec(config, ssh_con):
         url = out.strip()
         idp_url_for_arn = url.replace("https://", "")
         policy_document = policy_document.replace("idp_url", idp_url_for_arn)
-        stsaswi.create_open_id_connect_provider(iam_client, identity_provider)
+        stsaswi.create_open_id_connect_provider(
+            iam_client,
+            identity_provider,
+            use_dummy_thumbprint=config.test_ops.get("use_dummy_thumbprint", False),
+        )
     stsaswi.list_open_id_connect_provider(iam_client)
 
     log.info(f"assume-role-policy-doc: {policy_document}")
@@ -224,12 +239,24 @@ def test_exec(config, ssh_con):
 
     sts_creds_created_time = time.time()
     sts_creds_validity_seconds = config.test_ops.get("sts_creds_validity_seconds", 3600)
-    assume_role_response = sts_client.assume_role_with_web_identity(
-        RoleArn=create_role_response["Role"]["Arn"],
-        RoleSessionName=user1["user_id"],
-        DurationSeconds=sts_creds_validity_seconds,
-        WebIdentityToken=web_token,
-    )
+    use_dummy_thumbprint = config.test_ops.get("use_dummy_thumbprint", False)
+    assume_role_response = None
+    try:
+        assume_role_response = sts_client.assume_role_with_web_identity(
+            RoleArn=create_role_response["Role"]["Arn"],
+            RoleSessionName=user1["user_id"],
+            DurationSeconds=sts_creds_validity_seconds,
+            WebIdentityToken=web_token,
+        )
+    except ClientError as e:
+        if use_dummy_thumbprint:
+            log.info("BZ 2324153: aswi rejected as expected: %s", e)
+            return
+        raise
+    if use_dummy_thumbprint and assume_role_response:
+        raise TestExecError(
+            "BZ 2324153: aswi succeeded with dummy thumbprint (expected failure)"
+        )
     log.info(f"assume role with web identity response: {assume_role_response}")
 
     assumed_role_user_info = {

--- a/rgw/v2/utils/utils.py
+++ b/rgw/v2/utils/utils.py
@@ -225,14 +225,40 @@ class FileOps(object):
 
 
 class ConfigParse(object):
-    def __init__(self, fname, ssh_con=None):
+    def __init__(self, fname, ssh_con=None, no_remote_read=False):
         self.fname = fname
         self.cfg = configparser.ConfigParser()
+        if no_remote_read:
+            # Empty parser; used when cluster config is applied via ceph config set only
+            return
         if ssh_con is not None:
             tmp_file = fname + ".rgw.tmp"
+            remote_path = fname
             sftp_client = ssh_con.open_sftp()
-            fname = sftp_client.get(fname, tmp_file)
-            sftp_client.close()
+            try:
+                sftp_client.get(remote_path, tmp_file)
+            except Exception as e:
+                # SFTP cannot stat/read (e.g. /etc/ceph/ceph.conf is root-only); use sudo
+                log.info(
+                    "SFTP get %s failed (%s); reading via sudo cat on remote",
+                    remote_path,
+                    e,
+                )
+                stdin, stdout, stderr = ssh_con.exec_command(
+                    "sudo cat %s" % remote_path
+                )
+                exit_status = stdout.channel.recv_exit_status()
+                out_b = stdout.read()
+                err_b = stderr.read().decode()
+                if exit_status != 0:
+                    raise OSError(
+                        "Could not read %s on remote (sudo cat failed): %s"
+                        % (remote_path, err_b)
+                    )
+                with open(tmp_file, "wb") as fp:
+                    fp.write(out_b)
+            finally:
+                sftp_client.close()
             self.cfg.read(tmp_file)
             self.fname = tmp_file
         else:


### PR DESCRIPTION
Automating 2 Bug BZ2324153 and BZ2237854

[Bug 2324153](https://bugzilla.redhat.com/show_bug.cgi?id=2324153) - [8.0][rgw][sts] with incorrect thumbprints in the OIDC provider, sts aswi request is successful bypassing thumbprint verification
 
[Bug 2237854](https://bugzilla.redhat.com/show_bug.cgi?id=2237854) - [rgw][sts]: assume_role_with_web_identity call is failing as validation of signature is failing with invalid padding

log: 
testcase log: http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/test_sts_aswi_wrong_thumbprint.console.log
different testcase : http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/test_sts_using_boto.console.log
end to end log: http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-6CZRC9/