### PR TITLE
Adding another config yaml for global CORS

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_gcors_config.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_gcors_config.yaml
@@ -13,8 +13,8 @@ config:
 
   # Global CORS configuration options
   test_ops:
-    gcors_allow_origins: "*"
-    gcors_allow_headers: "x-amz-*, Content-*, Authorization"
+    gcors_allow_origins: '"*"'
+    gcors_allow_headers: "Content-Type,Authorization"
     gcors_allow_methods: "GET,PUT,POST,DELETE,HEAD"
     enable_gcors: true
     create_bucket: true

--- a/rgw/v2/tests/s3_swift/configs/test_gcors_config_strict.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_gcors_config_strict.yaml
@@ -1,0 +1,25 @@
+# Global CORS (GCORS) Configuration Test - Strict Settings
+# Script: test_gcors_config.py
+# This test configures RGW global CORS with strict/specific settings
+
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 5
+  objects_size_range:
+    min: 5
+    max: 15
+
+  # Strict Global CORS configuration options
+  # Specific origins instead of wildcard
+  # Specific headers only
+  # Limited methods (no DELETE)
+  test_ops:
+    gcors_allow_origins: "https://example.com,https://app.example.com"
+    gcors_allow_headers: "x-amz-date,x-amz-content-sha256,Authorization,Content-Type"
+    gcors_allow_methods: "GET,PUT,POST,HEAD"
+    enable_gcors: true
+    create_bucket: true
+    create_object: true
+    download_object: true
+    delete_bucket_object: false


### PR DESCRIPTION
I had forgotten to add 1 config yaml for Global CORS in my earlier PR, so raising a new one 

Pass logs :
https://magna002.ceph.redhat.com/cephci-jenkins/tchandra/test_gcors.txt
https://magna002.ceph.redhat.com/cephci-jenkins/tchandra/test_gcors_strict_config.txt