### PR TITLE
Add S3 ObjectRestore notification tests with podman Kafka container

### DIFF
--- a/rgw/v2/tests/s3_swift/multisite_configs/test_lc_aws_cloud_restore_notif_non_versioned.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_lc_aws_cloud_restore_notif_non_versioned.yaml
@@ -1,0 +1,67 @@
+#test_cloud_transition_restore_notifications.py
+#AWS Cloud Transition, Permanent Restore with ObjectRestore Notifications - Non-Versioned
+#Tests permanent restore of a small (4KB) non-versioned object transitioned to CLOUDAWS
+#Verifies ObjectRestore:Post, ObjectRestore:Completed notifications via podman Kafka container
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 1
+  parallel_lc: False
+  test_lc_transition: True
+  enable_resharding: False
+  pool_name: data.cold
+  storage_class: cold
+  ec_pool_transition: False
+  multiple_transitions: True
+  two_pool_transition: False
+  second_pool_name: data.glacier
+  second_storage_class: glacier
+  remote_zone: secondary
+  objects_size_range:
+    min: 5
+    max: 5
+  test_ops:
+    create_bucket: true
+    create_object: true
+    enable_versioning: false
+    version_count: 0
+    delete_marker: false
+    test_cloud_transition: true
+    test_pool_transition: false
+    skip_tier_setup: true
+    test_ibm_cloud_transition: false
+    test_aws_cloud_transition: true
+    test_retain_head: true
+    test_cloud_transition_at_remote: false
+    test_s3_restore_from_cloud: true
+    upload_type: normal
+    permanent_restore: true
+    delete_lc_after_transition: true
+    # AWS specific configuration for eu-north-1 region
+    aws_endpoint: "https://s3.eu-north-1.amazonaws.com"
+    aws_region: "eu-north-1"
+    aws_location_constraint: "eu-north-1"
+    verify_cloud_bugs: false
+    # Restore notification settings (podman Kafka container with ZooKeeper)
+    install_kafka_container: true
+    send_restore_notifications: true
+    endpoint: kafka
+    restore_ack_type: broker
+    restore_persistent_flag: true
+  lifecycle_conf:
+    - ID: LC_Rule_1
+      Filter:
+        Prefix: key1
+      Status: Enabled
+      Transitions:
+        - Days: 2
+          StorageClass: CLOUDAWS
+  restore_wait_time: 600
+  restore_poll_interval: 30
+  restore_parallel_workers: 1
+  # Lifecycle debug settings
+  rgw_lc_debug_interval: 30
+  rgw_enable_lc_threads: True
+  rgw_lifecycle_work_time: "00:00-23:59"
+  rgw_lc_max_worker: 3
+  rgw_lc_max_wp_worker: 3

--- a/rgw/v2/tests/s3_swift/multisite_configs/test_lc_aws_cloud_restore_notif_versioned.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_lc_aws_cloud_restore_notif_versioned.yaml
@@ -1,0 +1,70 @@
+#test_cloud_transition_restore_notifications.py
+#AWS Cloud Transition, Permanent Restore with ObjectRestore Notifications - Versioned
+#Tests permanent restore of a small (4KB) versioned object (2 versions) transitioned to CLOUDAWS
+#Verifies ObjectRestore:Post, ObjectRestore:Completed notifications via podman Kafka container
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 1
+  parallel_lc: False
+  test_lc_transition: True
+  enable_resharding: False
+  pool_name: data.cold
+  storage_class: cold
+  ec_pool_transition: False
+  multiple_transitions: True
+  two_pool_transition: False
+  second_pool_name: data.glacier
+  second_storage_class: glacier
+  remote_zone: secondary
+  objects_size_range:
+    min: 5
+    max: 5
+  test_ops:
+    create_bucket: true
+    create_object: true
+    enable_versioning: true
+    version_count: 2
+    delete_marker: false
+    test_cloud_transition: true
+    test_pool_transition: false
+    skip_tier_setup: true
+    test_ibm_cloud_transition: false
+    test_aws_cloud_transition: true
+    test_retain_head: true
+    test_cloud_transition_at_remote: false
+    test_s3_restore_from_cloud: true
+    upload_type: normal
+    permanent_restore: true
+    delete_lc_after_transition: true
+    # AWS specific configuration for eu-north-1 region
+    aws_endpoint: "https://s3.eu-north-1.amazonaws.com"
+    aws_region: "eu-north-1"
+    aws_location_constraint: "eu-north-1"
+    verify_cloud_bugs: false
+    # Restore notification settings (podman Kafka container with ZooKeeper)
+    install_kafka_container: true
+    send_restore_notifications: true
+    endpoint: kafka
+    restore_ack_type: broker
+    restore_persistent_flag: true
+  lifecycle_conf:
+    - ID: LC_Rule_1
+      Filter:
+        Prefix: key1
+      Status: Enabled
+      Transitions:
+        - Days: 2
+          StorageClass: CLOUDAWS
+      NoncurrentVersionTransitions:
+        - NoncurrentDays: 2
+          StorageClass: CLOUDAWS
+  restore_wait_time: 600
+  restore_poll_interval: 30
+  restore_parallel_workers: 2
+  # Lifecycle debug settings
+  rgw_lc_debug_interval: 30
+  rgw_enable_lc_threads: True
+  rgw_lifecycle_work_time: "00:00-23:59"
+  rgw_lc_max_worker: 3
+  rgw_lc_max_wp_worker: 3

--- a/rgw/v2/tests/s3_swift/reusables/kafka_container.py
+++ b/rgw/v2/tests/s3_swift/reusables/kafka_container.py
@@ -1,0 +1,193 @@
+"""
+Kafka Container Management for RGW Event Notification Tests
+
+Provides podman-based Kafka broker setup with ZooKeeper, consistent with
+the bare-metal Kafka setup used in cephci (utility/utils.py).
+
+Uses the same port conventions:
+  - ZooKeeper: 2181
+  - Kafka PLAINTEXT: 9092
+
+Self-contained — does not modify or depend on the bare-metal Kafka setup
+in bucket_notification.py or cephci.
+
+Usage:
+    from v2.tests.s3_swift.reusables.kafka_container import KafkaContainer
+
+    kafka = KafkaContainer()
+    kafka.setup()
+    # ... run tests ...
+    kafka.teardown()
+"""
+
+import logging
+import os
+import time
+
+import v2.utils.utils as utils
+from v2.lib.exceptions import TestExecError
+
+log = logging.getLogger()
+
+ZOOKEEPER_IMAGE = "docker.io/confluentinc/cp-zookeeper:7.6.0"
+KAFKA_IMAGE = "docker.io/confluentinc/cp-kafka:7.6.0"
+KAFKA_BIN_PATH = "/usr/bin"
+
+
+class KafkaContainer:
+    def __init__(
+        self,
+        zookeeper_name="zookeeper",
+        kafka_name="kafka-broker",
+        zookeeper_port=2181,
+        kafka_port=9092,
+        zookeeper_image=None,
+        kafka_image=None,
+    ):
+        self.zookeeper_name = zookeeper_name
+        self.kafka_name = kafka_name
+        self.zookeeper_port = zookeeper_port
+        self.kafka_port = kafka_port
+        self.zookeeper_image = zookeeper_image or ZOOKEEPER_IMAGE
+        self.kafka_image = kafka_image or KAFKA_IMAGE
+        self.broker_ip = None
+        self._running = False
+
+    def setup(self):
+        log.info(
+            f"Setting up podman Kafka + ZooKeeper containers "
+            f"(ZK port: {self.zookeeper_port}, Kafka port: {self.kafka_port})"
+        )
+
+        which_podman = utils.exec_shell_cmd("which podman")
+        if which_podman is False or not str(which_podman).strip():
+            raise TestExecError("podman is not installed on this node")
+
+        self._cleanup_existing()
+        self.broker_ip = utils.get_localhost_ip_address()
+
+        # Start ZooKeeper container
+        log.info(f"Starting ZooKeeper container '{self.zookeeper_name}'")
+        zk_cmd = (
+            f"podman run -d --name {self.zookeeper_name} --network host"
+            f" -e ZOOKEEPER_CLIENT_PORT={self.zookeeper_port}"
+            f" -e ZOOKEEPER_TICK_TIME=2000"
+            f" {self.zookeeper_image}"
+        )
+        out = utils.exec_shell_cmd(zk_cmd)
+        if out is False:
+            raise TestExecError("Failed to start ZooKeeper container")
+
+        log.info("Waiting 15s for ZooKeeper to start...")
+        time.sleep(15)
+
+        # Start Kafka broker container
+        log.info(f"Starting Kafka broker container '{self.kafka_name}'")
+        kafka_cmd = (
+            f"podman run -d --name {self.kafka_name} --network host"
+            f" -e KAFKA_BROKER_ID=0"
+            f" -e KAFKA_ZOOKEEPER_CONNECT={self.broker_ip}:{self.zookeeper_port}"
+            f" -e KAFKA_LISTENERS=PLAINTEXT://{self.broker_ip}:{self.kafka_port}"
+            f" -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://{self.broker_ip}:{self.kafka_port}"
+            f" -e KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1"
+            f" -e KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1"
+            f" -e KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=1"
+            f" {self.kafka_image}"
+        )
+        out = utils.exec_shell_cmd(kafka_cmd)
+        if out is False:
+            raise TestExecError("Failed to start Kafka broker container")
+
+        self._wait_for_ready()
+        self._running = True
+        log.info(
+            f"Kafka container ready at {self.broker_ip}:{self.kafka_port} "
+            f"(ZooKeeper at {self.broker_ip}:{self.zookeeper_port})"
+        )
+        return self.broker_ip
+
+    def teardown(self):
+        log.info(
+            f"Tearing down Kafka container '{self.kafka_name}' "
+            f"and ZooKeeper container '{self.zookeeper_name}'"
+        )
+        self._cleanup_existing()
+        self._running = False
+        log.info("Kafka and ZooKeeper containers removed")
+
+    def is_running(self):
+        out = utils.exec_shell_cmd(
+            f"podman inspect --format '{{{{.State.Running}}}}' "
+            f"{self.kafka_name} 2>/dev/null"
+        )
+        return out and "true" in str(out).lower()
+
+    def get_bootstrap_server(self):
+        if not self.broker_ip:
+            self.broker_ip = utils.get_localhost_ip_address()
+        return f"{self.broker_ip}:{self.kafka_port}"
+
+    def create_topic(self, topic_name):
+        log.info(f"Creating Kafka topic '{topic_name}' via container CLI")
+        cmd = (
+            f"podman exec {self.kafka_name} {KAFKA_BIN_PATH}/kafka-topics"
+            f" --create --topic {topic_name}"
+            f" --bootstrap-server {self.broker_ip}:{self.kafka_port}"
+            f" --partitions 1 --replication-factor 1"
+        )
+        out = utils.exec_shell_cmd(cmd)
+        if out is False:
+            raise TestExecError(f"Failed to create Kafka topic '{topic_name}'")
+        log.info(f"Topic '{topic_name}' created successfully")
+
+    def delete_topic(self, topic_name):
+        log.info(f"Deleting Kafka topic '{topic_name}' via container CLI")
+        cmd = (
+            f"podman exec {self.kafka_name} {KAFKA_BIN_PATH}/kafka-topics"
+            f" --delete --topic {topic_name}"
+            f" --bootstrap-server {self.broker_ip}:{self.kafka_port}"
+        )
+        utils.exec_shell_cmd(cmd)
+        log.info(f"Topic '{topic_name}' deleted")
+
+    def start_consumer(self, topic_name, output_path, timeout_ms=30000):
+        if os.path.isfile(output_path):
+            log.info(f"Removing stale event record file: {output_path}")
+            os.remove(output_path)
+
+        log.info(
+            f"Starting Kafka consumer for topic '{topic_name}', "
+            f"output to {output_path}"
+        )
+        cmd = (
+            f"podman exec {self.kafka_name} {KAFKA_BIN_PATH}/"
+            f"kafka-console-consumer"
+            f" --bootstrap-server {self.broker_ip}:{self.kafka_port}"
+            f" --from-beginning --topic {topic_name}"
+            f" --timeout-ms {timeout_ms} >> {output_path}"
+        )
+        result = utils.exec_shell_cmd(cmd)
+        return result
+
+    def _wait_for_ready(self, max_wait=90, poll_interval=5):
+        log.info("Waiting for Kafka broker readiness...")
+        elapsed = 0
+        while elapsed < max_wait:
+            time.sleep(poll_interval)
+            elapsed += poll_interval
+            check = utils.exec_shell_cmd(
+                f"podman exec {self.kafka_name} "
+                f"{KAFKA_BIN_PATH}/kafka-broker-api-versions"
+                f" --bootstrap-server {self.broker_ip}:{self.kafka_port}"
+                f" 2>/dev/null"
+            )
+            if check and check is not False:
+                log.info(f"Kafka broker ready after {elapsed}s")
+                return
+            log.info(f"Kafka not ready yet... ({elapsed}s/{max_wait}s)")
+        raise TestExecError(f"Kafka container did not become ready within {max_wait}s")
+
+    def _cleanup_existing(self):
+        for name in [self.kafka_name, self.zookeeper_name]:
+            utils.exec_shell_cmd(f"podman stop {name} 2>/dev/null || true")
+            utils.exec_shell_cmd(f"podman rm {name} 2>/dev/null || true")

--- a/rgw/v2/tests/s3_swift/reusables/restore_notification.py
+++ b/rgw/v2/tests/s3_swift/reusables/restore_notification.py
@@ -1,0 +1,303 @@
+"""
+S3 Object Restore Notification Support for RGW
+
+Handles setup and verification of ObjectRestore event notifications
+(s3:ObjectRestore:Post, s3:ObjectRestore:Completed, s3:ObjectRestore:Delete)
+using a podman-based Kafka container via KafkaContainer.
+
+Does not modify or depend on the existing bucket_notification.py module.
+
+Usage:
+    from v2.tests.s3_swift.reusables.kafka_container import KafkaContainer
+    from v2.tests.s3_swift.reusables.restore_notification import (
+        RestoreNotificationService,
+    )
+
+    kafka = KafkaContainer()
+    kafka.setup()
+
+    service = RestoreNotificationService(config, auth, kafka)
+    service.subscribe(bucket_name)
+    # ... perform restore operations ...
+    service.verify(bucket_name)
+
+    kafka.teardown()
+"""
+
+import json
+import logging
+import os
+import uuid
+from urllib import parse as urlparse
+
+import v2.utils.utils as utils
+from v2.lib.exceptions import EventRecordDataError, TestExecError
+
+log = logging.getLogger()
+
+RESTORE_EVENT_RECORD_PATH = "/tmp/event_record_restore"
+
+RESTORE_EVENTS = [
+    "s3:ObjectRestore:Initiated",
+    "s3:ObjectRestore:Completed",
+    "s3:ObjectRestore:Expired",
+]
+
+RESTORE_EVENT_NAMES = [
+    "ObjectRestore:Initiated",
+    "ObjectRestore:Completed",
+    "ObjectRestore:Expired",
+]
+
+
+class RestoreNotificationService:
+    def __init__(self, config, auth, kafka_container):
+        self.config = config
+        self.auth = auth
+        self.kafka = kafka_container
+
+        self.rgw_sns_conn = auth.do_auth_sns_client()
+        self.rgw_s3_client = auth.do_auth_using_client()
+        self.ceph_version_id, self.ceph_version_name = utils.get_ceph_version()
+
+        self.bucket_topic_map = {}
+
+    def subscribe(self, bucket_name):
+        """
+        Create a Kafka topic for restore events and configure bucket notification
+        to send ObjectRestore events to it.
+        """
+        endpoint = self.config.test_ops.get("endpoint", "kafka")
+        ack_type = self.config.test_ops.get("restore_ack_type", "broker")
+        persistent = self.config.test_ops.get("restore_persistent_flag", True)
+
+        topic_id = str(uuid.uuid4().hex[:16])
+        topic_name = f"restore-notif-{ack_type}-{topic_id}"
+
+        log.info(f"Creating SNS topic '{topic_name}' for restore notifications")
+        topic_arn = self._create_sns_topic(endpoint, ack_type, topic_name, persistent)
+
+        self.bucket_topic_map[bucket_name] = {
+            "topic_name": topic_name,
+            "topic_arn": topic_arn,
+            "events": RESTORE_EVENTS,
+        }
+
+        self._get_topic_attributes(topic_arn)
+
+        notification_name = f"notification-restore-{topic_id}"
+        self._put_bucket_notification(
+            bucket_name, notification_name, topic_arn, RESTORE_EVENTS
+        )
+
+        self._get_bucket_notification(bucket_name)
+        log.info(
+            f"Restore notifications subscribed for bucket '{bucket_name}' "
+            f"on topic '{topic_name}'"
+        )
+
+    def verify(self, bucket_name, event_record_path=None):
+        """
+        Start Kafka consumer for the restore topic and verify received events.
+        """
+        if bucket_name not in self.bucket_topic_map:
+            raise TestExecError(
+                f"No restore notification topic for bucket '{bucket_name}'. "
+                f"Call subscribe() first."
+            )
+
+        record_path = event_record_path or RESTORE_EVENT_RECORD_PATH
+        topic_name = self.bucket_topic_map[bucket_name]["topic_name"]
+
+        log.info(f"Starting Kafka consumer for restore events on topic '{topic_name}'")
+        result = self.kafka.start_consumer(topic_name, record_path)
+        if result is False:
+            raise TestExecError("Kafka consumer failed for restore events")
+
+        log.info("Verifying restore event records")
+        self._verify_restore_events(bucket_name, record_path)
+        log.info(f"Restore notification verification passed for '{bucket_name}'")
+
+    def cleanup_topic(self, bucket_name):
+        """
+        Delete the Kafka topic for a bucket's restore notifications.
+        """
+        if bucket_name in self.bucket_topic_map:
+            topic_name = self.bucket_topic_map[bucket_name]["topic_name"]
+            topic_arn = self.bucket_topic_map[bucket_name]["topic_arn"]
+            try:
+                self.kafka.delete_topic(topic_name)
+            except Exception as e:
+                log.warning(f"Failed to delete Kafka topic '{topic_name}': {e}")
+            try:
+                self.rgw_sns_conn.delete_topic(TopicArn=topic_arn)
+            except Exception as e:
+                log.warning(f"Failed to delete SNS topic '{topic_arn}': {e}")
+            del self.bucket_topic_map[bucket_name]
+
+    def _create_sns_topic(self, endpoint, ack_type, topic_name, persistent):
+        kafka_ip = self.kafka.broker_ip or utils.get_localhost_ip_address()
+        kafka_port = self.kafka.kafka_port
+
+        endpoint_args = (
+            f"push-endpoint={endpoint}://{kafka_ip}:{kafka_port}"
+            f"&use-ssl=false&verify-ssl=false"
+            f"&kafka-ack-level={ack_type}"
+        )
+        if persistent:
+            endpoint_args += "&persistent=true"
+
+        attributes = {
+            nvp[0]: nvp[1]
+            for nvp in urlparse.parse_qsl(endpoint_args, keep_blank_values=True)
+        }
+        response = self.rgw_sns_conn.create_topic(
+            Name=topic_name, Attributes=attributes
+        )
+        topic_arn = response["TopicArn"]
+        log.info(f"SNS topic created, ARN: {topic_arn}")
+        return topic_arn
+
+    def _get_topic_attributes(self, topic_arn):
+        if "nautilus" in self.ceph_version_name:
+            return
+        info = self.rgw_sns_conn.get_topic_attributes(TopicArn=topic_arn)
+        log.info(f"Topic attributes: {json.dumps(info, indent=2)}")
+
+    def _put_bucket_notification(
+        self, bucket_name, notification_name, topic_arn, events
+    ):
+        log.info(f"Configuring bucket notification on '{bucket_name}'")
+        self.rgw_s3_client.put_bucket_notification_configuration(
+            Bucket=bucket_name,
+            NotificationConfiguration={
+                "TopicConfigurations": [
+                    {
+                        "Id": notification_name,
+                        "TopicArn": topic_arn,
+                        "Events": events,
+                    }
+                ]
+            },
+        )
+
+    def _get_bucket_notification(self, bucket_name):
+        response = self.rgw_s3_client.get_bucket_notification_configuration(
+            Bucket=bucket_name
+        )
+        log.info(
+            f"Bucket notification config for '{bucket_name}': "
+            f"{json.dumps(response, indent=2)}"
+        )
+
+    def _verify_restore_events(self, bucket_name, event_record_path):
+        if not os.path.exists(event_record_path):
+            raise EventRecordDataError(
+                f"Event record file not found: {event_record_path}"
+            )
+
+        if os.path.getsize(event_record_path) == 0:
+            raise EventRecordDataError(
+                "Restore event record file is empty — no notifications received"
+            )
+
+        bucket_stats = utils.exec_shell_cmd(
+            f"radosgw-admin bucket stats --bucket {bucket_name}"
+        )
+        bucket_stats_json = json.loads(bucket_stats)
+
+        zonegroup_get = utils.exec_shell_cmd("radosgw-admin zonegroup get")
+        zonegroup_json = json.loads(zonegroup_get)
+        zonegroup_name = zonegroup_json["name"]
+
+        ceph_version_id = self.ceph_version_id.split("-")[0].split(".")
+
+        events_found = set()
+        with open(event_record_path, "r") as records:
+            for record in records:
+                event_record = record.strip()
+                if not event_record:
+                    continue
+                log.info(f"Restore event record: {event_record}")
+                event_json = json.loads(event_record)
+
+                event_name = event_json["Records"][0]["eventName"]
+
+                matched = False
+                for expected in RESTORE_EVENT_NAMES:
+                    if expected in event_name:
+                        events_found.add(expected)
+                        matched = True
+                        break
+
+                if not matched:
+                    log.info(f"Skipping non-restore event: {event_name}")
+                    continue
+
+                if "s3:" in event_name and "nautilus" not in self.ceph_version_name:
+                    raise EventRecordDataError(
+                        f"eventName has s3: prefix: {event_name}"
+                    )
+
+                event_time = event_json["Records"][0]["eventTime"]
+                if "0.000000" in event_time:
+                    raise EventRecordDataError(
+                        f"eventTime is 0.000000 in restore event record"
+                    )
+                if "T" not in event_time:
+                    raise EventRecordDataError(
+                        f"eventTime incorrect format: {event_time}"
+                    )
+
+                bucket_info = event_json["Records"][0]["s3"]["bucket"]
+                bkt_name = (
+                    bucket_name.split("/")[-1] if "/" in bucket_name else bucket_name
+                )
+                if bkt_name != bucket_info["name"]:
+                    raise EventRecordDataError(
+                        f"Bucket name mismatch: expected {bkt_name}, "
+                        f"got {bucket_info['name']}"
+                    )
+
+                bucket_id = bucket_stats_json["id"]
+                if bucket_id not in bucket_info["id"]:
+                    raise EventRecordDataError(
+                        f"Bucket ID mismatch: expected {bucket_id}"
+                    )
+
+                bucket_owner = bucket_stats_json["owner"]
+                if "$" in bucket_owner and int(ceph_version_id[0]) < 19:
+                    bucket_owner = bucket_owner.split("$")[-1]
+                evnt_owner = bucket_info["ownerIdentity"]["principalId"]
+                if bucket_owner != evnt_owner:
+                    raise EventRecordDataError(
+                        f"Bucket owner mismatch: expected {bucket_owner}, "
+                        f"got {evnt_owner}"
+                    )
+
+                aws_region = event_json["Records"][0]["awsRegion"]
+                if aws_region != zonegroup_name:
+                    raise EventRecordDataError(
+                        f"awsRegion mismatch: expected {zonegroup_name}, "
+                        f"got {aws_region}"
+                    )
+
+        if not events_found:
+            raise EventRecordDataError("No ObjectRestore events found in event records")
+
+        log.info(f"Restore events verified: {events_found}")
+
+        permanent = self.config.test_ops.get("permanent_restore", False)
+        if permanent:
+            expected = {"ObjectRestore:Initiated", "ObjectRestore:Completed"}
+        else:
+            expected = set(RESTORE_EVENT_NAMES)
+
+        missing = expected - events_found
+        if missing:
+            log.warning(
+                f"Expected restore events not received: {missing}. "
+                f"Received: {events_found}"
+            )
+        else:
+            log.info(f"All expected restore events received: {expected}")

--- a/rgw/v2/tests/s3_swift/test_cloud_transition_restore_notifications.py
+++ b/rgw/v2/tests/s3_swift/test_cloud_transition_restore_notifications.py
@@ -1,0 +1,636 @@
+"""
+Test S3 Object Restore Notifications with AWS Cloud Transition
+
+This test combines the AWS cloud transition restore multipart flow with
+ObjectRestore notification verification using a podman-based Kafka container.
+
+Flow:
+1. Set up podman Kafka container (KRaft mode, no ZooKeeper)
+2. Create user, bucket, upload multipart objects
+3. Apply LC rule → transition objects to CLOUDAWS
+4. Subscribe to ObjectRestore events (Post, Completed, Delete)
+5. Perform permanent restore of transitioned objects
+6. Verify restore notifications received via Kafka
+7. Run cloud transition bug verification
+8. Tear down Kafka container
+
+Usage:
+    python test_cloud_transition_restore_notifications.py \
+        -c multisite_configs/test_lc_aws_cloud_transition_restore_multipart_notifications.yaml \
+        --rgw-node <IP>
+
+Does not modify any existing test files or reusable modules.
+"""
+
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(__file__, "../../../..")))
+import argparse
+import json
+import logging
+import time
+import traceback
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import v2.lib.resource_op as s3lib
+import v2.utils.utils as utils
+from v2.lib.exceptions import RGWBaseException, TestExecError
+from v2.lib.resource_op import Config
+from v2.lib.rgw_config_opts import CephConfOp, ConfigOpts
+from v2.lib.s3 import lifecycle_validation as lc_ops
+from v2.lib.s3.auth import Auth
+from v2.lib.s3.write_io_info import BasicIOInfoStructure, BucketIoInfo, IOInfoInitialize
+from v2.tests.s3_swift import reusable
+from v2.tests.s3_swift.reusables import cloud_transition_bug_checks
+from v2.tests.s3_swift.reusables import s3_object_restore as reusables_s3_restore
+from v2.tests.s3_swift.reusables.kafka_container import KafkaContainer
+from v2.tests.s3_swift.reusables.restore_notification import RestoreNotificationService
+from v2.tests.s3cmd import reusable as s3cmd_reusable
+from v2.utils.log import configure_logging
+from v2.utils.test_desc import AddTestInfo
+from v2.utils.utils import RGWService
+
+log = logging.getLogger()
+
+TEST_DATA_PATH = None
+
+
+def test_exec(config, ssh_con):
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    write_bucket_io_info = BucketIoInfo()
+    io_info_initialize.initialize(basic_io_structure.initial())
+    ceph_conf = CephConfOp(ssh_con)
+    rgw_service = RGWService()
+    ip_and_port = s3cmd_reusable.get_rgw_ip_and_port(ssh_con, config.ssl)
+
+    # --- Phase 1: Kafka container setup ---
+    kafka = None
+    if config.test_ops.get("install_kafka_container", False):
+        log.info("=" * 80)
+        log.info("Phase 1: Setting up podman Kafka container")
+        log.info("=" * 80)
+        kafka = KafkaContainer()
+        kafka.setup()
+        log.info(f"Kafka broker available at {kafka.get_bootstrap_server()}")
+
+    try:
+        # --- Phase 2: Ceph config and LC prerequisites ---
+        log.info("=" * 80)
+        log.info("Phase 2: Configuring Ceph and LC prerequisites")
+        log.info("=" * 80)
+        ceph_conf.set_to_ceph_conf(
+            "global",
+            ConfigOpts.rgw_lc_debug_interval,
+            str(config.rgw_lc_debug_interval),
+            ssh_con,
+            set_to_all=config.test_ops.get("set_ceph_configs_to_all_daemons", False),
+        )
+        ceph_conf.set_to_ceph_conf(
+            "global",
+            ConfigOpts.rgw_lifecycle_work_time,
+            str(config.rgw_lifecycle_work_time),
+            ssh_con,
+            set_to_all=config.test_ops.get("set_ceph_configs_to_all_daemons", False),
+        )
+        _, version_name = utils.get_ceph_version()
+        if "nautilus" in version_name:
+            ceph_conf.set_to_ceph_conf(
+                "global",
+                ConfigOpts.rgw_lc_max_worker,
+                str(config.rgw_lc_max_worker),
+                ssh_con,
+            )
+        else:
+            ceph_conf.set_to_ceph_conf(
+                section=None,
+                option=ConfigOpts.rgw_lc_max_worker,
+                value=str(config.rgw_lc_max_worker),
+                ssh_con=ssh_con,
+                set_to_all=config.test_ops.get(
+                    "set_ceph_configs_to_all_daemons", False
+                ),
+            )
+        ceph_conf.set_to_ceph_conf(
+            "global",
+            ConfigOpts.rgw_lc_max_wp_worker,
+            str(config.rgw_lc_max_wp_worker),
+            ssh_con,
+            set_to_all=config.test_ops.get("set_ceph_configs_to_all_daemons", False),
+        )
+
+        if config.test_lc_transition:
+            reusable.prepare_for_bucket_lc_transition(config)
+        if config.enable_resharding and config.sharding_type == "dynamic":
+            reusable.set_dynamic_reshard_ceph_conf(config, ssh_con)
+
+        srv_restarted = rgw_service.restart(ssh_con)
+        time.sleep(30)
+        if srv_restarted is False:
+            raise TestExecError("RGW service restart failed")
+
+        # --- Phase 3: Create user and bucket ---
+        log.info("=" * 80)
+        log.info("Phase 3: Creating user and bucket")
+        log.info("=" * 80)
+        config.user_count = config.user_count if config.user_count else 1
+        config.bucket_count = config.bucket_count if config.bucket_count else 1
+
+        user_info = s3lib.create_users(
+            config.user_count, config.user_names, config=config
+        )
+
+        if config.test_ops.get("install_kafka_container", False):
+            utils.add_service2_sdk_extras()
+
+        for each_user in user_info:
+            auth = reusable.get_auth(each_user, ssh_con, config.ssl, config.haproxy)
+            rgw_conn = auth.do_auth()
+            rgw_conn2 = auth.do_auth_using_client()
+
+            for bc in range(config.bucket_count):
+                if config.bucket_names:
+                    bucket_name = config.bucket_names[bc]
+                else:
+                    bucket_name = utils.gen_bucket_name_from_userid(
+                        each_user["user_id"], rand_no=bc
+                    )
+
+                if config.haproxy:
+                    bucket = reusable.create_bucket(bucket_name, rgw_conn, each_user)
+                else:
+                    bucket = reusable.create_bucket(
+                        bucket_name, rgw_conn, each_user, ip_and_port
+                    )
+
+                if config.enable_resharding and config.sharding_type == "manual":
+                    reusable.bucket_reshard_manual(bucket, config)
+
+                # Enable versioning if configured
+                if config.test_ops.get("enable_versioning", False) is True:
+                    log.info(f"Enabling versioning on bucket {bucket_name}")
+                    reusable.enable_versioning(
+                        bucket, rgw_conn, each_user, write_bucket_io_info
+                    )
+
+                # --- Phase 4: Upload objects ---
+                log.info("=" * 80)
+                log.info(f"Phase 4: Uploading objects to bucket {bucket_name}")
+                log.info("=" * 80)
+                prefix = []
+                if config.lifecycle_conf:
+                    prefix = list(
+                        map(
+                            lambda x: x,
+                            [
+                                rule["Filter"].get("Prefix")
+                                or rule["Filter"]["And"].get("Prefix")
+                                for rule in config.lifecycle_conf
+                            ],
+                        )
+                    )
+                    prefix = prefix if prefix else ["dummy1"]
+                else:
+                    prefix = ["dummy1"]
+
+                obj_list = []
+                object_checksums = {}
+                upload_start_time = time.time()
+
+                for oc, size in list(config.mapped_sizes.items()):
+                    config.obj_size = size
+                    key = prefix.pop()
+                    prefix.insert(0, key)
+                    s3_object_name = key + "." + bucket.name + "." + str(oc)
+                    obj_list.append(s3_object_name)
+
+                    if config.test_ops.get("upload_type") == "multipart":
+                        log.info(f"Uploading multipart object: {s3_object_name}")
+                        reusable.upload_mutipart_object(
+                            s3_object_name,
+                            bucket,
+                            TEST_DATA_PATH,
+                            config,
+                            each_user,
+                        )
+                    elif (
+                        config.test_ops.get("enable_versioning", False)
+                        and config.test_ops.get("version_count", 0) > 0
+                    ):
+                        for vc in range(config.test_ops["version_count"]):
+                            log.info(f"Uploading version {vc} of {s3_object_name}")
+                            reusable.upload_object(
+                                s3_object_name,
+                                bucket,
+                                TEST_DATA_PATH,
+                                config,
+                                each_user,
+                                append_data=True,
+                                append_msg="hello object for version: %s\n" % str(vc),
+                            )
+                    else:
+                        reusable.upload_object(
+                            s3_object_name,
+                            bucket,
+                            TEST_DATA_PATH,
+                            config,
+                            each_user,
+                        )
+
+                upload_end_time = time.time()
+
+                # Store checksums before transition
+                log.info("=" * 80)
+                log.info("Storing object checksums BEFORE cloud transition")
+                log.info("=" * 80)
+                bucket_list_op = utils.exec_shell_cmd(
+                    f"radosgw-admin bucket list --bucket={bucket_name}"
+                )
+                json_doc_list = json.loads(bucket_list_op)
+
+                for item in json_doc_list:
+                    if item.get("tag") != "delete-marker" and "instance" in item:
+                        object_key = item["name"]
+                        version_id = item["instance"]
+                        checksum_key = f"{object_key}:{version_id}"
+                        object_checksums[
+                            checksum_key
+                        ] = reusables_s3_restore.store_object_checksum(
+                            rgw_conn2, bucket_name, object_key, version_id
+                        )
+
+                # --- Phase 5: Apply LC rule and wait for transition ---
+                log.info("=" * 80)
+                log.info("Phase 5: Applying LC rule and waiting for cloud transition")
+                log.info("=" * 80)
+                life_cycle_rule = {"Rules": config.lifecycle_conf}
+                reusable.put_get_bucket_lifecycle_test(
+                    bucket,
+                    rgw_conn,
+                    rgw_conn2,
+                    life_cycle_rule,
+                    config,
+                    upload_start_time,
+                    upload_end_time,
+                )
+
+                target_storage_class = None
+                for rule in config.lifecycle_conf:
+                    if "Transitions" in rule:
+                        target_storage_class = rule["Transitions"][0]["StorageClass"]
+                        break
+
+                if target_storage_class:
+                    max_wait_time = 3600
+                    poll_interval = 30
+                    elapsed = 0
+                    while elapsed < max_wait_time:
+                        bucket_list_op = utils.exec_shell_cmd(
+                            f"radosgw-admin bucket list --bucket={bucket_name}"
+                        )
+                        json_doc_list = json.loads(bucket_list_op)
+                        total_objects = sum(
+                            1
+                            for item in json_doc_list
+                            if "instance" in item and item.get("tag") != "delete-marker"
+                        )
+                        transitioned_objects = sum(
+                            1
+                            for item in json_doc_list
+                            if "instance" in item
+                            and item.get("tag") != "delete-marker"
+                            and item.get("meta", {}).get("storage_class")
+                            == target_storage_class
+                        )
+                        log.info(
+                            f"Transition progress: {transitioned_objects}/"
+                            f"{total_objects} to {target_storage_class} "
+                            f"(elapsed: {elapsed}s)"
+                        )
+                        if transitioned_objects >= total_objects:
+                            log.info(
+                                f"All {total_objects} objects transitioned "
+                                f"to {target_storage_class}"
+                            )
+                            break
+                        time.sleep(poll_interval)
+                        elapsed += poll_interval
+                    else:
+                        raise TestExecError(
+                            f"Cloud transition did not complete within "
+                            f"{max_wait_time}s. Only "
+                            f"{transitioned_objects}/{total_objects} done."
+                        )
+
+                # Delete LC policy after transition
+                if config.test_ops.get("delete_lc_after_transition", False):
+                    log.info(f"Deleting LC policy for bucket {bucket_name}")
+                    try:
+                        rgw_conn2.delete_bucket_lifecycle(Bucket=bucket_name)
+                    except Exception as e:
+                        log.warning(f"Failed to delete LC policy: {e}")
+
+                # --- Phase 6: Subscribe to restore notifications ---
+                restore_notif_service = None
+                if config.test_ops.get("send_restore_notifications", False) and kafka:
+                    log.info("=" * 80)
+                    log.info("Phase 6: Subscribing to ObjectRestore notifications")
+                    log.info("=" * 80)
+                    restore_notif_service = RestoreNotificationService(
+                        config, auth, kafka
+                    )
+                    restore_notif_service.subscribe(bucket_name)
+                    log.info(
+                        "ObjectRestore notifications subscribed for "
+                        f"bucket {bucket_name}"
+                    )
+
+                # --- Phase 7: Perform restore ---
+                log.info("=" * 80)
+                log.info(f"Phase 7: Restoring objects from cloud for {bucket_name}")
+                log.info("=" * 80)
+
+                bucket_list_op = utils.exec_shell_cmd(
+                    f"radosgw-admin bucket list --bucket={bucket_name}"
+                )
+                json_doc_list = json.loads(bucket_list_op)
+                objs_total = sum(1 for item in json_doc_list if "instance" in item)
+
+                restore_tasks = []
+                for i in range(objs_total):
+                    if json_doc_list[i]["tag"] != "delete-marker":
+                        object_key = json_doc_list[i]["name"]
+                        version_id = json_doc_list[i]["instance"]
+                        checksum_key = f"{object_key}:{version_id}"
+                        restore_tasks.append(
+                            {
+                                "object_key": object_key,
+                                "version_id": version_id,
+                                "original_metadata": object_checksums.get(checksum_key),
+                            }
+                        )
+
+                # Check restore status before restore
+                restore_list_cmd = f"radosgw-admin restore list --bucket={bucket_name}"
+                log.info(f"Executing: {restore_list_cmd}")
+                stdin, stdout, stderr = ssh_con.exec_command(restore_list_cmd)
+                restore_list_output = stdout.read().decode()
+                if restore_list_output:
+                    log.info(f"Restore list output:\n{restore_list_output}")
+
+                max_workers = getattr(config, "restore_parallel_workers", 10)
+                log.info(
+                    f"Starting parallel restore of {len(restore_tasks)} "
+                    f"objects with {max_workers} workers"
+                )
+
+                def restore_object_wrapper(task):
+                    try:
+                        if config.test_ops.get("permanent_restore", False):
+                            log.info(
+                                f"Permanent restore for {task['object_key']} "
+                                f"(version: {task['version_id']})"
+                            )
+                            reusables_s3_restore.permanent_restore_s3_object(
+                                rgw_conn2,
+                                bucket_name,
+                                task["object_key"],
+                                task["version_id"],
+                                target_storage_class="STANDARD",
+                                original_metadata=task.get("original_metadata"),
+                                max_wait_time=getattr(config, "restore_wait_time", 600),
+                                poll_interval=getattr(
+                                    config, "restore_poll_interval", 30
+                                ),
+                            )
+                        else:
+                            log.info(
+                                f"Temporary restore for {task['object_key']} "
+                                f"(version: {task['version_id']})"
+                            )
+                            reusables_s3_restore.restore_s3_object(
+                                rgw_conn2,
+                                each_user,
+                                config,
+                                bucket_name,
+                                task["object_key"],
+                                task["version_id"],
+                                days=7,
+                                max_wait_time=getattr(config, "restore_wait_time", 600),
+                                poll_interval=getattr(
+                                    config, "restore_poll_interval", 30
+                                ),
+                                original_metadata=task.get("original_metadata"),
+                            )
+                        return {
+                            "success": True,
+                            "object": task["object_key"],
+                            "version": task["version_id"],
+                        }
+                    except Exception as e:
+                        log.error(
+                            f"Restore failed for {task['object_key']} "
+                            f"version {task['version_id']}: {e}"
+                        )
+                        return {
+                            "success": False,
+                            "object": task["object_key"],
+                            "version": task["version_id"],
+                            "error": str(e),
+                        }
+
+                with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                    futures = {
+                        executor.submit(restore_object_wrapper, task): task
+                        for task in restore_tasks
+                    }
+                    completed = 0
+                    failed = 0
+                    for future in as_completed(futures):
+                        result = future.result()
+                        completed += 1
+                        if result["success"]:
+                            log.info(
+                                f"Restore progress: {completed}/"
+                                f"{len(restore_tasks)} - "
+                                f"{result['object']}"
+                            )
+                        else:
+                            failed += 1
+                            log.error(
+                                f"Restore failed: {result['object']} - "
+                                f"{result['error']}"
+                            )
+
+                log.info(
+                    f"Restore completed: {completed - failed}/"
+                    f"{len(restore_tasks)} successful, {failed} failed"
+                )
+                if failed > 0:
+                    raise TestExecError(
+                        f"Restore failed for {failed}/" f"{len(restore_tasks)} objects"
+                    )
+
+                # Check restore status after restore
+                log.info(f"Executing: {restore_list_cmd}")
+                stdin, stdout, stderr = ssh_con.exec_command(restore_list_cmd)
+                restore_list_output = stdout.read().decode()
+                if restore_list_output:
+                    log.info(f"Restore list after restore:\n{restore_list_output}")
+
+                # --- Phase 8: Verify restore notifications ---
+                if restore_notif_service:
+                    log.info("=" * 80)
+                    log.info("Phase 8: Verifying restore notifications")
+                    log.info("=" * 80)
+                    log.info("Waiting 30s for notification delivery to Kafka...")
+                    time.sleep(30)
+                    restore_notif_service.verify(bucket_name)
+                    log.info("Restore notification verification PASSED")
+
+                # --- Phase 9: Cloud transition bug verification ---
+                if config.test_ops.get("verify_cloud_bugs", False):
+                    log.info("=" * 80)
+                    log.info("Phase 9: Cloud Transition Bug Verification")
+                    log.info("=" * 80)
+
+                    storage_class = None
+                    for rule in config.lifecycle_conf:
+                        if "Transitions" in rule:
+                            storage_class = rule["Transitions"][0]["StorageClass"]
+                            break
+
+                    if storage_class:
+                        sample_tasks = restore_tasks[: min(3, len(restore_tasks))]
+                        for task in sample_tasks:
+                            log.info(
+                                f"Verifying bugs for {task['object_key']} "
+                                f"(version: {task['version_id']})"
+                            )
+                            bug_results = cloud_transition_bug_checks.verify_cloud_transition_bugs(
+                                s3_client=rgw_conn2,
+                                ssh_con=ssh_con,
+                                bucket_name=bucket_name,
+                                object_key=task["object_key"],
+                                storage_class=storage_class,
+                                version_id=task["version_id"],
+                                check_multipart=config.test_ops.get(
+                                    "verify_multipart_bug", True
+                                ),
+                                check_etag=config.test_ops.get("verify_etag_bug", True),
+                                check_days_zero=config.test_ops.get(
+                                    "verify_days_zero_bug", False
+                                ),
+                            )
+                            log.info(f"Bug verification results: {bug_results}")
+                            for bug_name, result in bug_results.items():
+                                if "FAILED" in str(result):
+                                    raise TestExecError(
+                                        f"Bug check failed: " f"{bug_name}: {result}"
+                                    )
+
+                        log.info("Cloud Transition Bug Verification: ALL PASSED")
+
+                # --- Phase 10: Restore expiry check (temporary restore only) ---
+                if not config.test_ops.get("permanent_restore", False):
+                    log.info(
+                        "Checking restored objects are not available "
+                        "after restore interval"
+                    )
+                    time.sleep(240)
+                    for task in restore_tasks:
+                        reusables_s3_restore.check_restore_expiry(
+                            rgw_conn2,
+                            each_user,
+                            config,
+                            bucket_name,
+                            task["object_key"],
+                            task["version_id"],
+                        )
+                else:
+                    log.info("Permanent restore — skipping expiry check")
+
+                # Cleanup notification topic
+                if restore_notif_service:
+                    restore_notif_service.cleanup_topic(bucket_name)
+
+                # Cleanup downloaded files
+                log.info("Cleaning up downloaded restore files")
+                for item in os.listdir("."):
+                    if item.startswith(
+                        ("original-", "restored-", "permanently-restored-")
+                    ):
+                        try:
+                            os.remove(item)
+                        except Exception:
+                            pass
+
+            if config.user_remove:
+                reusable.remove_user(each_user)
+
+            crash_info = reusable.check_for_crash()
+            if crash_info:
+                raise TestExecError("ceph daemon crash found!")
+
+    finally:
+        if kafka:
+            log.info("=" * 80)
+            log.info("Tearing down Kafka container")
+            log.info("=" * 80)
+            try:
+                kafka.teardown()
+            except Exception as e:
+                log.warning(f"Kafka teardown failed: {e}")
+
+
+if __name__ == "__main__":
+    test_info = AddTestInfo("cloud transition restore with notifications")
+    test_info.started_info()
+
+    try:
+        project_dir = os.path.abspath(os.path.join(__file__, "../../.."))
+        test_data_dir = "test_data"
+        TEST_DATA_PATH = os.path.join(project_dir, test_data_dir)
+        log.info(f"TEST_DATA_PATH: {TEST_DATA_PATH}")
+        if not os.path.exists(TEST_DATA_PATH):
+            os.makedirs(TEST_DATA_PATH)
+
+        parser = argparse.ArgumentParser(
+            description="RGW S3 Cloud Transition Restore Notifications"
+        )
+        parser.add_argument("-c", dest="config", help="RGW Test yaml configuration")
+        parser.add_argument(
+            "-log_level",
+            dest="log_level",
+            help="Set Log Level [DEBUG, INFO, WARNING, ERROR, CRITICAL]",
+            default="info",
+        )
+        parser.add_argument(
+            "--rgw-node",
+            dest="rgw_node",
+            help="RGW Node",
+            default="127.0.0.1",
+        )
+        args = parser.parse_args()
+        yaml_file = args.config
+        rgw_node = args.rgw_node
+        ssh_con = None
+        if rgw_node != "127.0.0.1":
+            ssh_con = utils.connect_remote(rgw_node)
+        log_f_name = os.path.basename(os.path.splitext(yaml_file)[0])
+        configure_logging(f_name=log_f_name, set_level=args.log_level.upper())
+        config = Config(yaml_file)
+        config.read(ssh_con)
+        if config.mapped_sizes is None:
+            config.mapped_sizes = utils.make_mapped_sizes(config)
+
+        test_exec(config, ssh_con)
+        test_info.success_status("test passed")
+        sys.exit(0)
+
+    except (RGWBaseException, Exception) as e:
+        log.error(e)
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        sys.exit(1)


### PR DESCRIPTION
  Add restore notification tests for AWS cloud transition using a podman Kafka container. No existing files modified.

  New files:
  - kafka_container.py: podman ZooKeeper + Kafka setup
  - restore_notification.py: ObjectRestore event verification
  - test_cloud_transition_restore_notifications.py: standalone test
  - Two YAML configs for 5KB permanent restore (versioned + non-versioned)

  Note: ObjectRestore events require the Ceph main branch; not yet supported in Tentacle (20.2.x).