### PR TITLE
[TFA] fixing PublicAccessBlock RestrictPublicBuckets by adding failure_expected config for policy_verification

### DIFF
--- a/rgw/v2/tests/s3_swift/configs/test_public_access_block_restricted_public_buckets.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_public_access_block_restricted_public_buckets.yaml
@@ -23,6 +23,7 @@ config:
         "RestrictPublicBuckets": True
       }
     verify_policy: True
+    verify_policy_failure_expected: True
     endpoint: kafka
     ack_type: broker
     bucket_tags: [

--- a/rgw/v2/tests/s3_swift/test_bucket_policy_ops.py
+++ b/rgw/v2/tests/s3_swift/test_bucket_policy_ops.py
@@ -442,15 +442,21 @@ def test_exec(config, ssh_con):
             rgw_tenant1_user1_c.meta.events.unregister(
                 "before-parameter-build.s3", validate_bucket_name
             )
-            bucket_policy_ops.verify_policy(
-                bucket_owner_rgw_client=rgw_tenant1_user1_c,
-                config=config,
-                rgw_client=rgw_tenant2_user1_c,
-                bucket_name=bucket_name_verify_policy,
-                object_name=f"{s3_object_name}-verify-policy",
-                rgw_s3_resource=rgw_tenant2_user1,
-                sns_client=rgw_tenant2_user1_sns_client,
-            )
+            try:
+                bucket_policy_ops.verify_policy(
+                    bucket_owner_rgw_client=rgw_tenant1_user1_c,
+                    config=config,
+                    rgw_client=rgw_tenant2_user1_c,
+                    bucket_name=bucket_name_verify_policy,
+                    object_name=f"{s3_object_name}-verify-policy",
+                    rgw_s3_resource=rgw_tenant2_user1,
+                    sns_client=rgw_tenant2_user1_sns_client,
+                )
+            except Exception as e:
+                if config.test_ops.get("verify_policy_failure_expected"):
+                    log.info("verify_policy failure is expected")
+                else:
+                    raise Exception(f"verify_policy failed with error '{e}'")
 
         # modifying bucket policy to take new policy
         if config.bucket_policy_op == "modify":


### PR DESCRIPTION
this PR is to fix the automation issue with RestrictPublicBuckets testcase.
RestrictPublicBuckets set to true will block public access and the restriction applies to only authorized users within the bucket owner's account and access point owner's account. This blocks cross-account access to the access point or bucket, except for the cases specified, while still allowing users within the account to manage the access points or buckets.

the testcase checks the access from other tenanted users, but missing the error handling if the access is blocked.
so handling the failure_expected flow for the RestrictPublicBuckets testcase for cross tenanted user access.

pass logs: http://magna002.ceph.redhat.com/cephci-jenkins/hsm/TFA_pab_restrictpublicbuckets/test_public_access_block_restricted_public_buckets.verbose.log 