### PR TITLE
[TFA][sts_aswi] retain realms_keys_workaround for keycloak on reef

### DIFF
--- a/rgw/v2/tests/s3_swift/reusables/sts.py
+++ b/rgw/v2/tests/s3_swift/reusables/sts.py
@@ -224,6 +224,7 @@ class Keycloak:
         client_secret="client_secret1",
         ip_addr="localhost",
         attributes=None,
+        ceph_version_name=None,
     ):
         """
         Keycloak deployment and administration through curl
@@ -256,8 +257,9 @@ class Keycloak:
                 client_name=self.client_id, client_scope_name=set_audience_scope_name
             )
             self.set_session_tags_in_token(self.client_id)
-            # Commenting this as its fixed as part of https://bugzilla.redhat.com/show_bug.cgi?id=2237854
-            # self.realm_keys_workaround()
+            # workaround for the issue mentioned in this bz https://bugzilla.redhat.com/show_bug.cgi?id=2237854
+            if ceph_version_name == "reef":
+                self.realm_keys_workaround()
         if attributes is None:
             self.remove_user_attributes(username=f"service-account-{self.client_id}")
         else:

--- a/rgw/v2/tests/s3_swift/test_sts_aswi.py
+++ b/rgw/v2/tests/s3_swift/test_sts_aswi.py
@@ -176,6 +176,7 @@ def test_exec(config, ssh_con):
             client_secret="client_secret1",
             ip_addr=local_ip_addr,
             attributes=config.test_ops.get("session_tags"),
+            ceph_version_name=ceph_version_name,
         )
 
         web_token = keycloak.get_web_access_token()


### PR DESCRIPTION
this PR is to fix the issue of assume_role_with_webidentity failure on reef with keycloak signature_verification failure.
tfa fail log: https://10.8.128.2/cephci-jenkins/ibm-cos//IBM/7.1/rhel-9/regression/18.2.1-398/rgw/6/logs/Tier_2_rgw_sts_aswi/

actually this is a product issue which is fixed on squid and tentacle, but the fix is not backported to reef
bz: https://bugzilla.redhat.com/show_bug.cgi?id=2237854

so reverting the realms_keys_workaround code only to run on reef builds.

pass logs on 7.1 : http://magna002.ceph.redhat.com/cephci-jenkins/hsm/TFA_sts_aswi_invalid_padding_revert_71/test_sts_aswi.console.log