### PR TITLE
Increase lc_debug_interval

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_lc_rule_reverse_transition.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_lc_rule_reverse_transition.yaml
@@ -4,6 +4,7 @@ config:
   haproxy: true
   user_count: 1
   bucket_count: 1
+  rgw_lc_debug_interval: 120
   objects_count: 10
   parallel_lc: False
   test_lc_transition: True


### PR DESCRIPTION
Test case was failing due to intermittent timing issue wen lc_debug_interval was 30,
increasing it it 120.
Seen consistent pass in 5 Consecutive runs.

Pass logs:
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/test_lc_rule_reverse_transition.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/test_lc_rule_reverse_transition.console.log2
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/test_lc_rule_reverse_transition.console.log3
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/test_lc_rule_reverse_transition.console.log4
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/test_lc_rule_reverse_transition.console.log5