### PR TITLE
[Tier-2]RGW. Add Lua functionality for blocking requests

### DIFF
--- a/rgw/v2/tests/aws/configs/test_aws_lua_block_object_lock_request.yaml
+++ b/rgw/v2/tests/aws/configs/test_aws_lua_block_object_lock_request.yaml
@@ -1,0 +1,24 @@
+# polarion id: CEPH-83632419
+# RGW 9.1 block_request.lua — matches manual block-request test plan.
+# Negative: s3api create-bucket without lock (AccessDenied, bucket not created).
+# Positive: --object-lock-enabled-for-bucket, stats, objects, default retention.
+# Optional: remove script + plain create succeeds (w/out Lua).
+# Script: test_lua_script_prerequest.py
+config:
+    user_count: 1
+    bucket_count: 1
+    objects_count: 2
+    local_file_delete: true
+    objects_size_range:
+        min: 5K
+        max: 5K
+    user_remove: true
+    test_ops:
+        lua_block_object_lock: true
+        restart_rgw: true
+        negative_create_without_lock: true
+        verify_without_lua: true
+        create_object: true
+        put_default_retention: true
+        lock_mode: COMPLIANCE
+        retention_days: 1

--- a/rgw/v2/tests/aws/configs/test_aws_lua_block_object_lock_request_governance.yaml
+++ b/rgw/v2/tests/aws/configs/test_aws_lua_block_object_lock_request_governance.yaml
@@ -1,0 +1,21 @@
+# polarion id: CEPH-83632419
+# RGW 9.1: Lua block create-bucket without object lock; default retention GOVERNANCE.
+# Script: test_lua_script_prerequest.py
+config:
+    user_count: 1
+    bucket_count: 1
+    objects_count: 2
+    local_file_delete: true
+    objects_size_range:
+        min: 5K
+        max: 5K
+    user_remove: true
+    test_ops:
+        lua_block_object_lock: true
+        restart_rgw: true
+        negative_create_without_lock: true
+        verify_without_lua: true
+        create_object: true
+        put_default_retention: true
+        lock_mode: GOVERNANCE
+        retention_days: 1

--- a/rgw/v2/tests/aws/reusable.py
+++ b/rgw/v2/tests/aws/reusable.py
@@ -27,13 +27,17 @@ from v2.lib.exceptions import AWSCommandExecError, TestExecError
 from v2.lib.manage_data import io_generator
 
 
-def create_bucket(aws_auth, bucket_name, end_point, retries=3, wait_time=5):
+def create_bucket(
+    aws_auth, bucket_name, end_point, retries=3, wait_time=5, object_lock_enabled=False
+):
     """
     Creates bucket
     ex: /usr/local/bin/aws s3api create-bucket --bucket verbkt1 --endpoint-url http://x.x.x.x:xx
+    ex: /usr/local/bin/aws s3api create-bucket --bucket bkt1 --object-lock-enabled-for-bucket ...
     Args:
         bucket_name(str): Name of the bucket to be created
         end_point(str): endpoint
+        object_lock_enabled(bool): pass --object-lock-enabled-for-bucket on create
     """
 
     for attempt in range(1, retries + 1):
@@ -50,9 +54,12 @@ def create_bucket(aws_auth, bucket_name, end_point, retries=3, wait_time=5):
         log.error(f"Endpoint {end_point} is not reachable after {retries} attempts.")
         return
 
+    bucket_params = f"--bucket {bucket_name} --endpoint-url {end_point}"
+    if object_lock_enabled:
+        bucket_params += " --object-lock-enabled-for-bucket"
     command = aws_auth.command(
         operation="create-bucket",
-        params=[f"--bucket {bucket_name} --endpoint-url {end_point}"],
+        params=[bucket_params],
     )
     last_error = None
     for attempt in range(1, retries + 1):
@@ -69,6 +76,97 @@ def create_bucket(aws_auth, bucket_name, end_point, retries=3, wait_time=5):
             if attempt < retries:
                 time.sleep(wait_time)
     raise AWSCommandExecError(message=str(last_error))
+
+
+def verify_bucket_object_lock_stats(bucket_name, expected_objects=None):
+    """
+    Verify bucket stats show versioning enabled and object lock enabled.
+    Optionally assert minimum object count in rgw.main usage.
+    """
+    out = utils.exec_shell_cmd(f"radosgw-admin bucket stats --bucket {bucket_name}")
+    data = json.loads(out)
+    info = data[0] if isinstance(data, list) else data
+    if info.get("versioning") != "enabled":
+        raise AssertionError(
+            f"Bucket {bucket_name}: expected versioning enabled, got {info.get('versioning')}"
+        )
+    if not info.get("object_lock_enabled"):
+        raise AssertionError(
+            f"Bucket {bucket_name}: expected object_lock_enabled true, got {info.get('object_lock_enabled')}"
+        )
+    if expected_objects is not None:
+        usage = info.get("usage", {})
+        main_usage = usage.get("rgw.main", {})
+        num_objects = main_usage.get("num_objects", 0)
+        if num_objects < expected_objects:
+            raise AssertionError(
+                f"Bucket {bucket_name}: expected at least {expected_objects} objects, got {num_objects}"
+            )
+    log.info(
+        f"Bucket {bucket_name}: versioning=enabled, object_lock_enabled=true"
+        + (f", num_objects>={expected_objects}" if expected_objects is not None else "")
+    )
+    return info
+
+
+def get_object_lock_configuration(aws_auth, bucket_name, end_point):
+    """Return parsed get-object-lock-configuration response."""
+    command = aws_auth.command(
+        operation="get-object-lock-configuration",
+        params=[f"--bucket {bucket_name} --endpoint-url {end_point}"],
+    )
+    out = utils.exec_shell_cmd(command)
+    if not out:
+        raise Exception(f"get-object-lock-configuration failed for {bucket_name}")
+    return json.loads(out)
+
+
+def put_object_lock_default_retention(
+    aws_auth, bucket_name, end_point, mode="COMPLIANCE", days=1
+):
+    """Apply bucket default retention policy via put-object-lock-configuration."""
+    lock_cfg = json.dumps(
+        {
+            "ObjectLockEnabled": "Enabled",
+            "Rule": {"DefaultRetention": {"Mode": mode, "Days": days}},
+        }
+    )
+    command = aws_auth.command(
+        operation="put-object-lock-configuration",
+        params=[
+            f"--bucket {bucket_name} --endpoint-url {end_point} "
+            f"--object-lock-configuration '{lock_cfg}'"
+        ],
+    )
+    out = utils.exec_shell_cmd(command)
+    if out is False:
+        raise Exception(f"put-object-lock-configuration failed for {bucket_name}")
+    log.info(f"Set default retention {mode} {days} day(s) on {bucket_name}")
+
+
+LUA_ENABLE_OBJECT_LOCK_PREREQUEST = """
+-- enablog object lock on bucket creation
+
+if Request.RGWOp == "create_bucket" then
+  Request.HTTP.Metadata["x-amz-bucket-object-lock-enabled"] = "true"
+  RGWDebugLog("object lock is enabled on bucket: " .. Request.Bucket.Name)
+end
+"""
+
+LUA_ENABLE_OBJECT_LOCK_DEBUG_PATTERN = r"object lock is enabled on bucket"
+
+LUA_BLOCK_OBJECT_LOCK_PREREQUEST = """
+-- enforcing object lock on bucket creation
+
+if Request.RGWOp == "create_bucket" and
+  Request.HTTP.Metadata["x-amz-bucket-object-lock-enabled"] ~= "true" then
+  RGWDebugLog("object lock is missing on bucket: " .. Request.Bucket.Name)
+  Request.Response.Message = "Bucket must have object lock enabled"
+  return RGW_ABORT_REQUEST
+end
+"""
+
+LUA_BLOCK_OBJECT_LOCK_DEBUG_PATTERN = r"object lock is missing on bucket"
 
 
 def delete_bucket(aws_auth, bucket_name, end_point):
@@ -1120,7 +1218,7 @@ def perform_gc_process_and_list():
 def create_s3_replication_json(config, bucket_name, json_file="replication.json"):
     """
     Extract replication config from a YAML file and apply it to a bucket.
-    Ceph 9.0+ (20.2.1- onward) requires Destination.Bucket ARN; 8.1 uses plain name.
+    Ceph 8.1 (< 20.2.1): plain bucket name. Ceph 9.0+ (>= 20.2.1): bucket ARN.
     """
     replication_config = copy.deepcopy(config.test_ops["s3_replication"])
     dest_bucket = bucket_name
@@ -1136,7 +1234,6 @@ def create_s3_replication_json(config, bucket_name, json_file="replication.json"
             pass
     replication_config["Rules"][0]["Destination"]["Bucket"] = dest_bucket
     log.info(f"replication configuration data: {replication_config}")
-    # Save replication config as JSON
     with open(json_file, "w") as f:
         json.dump(replication_config, f, indent=4)
 
@@ -1653,17 +1750,25 @@ def check_log_directory_exists(log_dir, ssh_con=None):
 
 
 def search_lua_messages_in_log_file(
-    log_file, message_pattern, ssh_con=None, node_name=None
+    log_file, message_pattern, ssh_con=None, node_name=None, since_epoch=None
 ):
     """
     Search for lua debug messages in a log file.
     Returns list of matching lines, or empty list if none found.
     """
     try:
-        if ssh_con:
-            grep_cmd = f"sudo grep 'Lua INFO:' {log_file} 2>/dev/null | tail -100"
+        # Bucket names contain '.'; only treat intentional regex (e.g. '.*') as regex.
+        use_regex_pattern = bool(
+            message_pattern
+            and re.search(r"(\.\*|\.\+|\[\^?|\(\?|\(\)|\||\^|\$|\\)", message_pattern)
+        )
+        if message_pattern and not use_regex_pattern:
+            grep_cmd = (
+                f"sudo grep 'Lua INFO:' {log_file} 2>/dev/null "
+                f"| grep -F '{message_pattern}'"
+            )
         else:
-            grep_cmd = f"grep 'Lua INFO:' {log_file} 2>/dev/null | tail -100"
+            grep_cmd = f"sudo grep 'Lua INFO:' {log_file} 2>/dev/null"
 
         if ssh_con:
             stdin, stdout, stderr = ssh_con.exec_command(grep_cmd)
@@ -1687,13 +1792,15 @@ def search_lua_messages_in_log_file(
         if grep_output:
             all_lines = grep_output.strip().split("\n")
             if message_pattern:
-                pattern_re = re.compile(message_pattern)
-                matching_lines = []
-                for line in all_lines:
-                    if pattern_re.search(line):
-                        matching_lines.append(line)
-                    else:
-                        log.debug(f"Line does not match pattern: {line[:100]}...")
+                if use_regex_pattern:
+                    pattern_re = re.compile(message_pattern)
+                    matching_lines = [
+                        line for line in all_lines if pattern_re.search(line)
+                    ]
+                else:
+                    matching_lines = [
+                        line for line in all_lines if message_pattern in line
+                    ]
                 log.info(
                     f"Found {len(all_lines)} Lua INFO messages, {len(matching_lines)} match pattern"
                     + (f" on {node_name}" if node_name else "")
@@ -1702,8 +1809,49 @@ def search_lua_messages_in_log_file(
                     log.warning(
                         f"Pattern '{message_pattern}' did not match any of {len(all_lines)} Lua INFO messages. Sample message: {all_lines[0][:150]}"
                     )
+                if since_epoch is not None:
+                    from datetime import datetime
+
+                    cutoff = since_epoch - 1
+                    recent_lines = []
+                    for line in matching_lines:
+                        ts_match = re.match(r"^(\S+)\s", line)
+                        if not ts_match:
+                            continue
+                        ts = ts_match.group(1)
+                        if ts.endswith("+0000"):
+                            ts = ts[:-5] + "+00:00"
+                        try:
+                            if datetime.fromisoformat(ts).timestamp() >= cutoff:
+                                recent_lines.append(line)
+                        except ValueError:
+                            continue
+                    matching_lines = recent_lines
+                if since_epoch is not None and matching_lines:
+                    log.info(
+                        f"{len(matching_lines)} matching message(s) after negative create"
+                        + (f" on {node_name}" if node_name else "")
+                    )
                 return matching_lines
             else:
+                if since_epoch is not None:
+                    from datetime import datetime
+
+                    cutoff = since_epoch - 1
+                    recent_lines = []
+                    for line in all_lines:
+                        ts_match = re.match(r"^(\S+)\s", line)
+                        if not ts_match:
+                            continue
+                        ts = ts_match.group(1)
+                        if ts.endswith("+0000"):
+                            ts = ts[:-5] + "+00:00"
+                        try:
+                            if datetime.fromisoformat(ts).timestamp() >= cutoff:
+                                recent_lines.append(line)
+                        except ValueError:
+                            continue
+                    all_lines = recent_lines
                 log.info(
                     f"Found {len(all_lines)} Lua INFO messages"
                     + (f" on {node_name}" if node_name else "")
@@ -1719,7 +1867,9 @@ def search_lua_messages_in_log_file(
         return []
 
 
-def check_logs_on_node(log_dir, message_pattern, ssh_con=None, node_name=None):
+def check_logs_on_node(
+    log_dir, message_pattern, ssh_con=None, node_name=None, since_epoch=None
+):
     """
     Check logs on a single node (local or remote via SSH).
     Returns count of lua messages found, or None if checking was skipped.
@@ -1748,7 +1898,7 @@ def check_logs_on_node(log_dir, message_pattern, ssh_con=None, node_name=None):
     total_messages = 0
     for log_file in rgw_log_files:
         lines = search_lua_messages_in_log_file(
-            log_file, message_pattern, ssh_con, node_name
+            log_file, message_pattern, ssh_con, node_name, since_epoch
         )
         if lines:
             total_messages += len(lines)
@@ -1781,13 +1931,26 @@ def get_all_rgw_hosts():
 
 
 def check_rgw_debug_logs_and_reset(
-    message_pattern=None, ssh_con=None, haproxy=None, expected_count=None
+    message_pattern=None,
+    ssh_con=None,
+    haproxy=None,
+    expected_count=None,
+    check_all_rgw_nodes=False,
+    optional=False,
+    since_epoch=None,
+    exact_count=False,
 ):
     """
     Check RGW debug logs for lua script messages and reset debug_rgw to default level.
     message_pattern: regex pattern to search (None = any 'Lua INFO:' messages).
     ssh_con: SSH connection object for remote execution (optional).
     haproxy: If True, check logs on all RGW nodes (since requests can go to any node).
+    check_all_rgw_nodes: If True, aggregate logs from every RGW host (optional; use with
+        haproxy or multi-node endpoints only).
+    optional: If True, log a warning when expected messages are missing but do not raise
+        (use when functional checks already prove behavior, e.g. block Lua on RGW 9.1).
+    since_epoch: Only count log lines at or after this Unix timestamp (ignores stale entries).
+    exact_count: If True, require found count to equal expected_count (not just >=).
     expected_count: Expected number of lua debug messages. If provided, raises TestExecError if count doesn't match.
     Raises TestExecError if log checking or debug_rgw reset fails, or if expected_count is not met.
     """
@@ -1796,157 +1959,117 @@ def check_rgw_debug_logs_and_reset(
     try:
         fsid = utils.get_cluster_fsid()
         log_dir = f"/var/log/ceph/{fsid}"
-        total_lua_messages = 0
-        if haproxy:
-            log.info("HAProxy is enabled - checking logs on all RGW nodes")
-            try:
-                rgw_hosts = get_all_rgw_hosts()
-                if not rgw_hosts:
-                    log.warning("No RGW hosts found. Skipping log checking.")
-                else:
-                    log.info(f"Found {len(rgw_hosts)} RGW host(s): {rgw_hosts}")
-                    nodes_checked = 0
-                    for host in rgw_hosts:
-                        try:
-                            log.info(f"Checking logs on RGW node: {host}")
-                            node_ssh_con = utils.connect_remote(host)
-                            node_messages = check_logs_on_node(
-                                log_dir, message_pattern, node_ssh_con, host
-                            )
-                            if node_messages is not None:
-                                nodes_checked += 1
-                                total_lua_messages += node_messages
-                            node_ssh_con.close()
-                        except Exception as e:
-                            log.warning(f"Failed to check logs on RGW node {host}: {e}")
+        found_count = 0
+        nodes_searched = False
+        search_all = haproxy or check_all_rgw_nodes
 
-                    if nodes_checked == 0:
-                        log.warning(
-                            "Could not check logs on any RGW nodes (all skipped or failed)"
-                        )
-                        if expected_count is not None:
-                            raise TestExecError(
-                                f"Could not check logs on any RGW nodes, expected {expected_count} messages"
-                            )
-                    elif total_lua_messages == 0:
-                        if message_pattern:
-                            log.warning(
-                                f"No lua debug messages found matching pattern '{message_pattern}' in RGW logs across all nodes"
-                            )
-                        else:
-                            log.warning(
-                                "No lua debug messages found in RGW logs across all nodes"
-                            )
-                        if expected_count is not None:
-                            raise TestExecError(
-                                f"No lua debug messages found, expected {expected_count} messages"
-                            )
-                    else:
-                        log.info(
-                            f"Total lua debug messages found across all RGW nodes: {total_lua_messages}"
-                        )
-                        if expected_count is not None:
-                            if total_lua_messages < expected_count:
-                                raise TestExecError(
-                                    f"Found {total_lua_messages} lua debug messages, but expected at least {expected_count} messages"
-                                )
-                            log.info(
-                                f"Validation passed: Found {total_lua_messages} messages (expected: {expected_count})"
-                            )
-            except TestExecError as e:
-                raise
-            except Exception as e:
-                log.warning(
-                    f"Failed to check RGW debug logs on all nodes: {e}. Continuing with debug_rgw reset."
+        if not search_all:
+            local_count = check_logs_on_node(
+                log_dir,
+                message_pattern,
+                ssh_con=ssh_con,
+                since_epoch=since_epoch,
+            )
+            if local_count is not None and local_count > 0:
+                found_count = local_count
+                nodes_searched = True
+                log.info(f"Total lua debug messages found: {found_count}")
+            elif local_count is not None and expected_count is None:
+                nodes_searched = True
+            elif local_count is not None:
+                log.info(
+                    "No matching lua debug messages on local node. Checking all RGW nodes..."
                 )
-        else:
-            node_messages = check_logs_on_node(log_dir, message_pattern, ssh_con)
-            if node_messages is None:
-                if expected_count is not None:
-                    log.info(
-                        "Log directory not available on local node. Trying to check logs on RGW nodes..."
-                    )
-                    try:
-                        rgw_hosts = get_all_rgw_hosts()
-                        if rgw_hosts:
-                            log.info(f"Found {len(rgw_hosts)} RGW host(s): {rgw_hosts}")
-                            nodes_checked = 0
-                            for host in rgw_hosts:
-                                try:
-                                    log.info(f"Checking logs on RGW node: {host}")
-                                    node_ssh_con = utils.connect_remote(host)
-                                    host_messages = check_logs_on_node(
-                                        log_dir, message_pattern, node_ssh_con, host
-                                    )
-                                    if host_messages is not None:
-                                        nodes_checked += 1
-                                        total_lua_messages += host_messages
-                                    node_ssh_con.close()
-                                except Exception as e:
-                                    log.warning(
-                                        f"Failed to check logs on RGW node {host}: {e}"
-                                    )
+            else:
+                log.info(
+                    "Log directory not available on local node. Trying to check logs on RGW nodes..."
+                )
 
-                            if nodes_checked == 0:
-                                raise TestExecError(
-                                    f"Could not check logs on any RGW nodes, expected {expected_count} messages"
-                                )
-                            elif total_lua_messages == 0:
-                                raise TestExecError(
-                                    f"No lua debug messages found on RGW nodes, expected {expected_count} messages"
-                                )
-                            elif total_lua_messages < expected_count:
-                                raise TestExecError(
-                                    f"Found {total_lua_messages} lua debug messages on RGW nodes, but expected at least {expected_count} messages"
-                                )
-                            else:
-                                log.info(
-                                    f"Total lua debug messages found on RGW nodes: {total_lua_messages}"
-                                )
-                                log.info(
-                                    f"Validation passed: Found {total_lua_messages} messages (expected: {expected_count})"
-                                )
-                        else:
-                            raise TestExecError(
-                                f"No RGW hosts found, expected {expected_count} messages"
-                            )
-                    except TestExecError:
-                        raise
+        if search_all or not nodes_searched:
+            if search_all:
+                reason = (
+                    "HAProxy is enabled"
+                    if haproxy
+                    else "check_all_rgw_nodes is enabled"
+                )
+                log.info(f"{reason} - checking logs on all RGW nodes")
+            rgw_hosts = get_all_rgw_hosts()
+            if not rgw_hosts:
+                if expected_count is not None:
+                    raise TestExecError(
+                        f"No RGW hosts found, expected {expected_count} messages"
+                    )
+            else:
+                log.info(f"Found {len(rgw_hosts)} RGW host(s): {rgw_hosts}")
+                nodes_checked = 0
+                found_count = 0
+                for host in rgw_hosts:
+                    try:
+                        log.info(f"Checking logs on RGW node: {host}")
+                        node_ssh_con = utils.connect_remote(host)
+                        host_messages = check_logs_on_node(
+                            log_dir,
+                            message_pattern,
+                            node_ssh_con,
+                            host,
+                            since_epoch,
+                        )
+                        if host_messages is not None:
+                            nodes_checked += 1
+                            found_count += host_messages
+                        node_ssh_con.close()
                     except Exception as e:
+                        log.warning(f"Failed to check logs on RGW node {host}: {e}")
+                if nodes_checked == 0:
+                    if expected_count is not None:
                         raise TestExecError(
-                            f"Failed to check logs on RGW nodes: {e}, expected {expected_count} messages"
+                            f"Could not check logs on any RGW nodes, expected {expected_count} messages"
                         )
                 else:
-                    log.info(
-                        "Log checking was skipped (log directory not available on this node)"
-                    )
-            elif node_messages == 0:
+                    nodes_searched = True
+                    if search_all or expected_count is not None:
+                        log.info(
+                            f"Total lua debug messages found across all RGW nodes: {found_count}"
+                        )
+
+        if expected_count is not None:
+            if not nodes_searched:
+                raise TestExecError(
+                    f"Could not check RGW logs, expected {expected_count} messages"
+                )
+            if found_count == 0:
                 if message_pattern:
                     log.warning(
                         f"No lua debug messages found matching pattern '{message_pattern}' in RGW logs"
                     )
                 else:
                     log.warning("No lua debug messages found in RGW logs")
-                if expected_count is not None:
-                    raise TestExecError(
-                        f"No lua debug messages found, expected {expected_count} messages"
-                    )
-            else:
-                log.info(f"Total lua debug messages found: {node_messages}")
-                if expected_count is not None:
-                    if node_messages < expected_count:
-                        raise TestExecError(
-                            f"Found {node_messages} lua debug messages, but expected at least {expected_count} messages"
-                        )
-                    log.info(
-                        f"Validation passed: Found {node_messages} messages (expected: {expected_count})"
-                    )
+                raise TestExecError(
+                    f"No lua debug messages found, expected {expected_count} messages"
+                )
+            if exact_count and found_count != expected_count:
+                raise TestExecError(
+                    f"Found {found_count} lua debug messages, but expected exactly {expected_count}"
+                )
+            if not exact_count and found_count < expected_count:
+                raise TestExecError(
+                    f"Found {found_count} lua debug messages, but expected at least {expected_count}"
+                )
+            log.info(
+                f"Validation passed: Found {found_count} messages (expected: {expected_count})"
+            )
 
     except TestExecError as e:
         validation_error = e
-        log.warning(
-            f"Validation failed: {e}. Will reset debug_rgw and then fail the test."
-        )
+        if optional:
+            log.warning(
+                f"Optional lua debug log check: {e}. Continuing (functional checks are authoritative)."
+            )
+            validation_error = None
+        else:
+            log.warning(
+                f"Validation failed: {e}. Will reset debug_rgw and then fail the test."
+            )
     except Exception as e:
         log.warning(
             f"Failed to check RGW debug logs: {e}. Continuing with debug_rgw reset."
@@ -1959,7 +2082,7 @@ def check_rgw_debug_logs_and_reset(
         out_ps = utils.exec_shell_cmd(cmd_ps)
         rgw_daemons = json.loads(out_ps)
         for daemon in rgw_daemons:
-            daemon_name = daemon.get("service_name")
+            daemon_name = daemon.get("daemon_name") or daemon.get("service_name")
             if daemon_name:
                 debug_cmd = f"ceph config rm client.{daemon_name} debug_rgw"
                 log.info(f"Resetting debug_rgw for {daemon_name}: {debug_cmd}")

--- a/rgw/v2/tests/aws/test_lua_script_prerequest.py
+++ b/rgw/v2/tests/aws/test_lua_script_prerequest.py
@@ -6,29 +6,26 @@ Usage: test_lua_script_prerequest.py -c <input_yaml>
     configs/test_aws_lua_object_lock.yaml
     configs/test_aws_lua_object_lock_governance.yaml
     configs/test_aws_lua_object_lock_minimal.yaml
+    configs/test_aws_lua_block_object_lock_request.yaml
+    configs/test_aws_lua_block_object_lock_request_governance.yaml
 
 Operation:
     - object_placement_on_storage_class: Lua script auto-tiers objects by size.
-    - lua_object_lock: Lua script enables object lock on bucket creation (regular bucket becomes versioned + object lock).
-      Versioned objects: yes (bucket has versioning + object lock). Optional test_ops.test_multipart: true uses
-      multipart upload for the object with default retention (objects_size_range.max, e.g. 10M).
-      Steps (Test: obj lock LUA): set prerequest script -> create bucket (regular) -> verify versioning + object_lock
-      via radosgw-admin and s3api -> optional: object-level put-object-retention + get; put-object-lock-configuration
-      (Rule/DefaultRetention) -> verify get-object-lock-configuration returns Rule -> upload with default retention
-      (put_object or multipart when test_multipart) -> get-object-retention -> delete without version-id (DeleteMarker)
-      -> delete by version-id (forbidden) -> verify RGW log "object lock is enabled on bucket" -> remove script.
+    - lua_object_lock: Lua enable script on plain create-bucket; verify versioning + object lock.
+    - lua_block_object_lock: Lua block script — negative plain create-bucket, positive
+      --object-lock-enabled-for-bucket, optional verify without Lua (polarion CEPH-83632419).
 """
 
 
 import argparse
 import json
 import logging
-import math
 import os
 import random
 import re
 import subprocess
 import sys
+import time
 import traceback
 from datetime import datetime, timedelta, timezone
 
@@ -49,8 +46,129 @@ from v2.utils.utils import RGWService
 
 log = logging.getLogger(__name__)
 TEST_DATA_PATH = None
-# Use full path so CLI works when PATH does not include /usr/local/bin (e.g. CI)
 AWS_CLI = "/usr/local/bin/aws"
+
+
+def _run_lua_block_object_lock_tests(config, user_info, endpoint, ssh_con):
+    """RGW 9.1 Lua block: one negative create-bucket, positive object-lock bucket, optional w/out Lua."""
+    script_removed = False
+    for user in user_info:
+        user_name = user["user_id"]
+        cli_aws = AWS(ssl=config.ssl)
+        aws_auth.do_auth_aws(user)
+
+        neg_bucket = utils.gen_bucket_name_from_userid(user_name, rand_no=900)
+        pos_bucket = utils.gen_bucket_name_from_userid(user_name, rand_no=0)
+
+        if config.test_ops.get("negative_create_without_lock", True):
+            log.info(
+                "Negative: create-bucket without object lock (expect AccessDenied)"
+            )
+            bucket_list = json.loads(utils.exec_shell_cmd("radosgw-admin bucket list"))
+            if neg_bucket in bucket_list:
+                raise AssertionError(
+                    f"Bucket {neg_bucket} already exists before negative test"
+                )
+            neg_cmd = cli_aws.command(
+                operation="create-bucket",
+                params=[f"--bucket {neg_bucket} --endpoint-url {endpoint}"],
+            )
+            neg_start = time.time()
+            neg_err = utils.exec_shell_cmd(neg_cmd, return_err=True)
+            if neg_err is False:
+                raise AssertionError(
+                    f"create-bucket {neg_bucket}: command execution failed unexpectedly"
+                )
+            bucket_list = json.loads(utils.exec_shell_cmd("radosgw-admin bucket list"))
+            if neg_bucket in bucket_list:
+
+                raise AssertionError(
+                    f"Bucket {neg_bucket} was created but Lua should have blocked it"
+                )
+            neg_err_str = str(neg_err)
+            if (
+                "Bucket must have object lock enabled" not in neg_err_str
+                and "AccessDenied" not in neg_err_str
+            ):
+                raise AssertionError(
+                    f"Expected AccessDenied/object lock message, got: {neg_err_str}"
+                )
+            time.sleep(3)
+            neg_log_pattern = f"object lock is missing on bucket: {neg_bucket}"
+            aws_reusable.check_rgw_debug_logs_and_reset(
+                message_pattern=neg_log_pattern,
+                ssh_con=ssh_con,
+                haproxy=config.haproxy,
+                check_all_rgw_nodes=True,
+                expected_count=1,
+                since_epoch=neg_start,
+                exact_count=True,
+            )
+
+        log.info(f"Positive: create-bucket with object lock enabled: {pos_bucket}")
+        aws_reusable.create_bucket(
+            cli_aws, pos_bucket, endpoint, object_lock_enabled=True
+        )
+        aws_reusable.verify_bucket_object_lock_stats(pos_bucket)
+
+        lock_cfg = aws_reusable.get_object_lock_configuration(
+            cli_aws, pos_bucket, endpoint
+        )
+        olc = lock_cfg.get("ObjectLockConfiguration", {})
+        if olc.get("ObjectLockEnabled") != "Enabled":
+            raise AssertionError(f"Expected ObjectLockEnabled Enabled, got: {lock_cfg}")
+
+        if config.test_ops.get("create_object", False):
+            for oc, size in list(config.mapped_sizes.items()):
+                key_name = f"obj-lock-{oc}"
+                utils.exec_shell_cmd(f"fallocate -l {size} {key_name}")
+                try:
+                    aws_reusable.put_object(cli_aws, pos_bucket, key_name, endpoint)
+                finally:
+                    if os.path.exists(key_name):
+                        os.remove(key_name)
+            aws_reusable.verify_bucket_object_lock_stats(
+                pos_bucket, expected_objects=config.objects_count
+            )
+
+        if config.test_ops.get("put_default_retention", False):
+            mode = config.test_ops.get("lock_mode", "COMPLIANCE")
+            days = int(config.test_ops.get("retention_days", 1))
+            aws_reusable.put_object_lock_default_retention(
+                cli_aws, pos_bucket, endpoint, mode=mode, days=days
+            )
+            lock_cfg = aws_reusable.get_object_lock_configuration(
+                cli_aws, pos_bucket, endpoint
+            )
+            retention = (
+                lock_cfg.get("ObjectLockConfiguration", {})
+                .get("Rule", {})
+                .get("DefaultRetention", {})
+            )
+            if retention.get("Mode") != mode or retention.get("Days") != days:
+                raise AssertionError(f"Default retention mismatch: {lock_cfg}")
+
+        if config.test_ops.get("verify_without_lua", False):
+            log.info("Remove Lua script; create-bucket without lock should succeed")
+            aws_reusable.remove_lua_script(context="prerequest")
+            out = aws_reusable.get_lua_script(context="prerequest")
+            if out and "no script exists" not in out.lower():
+                raise AssertionError("Lua script was not removed")
+            script_removed = True
+            if config.test_ops.get("restart_rgw", True):
+                utils.restart_rgw(restart_all=True)
+                time.sleep(30)
+            free_bucket = utils.gen_bucket_name_from_userid(user_name, rand_no=901)
+            aws_reusable.create_bucket(cli_aws, free_bucket, endpoint)
+            if free_bucket not in json.loads(
+                utils.exec_shell_cmd("radosgw-admin bucket list")
+            ):
+                raise AssertionError(
+                    f"Bucket {free_bucket} should exist after script removal"
+                )
+            log.info(f"Without Lua: bucket {free_bucket} created without object lock")
+
+    return script_removed
 
 
 def test_exec(config, ssh_con):
@@ -76,6 +194,7 @@ def test_exec(config, ssh_con):
     lua_script_content = None
     lua_debug_message_pattern = None
     lua_object_lock_mode = False
+    lua_block_object_lock_mode = False
 
     if config.test_ops.get("object_placement_on_storage_class", False):
         aws_reusable.create_storage_class_single_site(
@@ -110,14 +229,12 @@ RGWDebugLog(Request.RGWOp ..
         )
     elif config.test_ops.get("lua_object_lock", False):
         lua_object_lock_mode = True
-        lua_script_content = """
--- Enable object lock on bucket creation (RGW prerequest script).
-if Request.RGWOp == "create_bucket" then
-  Request.HTTP.Metadata["x-amz-bucket-object-lock-enabled"] = "true"
-  RGWDebugLog("object lock is enabled on bucket: " .. Request.Bucket.Name)
-end
-"""
-        lua_debug_message_pattern = r"object lock is enabled on bucket"
+        lua_script_content = aws_reusable.LUA_ENABLE_OBJECT_LOCK_PREREQUEST
+        lua_debug_message_pattern = aws_reusable.LUA_ENABLE_OBJECT_LOCK_DEBUG_PATTERN
+    elif config.test_ops.get("lua_block_object_lock", False):
+        lua_block_object_lock_mode = True
+        lua_script_content = aws_reusable.LUA_BLOCK_OBJECT_LOCK_PREREQUEST
+        lua_debug_message_pattern = aws_reusable.LUA_BLOCK_OBJECT_LOCK_DEBUG_PATTERN
 
     if config.test_ops.get("user_name", False):
         op = json.loads(utils.exec_shell_cmd("radosgw-admin user list"))
@@ -145,35 +262,31 @@ end
     else:
         user_info = resource_op.create_users(no_of_users_to_create=config.user_count)
 
-    log.info("Setting log_to_file to true to enable logging to file")
+    log.info("Enabling RGW file logging and debug_rgw=20 for Lua RGWDebugLog")
     try:
-        log_to_file_cmd = "ceph config set global log_to_file true"
-        log.info(f"Setting log_to_file: {log_to_file_cmd}")
-        utils.exec_shell_cmd(log_to_file_cmd)
-        log.info("log_to_file set to true")
-    except Exception as e:
-        raise TestExecError(f"Failed to set log_to_file to true: {e}")
-
-    log.info("Setting debug_rgw to 20 to enable lua debug messages")
-    try:
-        cmd_ps = "ceph orch ps --daemon_type rgw -f json"
-        out_ps = utils.exec_shell_cmd(cmd_ps)
+        utils.exec_shell_cmd("ceph config set global log_to_file true")
+        out_ps = utils.exec_shell_cmd("ceph orch ps --daemon_type rgw -f json")
         rgw_daemons = json.loads(out_ps)
-
+        services = set()
         for daemon in rgw_daemons:
-            daemon_name = daemon.get("service_name")
+            service_name = daemon.get("service_name")
+            if service_name:
+                services.add(service_name)
+            daemon_name = daemon.get("daemon_name")
             if daemon_name:
-                debug_cmd = f"ceph config set client.{daemon_name} debug_rgw 20"
-                log.info(f"Setting debug_rgw for {daemon_name}: {debug_cmd}")
-                utils.exec_shell_cmd(debug_cmd)
-
-        log.info("debug_rgw set to 20 for all RGW daemons")
+                utils.exec_shell_cmd(
+                    f"ceph config set client.{daemon_name} debug_rgw 20"
+                )
+        for service_name in services:
+            utils.exec_shell_cmd(f"ceph config set client.{service_name} debug_rgw 20")
+        log.info("log_to_file and debug_rgw set for all RGW services and daemons")
     except Exception as e:
-        raise TestExecError(f"Failed to set debug_rgw to 20: {e}")
+        raise TestExecError(f"Failed to enable RGW Lua debug logging: {e}")
 
     if not lua_script_content:
         raise TestExecError(
-            "No Lua script configured. Set object_placement_on_storage_class or lua_object_lock in test_ops."
+            "No Lua script configured. Set object_placement_on_storage_class, "
+            "lua_object_lock, or lua_block_object_lock in test_ops."
         )
     log.info("Setting lua script prerequest (inline)")
     aws_reusable.set_lua_script(context="prerequest", script_content=lua_script_content)
@@ -191,260 +304,274 @@ end
         raise AssertionError(
             "Object lock Lua script was not set correctly (missing x-amz-bucket-object-lock-enabled)"
         )
+    if lua_block_object_lock_mode and "RGW_ABORT_REQUEST" not in retrieved_script:
+        raise AssertionError(
+            "Block object lock Lua script was not set correctly (missing RGW_ABORT_REQUEST)"
+        )
 
-    buckets_created_count = 0
-    for user in user_info:
-        user_name = user["user_id"]
-        log.info(user_name)
-        cli_aws = AWS(ssl=config.ssl)
-        aws_auth.do_auth_aws(user)
+    if lua_block_object_lock_mode:
+        if config.test_ops.get("restart_rgw", True):
+            utils.restart_rgw(restart_all=True)
+            time.sleep(30)
+        script_removed = _run_lua_block_object_lock_tests(
+            config, user_info, endpoint, ssh_con
+        )
+        if not script_removed:
+            aws_reusable.remove_lua_script(context="prerequest")
+            log.info("Lua script prerequest has been removed")
+    else:
+        if lua_object_lock_mode and config.test_ops.get("restart_rgw", False):
+            utils.restart_rgw(restart_all=True)
+            time.sleep(20)
+        buckets_created_count = 0
+        for user in user_info:
+            user_name = user["user_id"]
+            log.info(user_name)
+            cli_aws = AWS(ssl=config.ssl)
+            aws_auth.do_auth_aws(user)
 
-        for bc in range(config.bucket_count):
-            bucket_name = utils.gen_bucket_name_from_userid(user_name, rand_no=bc)
-            aws_reusable.create_bucket(cli_aws, bucket_name, endpoint)
-            buckets_created_count += 1
-            log.info(f"Bucket {bucket_name} created")
-            if config.test_ops.get("enable_version", False):
-                log.info(f"bucket versioning test on bucket: {bucket_name}")
-                aws_reusable.put_get_bucket_versioning(cli_aws, bucket_name, endpoint)
+            for bc in range(config.bucket_count):
+                bucket_name = utils.gen_bucket_name_from_userid(user_name, rand_no=bc)
+                aws_reusable.create_bucket(cli_aws, bucket_name, endpoint)
+                buckets_created_count += 1
+                log.info(f"Bucket {bucket_name} created")
+                if config.test_ops.get("enable_version", False):
+                    log.info(f"bucket versioning test on bucket: {bucket_name}")
+                    aws_reusable.put_get_bucket_versioning(
+                        cli_aws, bucket_name, endpoint
+                    )
 
-            if lua_object_lock_mode:
-                # Verify bucket has versioning and object lock (Lua converted regular create to versioned + object lock)
-                out = utils.exec_shell_cmd(
-                    f"radosgw-admin bucket stats --bucket {bucket_name}"
-                )
-                data = json.loads(out)
-                info = data[0] if isinstance(data, list) else data
-                if info.get("versioning") != "enabled":
-                    raise AssertionError(
-                        f"Bucket {bucket_name}: expected versioning enabled, got {info.get('versioning')}"
+                if lua_object_lock_mode:
+                    out = utils.exec_shell_cmd(
+                        f"radosgw-admin bucket stats --bucket {bucket_name}"
                     )
-                if not info.get("object_lock_enabled"):
-                    raise AssertionError(
-                        f"Bucket {bucket_name}: expected object_lock_enabled true, got {info.get('object_lock_enabled')}"
+                    data = json.loads(out)
+                    info = data[0] if isinstance(data, list) else data
+                    if info.get("versioning") != "enabled":
+                        raise AssertionError(
+                            f"Bucket {bucket_name}: expected versioning enabled, got {info.get('versioning')}"
+                        )
+                    if not info.get("object_lock_enabled"):
+                        raise AssertionError(
+                            f"Bucket {bucket_name}: expected object_lock_enabled true, got {info.get('object_lock_enabled')}"
+                        )
+                    log.info(
+                        f"Bucket {bucket_name}: versioning=enabled, object_lock_enabled=true"
                     )
-                log.info(
-                    f"Bucket {bucket_name}: versioning=enabled, object_lock_enabled=true"
-                )
-                ver_out = utils.exec_shell_cmd(
-                    f"{AWS_CLI} s3api get-bucket-versioning --bucket {bucket_name} --endpoint-url {endpoint}"
-                )
-                if "Enabled" not in ver_out:
-                    raise AssertionError(
-                        f"get-bucket-versioning for {bucket_name} did not show Enabled: {ver_out}"
+                    ver_out = utils.exec_shell_cmd(
+                        f"{AWS_CLI} s3api get-bucket-versioning --bucket {bucket_name} --endpoint-url {endpoint}"
                     )
-                lock_out = utils.exec_shell_cmd(
-                    f"{AWS_CLI} s3api get-object-lock-configuration --bucket {bucket_name} --endpoint-url {endpoint}"
-                )
-                if "ObjectLockEnabled" not in lock_out or "Enabled" not in lock_out:
-                    raise AssertionError(
-                        f"get-object-lock-configuration for {bucket_name} did not show Enabled: {lock_out}"
+                    if "Enabled" not in ver_out:
+                        raise AssertionError(
+                            f"get-bucket-versioning for {bucket_name} did not show Enabled: {ver_out}"
+                        )
+                    lock_out = utils.exec_shell_cmd(
+                        f"{AWS_CLI} s3api get-object-lock-configuration --bucket {bucket_name} --endpoint-url {endpoint}"
                     )
-                # Optional: object-level retention, default retention, upload, verify, delete (Doc: Test obj lock LUA)
-                if config.test_ops.get("put_default_retention"):
-                    mode = config.test_ops.get("lock_mode", "COMPLIANCE")
-                    days = config.test_ops.get("retention_days", 5)
-                    obj_size_str = config.objects_size_range.get("min", "4K")
-                    if isinstance(obj_size_str, str):
-                        s = obj_size_str.strip().upper()
-                        obj_size = (
-                            int(s.replace("M", "")) * 1024 * 1024
-                            if "M" in s
-                            else int(s.replace("K", "") or "4") * 1024
+                    if "ObjectLockEnabled" not in lock_out or "Enabled" not in lock_out:
+                        raise AssertionError(
+                            f"get-object-lock-configuration for {bucket_name} did not show Enabled: {lock_out}"
                         )
-                    else:
-                        obj_size = int(obj_size_str) if obj_size_str else 4096
-                    retain_until = (
-                        datetime.now(timezone.utc) + timedelta(days=days)
-                    ).strftime("%Y-%m-%dT%H:%M:%S.000Z")
-                    key_early = f"obj-retention-{bc}"
-                    key_name = f"obj-lock-{bc}"
-                    utils.exec_shell_cmd(f"fallocate -l {obj_size} {key_early}")
-                    if not config.test_ops.get("test_multipart", False):
-                        utils.exec_shell_cmd(f"fallocate -l {obj_size} {key_name}")
-                    try:
-                        aws_reusable.put_object(
-                            cli_aws, bucket_name, key_early, endpoint
-                        )
-                        utils.exec_shell_cmd(
-                            f"{AWS_CLI} s3api put-object-retention --bucket {bucket_name} --key {key_early} "
-                            f"--endpoint-url {endpoint} --retention "
-                            f'\'{{"Mode":"{mode}","RetainUntilDate":"{retain_until}"}}\''
-                        )
-                        ret_early = utils.exec_shell_cmd(
-                            f"{AWS_CLI} s3api get-object-retention --bucket {bucket_name} --key {key_early} --endpoint-url {endpoint}"
-                        )
-                        if (
-                            "Retention" not in ret_early
-                            or "RetainUntilDate" not in ret_early
-                        ):
-                            raise AssertionError(
-                                f"get-object-retention after put-object-retention for {key_early} failed: {ret_early}"
-                            )
-                        log.info(
-                            f"Object-level put-object-retention and get-object-retention verified for {key_early}"
-                        )
-                        lock_cfg = (
-                            '{"ObjectLockEnabled":"Enabled","Rule":{"DefaultRetention":{"Mode":"'
-                            + mode
-                            + '","Days":'
-                            + str(days)
-                            + "}}}"
-                        )
-                        utils.exec_shell_cmd(
-                            f"{AWS_CLI} s3api put-object-lock-configuration --bucket {bucket_name} "
-                            f"--endpoint-url {endpoint} --object-lock-configuration '{lock_cfg}'"
-                        )
-                        log.info(
-                            f"Set default retention {mode} {days} days on {bucket_name}"
-                        )
-                        lock_get = utils.exec_shell_cmd(
-                            f"{AWS_CLI} s3api get-object-lock-configuration --bucket {bucket_name} --endpoint-url {endpoint}"
-                        )
-                        if "Rule" not in lock_get or "DefaultRetention" not in lock_get:
-                            raise AssertionError(
-                                f"get-object-lock-configuration should return Rule/DefaultRetention: {lock_get}"
-                            )
-                        if config.test_ops.get("test_multipart", False):
-                            config.obj_size = config.objects_size_range["max"]
-                            log.info(
-                                "Uploading object with default retention via multipart: %s",
-                                key_name,
-                            )
-                            aws_reusable.upload_multipart_aws(
-                                cli_aws,
-                                bucket_name,
-                                key_name,
-                                TEST_DATA_PATH,
-                                endpoint,
-                                config,
+                    if config.test_ops.get("put_default_retention"):
+                        mode = config.test_ops.get("lock_mode", "COMPLIANCE")
+                        days = config.test_ops.get("retention_days", 5)
+                        obj_size_str = config.objects_size_range.get("min", "4K")
+                        if isinstance(obj_size_str, str):
+                            s = obj_size_str.strip().upper()
+                            obj_size = (
+                                int(s.replace("M", "")) * 1024 * 1024
+                                if "M" in s
+                                else int(s.replace("K", "") or "4") * 1024
                             )
                         else:
-                            aws_reusable.put_object(
-                                cli_aws, bucket_name, key_name, endpoint
-                            )
-                        ret_out = utils.exec_shell_cmd(
-                            f"{AWS_CLI} s3api get-object-retention --bucket {bucket_name} --key {key_name} --endpoint-url {endpoint}"
-                        )
-                        if "Retention" not in ret_out:
-                            log.warning(
-                                f"get-object-retention for {key_name} (may be NoneType on some versions): {ret_out}"
-                            )
-                        del_out = utils.exec_shell_cmd(
-                            f"{AWS_CLI} s3api delete-object --bucket {bucket_name} --key {key_name} --endpoint-url {endpoint}"
-                        )
-                        log.info(
-                            "aws s3api delete-object (no version-id) output: %s",
-                            del_out,
-                        )
-                        if "DeleteMarker" not in str(del_out):
-                            log.warning(
-                                f"delete-object (no version-id) expected DeleteMarker: {del_out}"
-                            )
-                        else:
-                            log.info(
-                                "delete-object without version-id returned DeleteMarker as expected"
-                            )
-                        list_ver = utils.exec_shell_cmd(
-                            f"{AWS_CLI} s3api list-object-versions --bucket {bucket_name} --endpoint-url {endpoint} "
-                            f"--query \"Versions[?Key=='{key_name}']\" --output json"
-                        )
+                            obj_size = int(obj_size_str) if obj_size_str else 4096
+                        retain_until = (
+                            datetime.now(timezone.utc) + timedelta(days=days)
+                        ).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+                        key_early = f"obj-retention-{bc}"
+                        key_name = f"obj-lock-{bc}"
+                        utils.exec_shell_cmd(f"fallocate -l {obj_size} {key_early}")
+                        if not config.test_ops.get("test_multipart", False):
+                            utils.exec_shell_cmd(f"fallocate -l {obj_size} {key_name}")
                         try:
-                            ver_list = json.loads(list_ver) if list_ver else []
-                        except (json.JSONDecodeError, TypeError):
-                            ver_list = []
-                        ver_list = ver_list or []
-                        if ver_list and ver_list[0].get("VersionId"):
-                            vid = ver_list[0]["VersionId"]
-                            err = utils.exec_shell_cmd(
-                                f"{AWS_CLI} s3api delete-object --bucket {bucket_name} --key {key_name} "
-                                f"--version-id {vid} --endpoint-url {endpoint}",
-                                return_err=True,
+                            aws_reusable.put_object(
+                                cli_aws, bucket_name, key_early, endpoint
+                            )
+                            utils.exec_shell_cmd(
+                                f"{AWS_CLI} s3api put-object-retention --bucket {bucket_name} --key {key_early} "
+                                f"--endpoint-url {endpoint} --retention "
+                                f'\'{{"Mode":"{mode}","RetainUntilDate":"{retain_until}"}}\''
+                            )
+                            ret_early = utils.exec_shell_cmd(
+                                f"{AWS_CLI} s3api get-object-retention --bucket {bucket_name} --key {key_early} --endpoint-url {endpoint}"
+                            )
+                            if (
+                                "Retention" not in ret_early
+                                or "RetainUntilDate" not in ret_early
+                            ):
+                                raise AssertionError(
+                                    f"get-object-retention after put-object-retention for {key_early} failed: {ret_early}"
+                                )
+                            log.info(
+                                f"Object-level put-object-retention and get-object-retention verified for {key_early}"
+                            )
+                            lock_cfg = (
+                                '{"ObjectLockEnabled":"Enabled","Rule":{"DefaultRetention":{"Mode":"'
+                                + mode
+                                + '","Days":'
+                                + str(days)
+                                + "}}}"
+                            )
+                            utils.exec_shell_cmd(
+                                f"{AWS_CLI} s3api put-object-lock-configuration --bucket {bucket_name} "
+                                f"--endpoint-url {endpoint} --object-lock-configuration '{lock_cfg}'"
                             )
                             log.info(
-                                "aws s3api delete-object (version-id %s, locked) output: %s",
-                                vid,
-                                err,
+                                f"Set default retention {mode} {days} days on {bucket_name}"
                             )
-                            if err and (
-                                "forbidden by object lock" in str(err).lower()
-                                or "AccessDenied" in str(err)
+                            lock_get = utils.exec_shell_cmd(
+                                f"{AWS_CLI} s3api get-object-lock-configuration --bucket {bucket_name} --endpoint-url {endpoint}"
+                            )
+                            if (
+                                "Rule" not in lock_get
+                                or "DefaultRetention" not in lock_get
                             ):
+                                raise AssertionError(
+                                    f"get-object-lock-configuration should return Rule/DefaultRetention: {lock_get}"
+                                )
+                            if config.test_ops.get("test_multipart", False):
+                                config.obj_size = config.objects_size_range["max"]
                                 log.info(
-                                    "Delete of locked object version correctly forbidden"
+                                    "Uploading object with default retention via multipart: %s",
+                                    key_name,
+                                )
+                                aws_reusable.upload_multipart_aws(
+                                    cli_aws,
+                                    bucket_name,
+                                    key_name,
+                                    TEST_DATA_PATH,
+                                    endpoint,
+                                    config,
                                 )
                             else:
-                                log.warning(
-                                    f"Expected AccessDenied/forbidden when deleting locked version: {err}"
+                                aws_reusable.put_object(
+                                    cli_aws, bucket_name, key_name, endpoint
                                 )
-                        list_early = utils.exec_shell_cmd(
-                            f"{AWS_CLI} s3api list-object-versions --bucket {bucket_name} --endpoint-url {endpoint} "
-                            f"--query \"Versions[?Key=='{key_early}']\" --output json"
-                        )
-                        try:
-                            early_list = json.loads(list_early) if list_early else []
-                        except (json.JSONDecodeError, TypeError):
-                            early_list = []
-                        early_list = early_list or []
-                        if early_list and early_list[0].get("VersionId"):
-                            vid_early = early_list[0]["VersionId"]
-                            err_early = utils.exec_shell_cmd(
-                                f"{AWS_CLI} s3api delete-object --bucket {bucket_name} --key {key_early} "
-                                f"--version-id {vid_early} --endpoint-url {endpoint}",
-                                return_err=True,
+                            ret_out = utils.exec_shell_cmd(
+                                f"{AWS_CLI} s3api get-object-retention --bucket {bucket_name} --key {key_name} --endpoint-url {endpoint}"
+                            )
+                            if "Retention" not in ret_out:
+                                log.warning(
+                                    f"get-object-retention for {key_name} (may be NoneType on some versions): {ret_out}"
+                                )
+                            del_out = utils.exec_shell_cmd(
+                                f"{AWS_CLI} s3api delete-object --bucket {bucket_name} --key {key_name} --endpoint-url {endpoint}"
                             )
                             log.info(
-                                "aws s3api delete-object (version-id %s, object-level retention) output: %s",
-                                vid_early,
-                                err_early,
+                                "aws s3api delete-object (no version-id) output: %s",
+                                del_out,
                             )
-                            if err_early and (
-                                "forbidden by object lock" in str(err_early).lower()
-                                or "AccessDenied" in str(err_early)
-                            ):
-                                log.info(
-                                    "Delete of object-level retention version correctly forbidden"
+                            if "DeleteMarker" not in str(del_out):
+                                log.warning(
+                                    f"delete-object (no version-id) expected DeleteMarker: {del_out}"
                                 )
-                    finally:
-                        for f in (key_early, key_name):
-                            if os.path.exists(f):
-                                try:
-                                    os.remove(f)
-                                except OSError:
-                                    pass
+                            else:
+                                log.info(
+                                    "delete-object without version-id returned DeleteMarker as expected"
+                                )
+                            list_ver = utils.exec_shell_cmd(
+                                f"{AWS_CLI} s3api list-object-versions --bucket {bucket_name} --endpoint-url {endpoint} "
+                                f"--query \"Versions[?Key=='{key_name}']\" --output json"
+                            )
+                            try:
+                                ver_list = json.loads(list_ver) if list_ver else []
+                            except (json.JSONDecodeError, TypeError):
+                                ver_list = []
+                            ver_list = ver_list or []
+                            if ver_list and ver_list[0].get("VersionId"):
+                                vid = ver_list[0]["VersionId"]
+                                err = utils.exec_shell_cmd(
+                                    f"{AWS_CLI} s3api delete-object --bucket {bucket_name} --key {key_name} "
+                                    f"--version-id {vid} --endpoint-url {endpoint}",
+                                    return_err=True,
+                                )
+                                log.info(
+                                    "aws s3api delete-object (version-id %s, locked) output: %s",
+                                    vid,
+                                    err,
+                                )
+                                if err and (
+                                    "forbidden by object lock" in str(err).lower()
+                                    or "AccessDenied" in str(err)
+                                ):
+                                    log.info(
+                                        "Delete of locked object version correctly forbidden"
+                                    )
+                                else:
+                                    log.warning(
+                                        f"Expected AccessDenied/forbidden when deleting locked version: {err}"
+                                    )
+                            list_early = utils.exec_shell_cmd(
+                                f"{AWS_CLI} s3api list-object-versions --bucket {bucket_name} --endpoint-url {endpoint} "
+                                f"--query \"Versions[?Key=='{key_early}']\" --output json"
+                            )
+                            try:
+                                early_list = (
+                                    json.loads(list_early) if list_early else []
+                                )
+                            except (json.JSONDecodeError, TypeError):
+                                early_list = []
+                            early_list = early_list or []
+                            if early_list and early_list[0].get("VersionId"):
+                                vid_early = early_list[0]["VersionId"]
+                                err_early = utils.exec_shell_cmd(
+                                    f"{AWS_CLI} s3api delete-object --bucket {bucket_name} --key {key_early} "
+                                    f"--version-id {vid_early} --endpoint-url {endpoint}",
+                                    return_err=True,
+                                )
+                                log.info(
+                                    "aws s3api delete-object (version-id %s, object-level retention) output: %s",
+                                    vid_early,
+                                    err_early,
+                                )
+                                if err_early and (
+                                    "forbidden by object lock" in str(err_early).lower()
+                                    or "AccessDenied" in str(err_early)
+                                ):
+                                    log.info(
+                                        "Delete of object-level retention version correctly forbidden"
+                                    )
+                        finally:
+                            for f in (key_early, key_name):
+                                if os.path.exists(f):
+                                    try:
+                                        os.remove(f)
+                                    except OSError:
+                                        pass
 
-            if config.test_ops.get("object_placement_on_storage_class", False):
-                object_count = config.objects_count // 2
-                log.info(f"uploading some small objects to bucket {bucket_name}")
-                for sobj in range(object_count):
-                    config.obj_size = config.objects_size_range["min"]
-                    small_key_name = f"small-object-{sobj}"
-                    utils.exec_shell_cmd(
-                        f"fallocate -l {config.obj_size} {small_key_name}"
-                    )
-                    log.info(f"upload s3 object: {small_key_name}")
-                    aws_reusable.put_object(
-                        cli_aws, bucket_name, small_key_name, endpoint
-                    )
-                    if config.test_ops.get("enable_version", False):
+                if config.test_ops.get("object_placement_on_storage_class", False):
+                    object_count = config.objects_count // 2
+                    log.info(f"uploading some small objects to bucket {bucket_name}")
+                    for sobj in range(object_count):
+                        config.obj_size = config.objects_size_range["min"]
+                        small_key_name = f"small-object-{sobj}"
+                        utils.exec_shell_cmd(
+                            f"fallocate -l {config.obj_size} {small_key_name}"
+                        )
+                        log.info(f"upload s3 object: {small_key_name}")
                         aws_reusable.put_object(
                             cli_aws, bucket_name, small_key_name, endpoint
                         )
+                        if config.test_ops.get("enable_version", False):
+                            aws_reusable.put_object(
+                                cli_aws, bucket_name, small_key_name, endpoint
+                            )
 
-                log.info(f"uploading some large objects to bucket {bucket_name}")
-                for mobj in range(object_count):
-                    config.obj_size = config.objects_size_range["max"]
-                    key_name = f"large-object-{mobj}"
-                    log.info(f"upload s3 object: {key_name}")
-                    aws_reusable.upload_multipart_aws(
-                        cli_aws,
-                        bucket_name,
-                        key_name,
-                        TEST_DATA_PATH,
-                        endpoint,
-                        config,
-                    )
-                    if config.test_ops.get("enable_version", False):
+                    log.info(f"uploading some large objects to bucket {bucket_name}")
+                    for mobj in range(object_count):
+                        config.obj_size = config.objects_size_range["max"]
+                        key_name = f"large-object-{mobj}"
+                        log.info(f"upload s3 object: {key_name}")
                         aws_reusable.upload_multipart_aws(
                             cli_aws,
                             bucket_name,
@@ -453,133 +580,141 @@ end
                             endpoint,
                             config,
                         )
+                        if config.test_ops.get("enable_version", False):
+                            aws_reusable.upload_multipart_aws(
+                                cli_aws,
+                                bucket_name,
+                                key_name,
+                                TEST_DATA_PATH,
+                                endpoint,
+                                config,
+                            )
 
-                log.info("Verifying lua script prerequest is working as expected")
-                standalone_dir = os.path.abspath(
-                    os.path.join(__file__, "../../../../standalone")
-                )
-                validation_script_path = os.path.join(
-                    standalone_dir,
-                    "boto_s3_list_object_validation.py",
-                )
-
-                if config.test_ops.get("enable_version", False):
+                    log.info("Verifying lua script prerequest is working as expected")
+                    standalone_dir = os.path.abspath(
+                        os.path.join(__file__, "../../../../standalone")
+                    )
                     validation_script_path = os.path.join(
                         standalone_dir,
-                        "boto_s3_list_ver_object_validation.py",
+                        "boto_s3_list_object_validation.py",
                     )
 
-                if not os.path.exists(validation_script_path):
-                    raise TestExecError(
-                        f"Validation script not found at {validation_script_path}. Cannot validate object storage classes."
-                    )
+                    if config.test_ops.get("enable_version", False):
+                        validation_script_path = os.path.join(
+                            standalone_dir,
+                            "boto_s3_list_ver_object_validation.py",
+                        )
 
-                log.info(f"Running validation script: {validation_script_path}")
-                validation_output = f"list_validate_{bucket_name}.log"
-                env = os.environ.copy()
-                env["BUCKET_NAME"] = bucket_name
-                env["OUTPUT_FILE"] = validation_output
-                env["S3_ENDPOINT"] = endpoint
-                env["AWS_ACCESS_KEY_ID"] = user["access_key"]
-                env["AWS_SECRET_ACCESS_KEY"] = user["secret_key"]
-                env["EXPECTED_STORAGE_CLASS"] = config.test_ops.get(
-                    "storage_class", None
-                )
-                validation_cmd = f"{sys.executable} {validation_script_path}"
-                log.info(f"Executing: {validation_cmd}")
-                try:
-                    result = subprocess.run(
-                        validation_cmd,
-                        shell=True,
-                        env=env,
-                        stdout=subprocess.PIPE,
-                        stderr=subprocess.PIPE,
-                        text=True,
-                        timeout=3600,
-                    )
-                    if result.returncode != 0:
+                    if not os.path.exists(validation_script_path):
                         raise TestExecError(
-                            f"Validation script returned non-zero exit code: {result.returncode}. "
-                            f"Stderr: {result.stderr}"
+                            f"Validation script not found at {validation_script_path}. Cannot validate object storage classes."
                         )
-                    log.info("Validation script completed successfully")
-                except subprocess.TimeoutExpired:
-                    raise TestExecError("Validation script timed out after 1 hour")
-                except Exception as e:
-                    raise TestExecError(f"Error running validation script: {e}")
 
-                if not os.path.exists(validation_output):
-                    raise TestExecError(
-                        f"Validation output file {validation_output} not found after script execution"
+                    log.info(f"Running validation script: {validation_script_path}")
+                    validation_output = f"list_validate_{bucket_name}.log"
+                    env = os.environ.copy()
+                    env["BUCKET_NAME"] = bucket_name
+                    env["OUTPUT_FILE"] = validation_output
+                    env["S3_ENDPOINT"] = endpoint
+                    env["AWS_ACCESS_KEY_ID"] = user["access_key"]
+                    env["AWS_SECRET_ACCESS_KEY"] = user["secret_key"]
+                    env["EXPECTED_STORAGE_CLASS"] = config.test_ops.get(
+                        "storage_class", None
                     )
-                try:
-                    with open(validation_output, "r") as f:
-                        validation_content = f.read()
-                        error_count = validation_content.count("ERROR")
-                        pass_count = validation_content.count("PASS")
-                        log.info(
-                            f"Validation results - PASS: {pass_count}, ERROR: {error_count}"
-                        )
-
-                        if error_count > 0:
-                            error_lines = [
-                                line
-                                for line in validation_content.split("\n")
-                                if "ERROR" in line
-                            ]
-                            for error_line in error_lines[:10]:  # Show first 10 errors
-                                log.warning(f"Validation error: {error_line}")
-                            raise AssertionError(
-                                f"Validation failed: {error_count} objects have incorrect storage class. "
-                                f"Check {validation_output} for details"
-                            )
-                        else:
-                            log.info(
-                                "All objects validated successfully - storage classes are correct"
-                            )
-                finally:
+                    validation_cmd = f"{sys.executable} {validation_script_path}"
+                    log.info(f"Executing: {validation_cmd}")
                     try:
-                        if os.path.exists(validation_output):
-                            os.remove(validation_output)
-                    except Exception as e:
-                        log.warning(
-                            f"Failed to remove validation output file {validation_output}: {e}"
+                        result = subprocess.run(
+                            validation_cmd,
+                            shell=True,
+                            env=env,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                            text=True,
+                            timeout=3600,
                         )
+                        if result.returncode != 0:
+                            raise TestExecError(
+                                f"Validation script returned non-zero exit code: {result.returncode}. "
+                                f"Stderr: {result.stderr}"
+                            )
+                        log.info("Validation script completed successfully")
+                    except subprocess.TimeoutExpired:
+                        raise TestExecError("Validation script timed out after 1 hour")
+                    except Exception as e:
+                        raise TestExecError(f"Error running validation script: {e}")
 
-    if lua_debug_message_pattern:
-        if lua_object_lock_mode:
-            expected_message_count = buckets_created_count
-            log.info(
-                f"Expected lua debug message count: {expected_message_count} (object lock: one per bucket)"
-            )
-        else:
-            object_count = config.objects_count // 2
-            small_object_messages = object_count
-            split_size = getattr(config, "split_size", 5)
-            large_object_size = config.objects_size_range["max"]
-            size_mb = float(str(large_object_size).replace("M", "").replace("m", ""))
-            num_parts = math.ceil(size_mb / split_size)
-            large_object_messages = object_count * (1 + num_parts)
-            messages_per_bucket = small_object_messages + large_object_messages
-            expected_message_count = messages_per_bucket * config.bucket_count
-            if config.test_ops.get("enable_version", False):
-                expected_message_count = expected_message_count * 2
-            log.info(
-                f"Expected lua debug message count: {expected_message_count} "
-                f"(objects_count={config.objects_count}, bucket_count={config.bucket_count}, "
-                f"small_objects={object_count}, large_objects={object_count}, "
-                f"large_object_size={large_object_size}, split_size={split_size}MB, "
-                f"parts_per_large_object={num_parts}, versioning={config.test_ops.get('enable_version', False)})"
-            )
-        aws_reusable.check_rgw_debug_logs_and_reset(
-            message_pattern=lua_debug_message_pattern,
-            ssh_con=ssh_con,
-            haproxy=config.haproxy,
-            expected_count=expected_message_count,
-        )
+                    if not os.path.exists(validation_output):
+                        raise TestExecError(
+                            f"Validation output file {validation_output} not found after script execution"
+                        )
+                    try:
+                        with open(validation_output, "r") as f:
+                            validation_content = f.read()
+                            error_count = validation_content.count("ERROR")
+                            pass_count = validation_content.count("PASS")
+                            log.info(
+                                f"Validation results - PASS: {pass_count}, ERROR: {error_count}"
+                            )
 
-    aws_reusable.remove_lua_script(context="prerequest")
-    log.info("Lua script prerequest has been removed")
+                            if error_count > 0:
+                                error_lines = [
+                                    line
+                                    for line in validation_content.split("\n")
+                                    if "ERROR" in line
+                                ]
+                                for error_line in error_lines[
+                                    :10
+                                ]:  # Show first 10 errors
+                                    log.warning(f"Validation error: {error_line}")
+                                raise AssertionError(
+                                    f"Validation failed: {error_count} objects have incorrect storage class. "
+                                    f"Check {validation_output} for details"
+                                )
+                            else:
+                                log.info(
+                                    "All objects validated successfully - storage classes are correct"
+                                )
+                    finally:
+                        try:
+                            if os.path.exists(validation_output):
+                                os.remove(validation_output)
+                        except Exception as e:
+                            log.warning(
+                                f"Failed to remove validation output file {validation_output}: {e}"
+                            )
+
+        if lua_debug_message_pattern:
+            if lua_object_lock_mode:
+                expected_message_count = buckets_created_count
+                log.info(
+                    f"Expected lua debug message count: {expected_message_count} "
+                    "(object lock: one per bucket)"
+                )
+            else:
+                # Small objects: one put_obj log each; large objects: one init_multipart log each
+                # (upload_part ops are not handled by the Lua prerequest script).
+                object_count = config.objects_count // 2
+                expected_message_count = (
+                    object_count + object_count
+                ) * config.bucket_count
+                if config.test_ops.get("enable_version", False):
+                    expected_message_count = expected_message_count * 2
+                log.info(
+                    f"Expected lua debug message count: {expected_message_count} "
+                    f"(small_objects={object_count}, large_objects={object_count}, "
+                    f"bucket_count={config.bucket_count}, "
+                    f"versioning={config.test_ops.get('enable_version', False)})"
+                )
+            aws_reusable.check_rgw_debug_logs_and_reset(
+                message_pattern=lua_debug_message_pattern,
+                ssh_con=ssh_con,
+                haproxy=config.haproxy,
+                expected_count=expected_message_count,
+            )
+
+        aws_reusable.remove_lua_script(context="prerequest")
+        log.info("Lua script prerequest has been removed")
     if config.user_remove is True:
         for user in user_info:
             s3_reusable.remove_user(user)


### PR DESCRIPTION
Negative: s3api create-bucket without lock (AccessDenied, bucket not created).
Positive: --object-lock-enabled-for-bucket, stats, objects, default retention.
Optional: remove script + plain create succeeds (w/out Lua).

log : http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/9_1_logs/


  | test_aws_lua_block_object_lock_request.console.log | 2026-06-10 07:19 | 70K |  
-- | -- | -- | -- | --
  | test_aws_lua_block_object_lock_request_governance.console.log | 2026-06-10 07:19 | 71K |  
  | test_aws_lua_object_lock.console.log | 2026-06-10 07:19 | 65K |  
  | test_aws_lua_object_lock_governance.console.log | 2026-06-10 07:19 | 65K |  
  | test_aws_lua_object_lock_minimal.console.log | 2026-06-10 07:19 | 54K |  
  | test_aws_lua_object_placement_on_stoarge_class.console.log | 2026-06-10 07:19 | 104K |  
  | test_lc_cloud_transition_restore_object.console.log
