### PR TITLE
Fixes Test rgw opslog io though s3cmd failure

### DIFF
--- a/rgw/v2/tests/s3cmd/test_rgw_ops_log.py
+++ b/rgw/v2/tests/s3cmd/test_rgw_ops_log.py
@@ -77,7 +77,7 @@ def test_exec(config, ssh_con):
         ceph_version_id, _ = utils.get_ceph_version()
         ceph_version_id = ceph_version_id.split("-")[0].split(".")
         if float(ceph_version_id[0]) >= 17:
-            cmd = " ceph orch ps | grep rgw"
+            cmd = " ceph orch ps --daemon_type=rgw"
             out = utils.exec_shell_cmd(cmd)
             rgw_process_name = out.split()[0]
             utils.exec_shell_cmd(
@@ -174,7 +174,7 @@ def test_exec(config, ssh_con):
             utils.exec_shell_cmd(f"ceph config set global log_to_file true")
 
         ceph_detail = json.loads(utils.exec_shell_cmd("ceph -s -f json"))
-        out = utils.exec_shell_cmd("ceph orch ps | grep rgw | cut -d ' ' -f 1")
+        out = utils.exec_shell_cmd("ceph orch ps --daemon_type=rgw | awk '{print $1}'")
         rgw_process_names = out.split()
 
         with open(root_path, "r") as file:

--- a/rgw/v2/tests/s3cmd/test_rgw_ops_log.py
+++ b/rgw/v2/tests/s3cmd/test_rgw_ops_log.py
@@ -78,15 +78,15 @@ def test_exec(config, ssh_con):
         ceph_version_id = ceph_version_id.split("-")[0].split(".")
         if float(ceph_version_id[0]) >= 17:
             out = utils.exec_shell_cmd("ceph orch ls --service_type=rgw --format json")
-            rgw_process_name = json.loads(out)[0]["service_name"]
+            service_name = json.loads(out)[0]["service_name"]
             utils.exec_shell_cmd(
-                f"ceph config set client.{rgw_process_name} rgw_enable_ops_log true"
+                f"ceph config set client.{service_name} rgw_enable_ops_log true"
             )
             utils.exec_shell_cmd(
-                f"ceph config set client.{rgw_process_name} rgw_log_http_headers http_x_forwarded_for,http_expect,http_content_md5"
+                f"ceph config set client.{service_name} rgw_log_http_headers http_x_forwarded_for,http_expect,http_content_md5"
             )
             utils.exec_shell_cmd(
-                f"ceph config set client.{rgw_process_name} rgw_ops_log_socket_path /var/run/ceph/opslog"
+                f"ceph config set client.{service_name} rgw_ops_log_socket_path /var/run/ceph/opslog"
             )
             srv_restarted = rgw_service.restart()
             time.sleep(30)
@@ -174,7 +174,7 @@ def test_exec(config, ssh_con):
 
         ceph_detail = json.loads(utils.exec_shell_cmd("ceph -s -f json"))
         out = utils.exec_shell_cmd("ceph orch ps --daemon_type=rgw --format json")
-        rgw_process_names = [d["daemon_name"] for d in json.loads(out)]
+        rgw_process_names = [d["service_name"] for d in json.loads(out)]
 
         with open(root_path, "r") as file:
             file_details = yaml.safe_load(file)

--- a/rgw/v2/tests/s3cmd/test_rgw_ops_log.py
+++ b/rgw/v2/tests/s3cmd/test_rgw_ops_log.py
@@ -174,7 +174,7 @@ def test_exec(config, ssh_con):
 
         ceph_detail = json.loads(utils.exec_shell_cmd("ceph -s -f json"))
         out = utils.exec_shell_cmd("ceph orch ps --daemon_type=rgw --format json")
-        rgw_process_names = [d["service_name"] for d in json.loads(out)]
+        rgw_process_names = [d["daemon_name"] for d in json.loads(out)]
 
         with open(root_path, "r") as file:
             file_details = yaml.safe_load(file)

--- a/rgw/v2/tests/s3cmd/test_rgw_ops_log.py
+++ b/rgw/v2/tests/s3cmd/test_rgw_ops_log.py
@@ -77,9 +77,8 @@ def test_exec(config, ssh_con):
         ceph_version_id, _ = utils.get_ceph_version()
         ceph_version_id = ceph_version_id.split("-")[0].split(".")
         if float(ceph_version_id[0]) >= 17:
-            cmd = " ceph orch ps --daemon_type=rgw"
-            out = utils.exec_shell_cmd(cmd)
-            rgw_process_name = out.split()[0]
+            out = utils.exec_shell_cmd("ceph orch ls --service_type=rgw --format json")
+            rgw_process_name = json.loads(out)[0]["service_name"]
             utils.exec_shell_cmd(
                 f"ceph config set client.{rgw_process_name} rgw_enable_ops_log true"
             )
@@ -174,8 +173,8 @@ def test_exec(config, ssh_con):
             utils.exec_shell_cmd(f"ceph config set global log_to_file true")
 
         ceph_detail = json.loads(utils.exec_shell_cmd("ceph -s -f json"))
-        out = utils.exec_shell_cmd("ceph orch ps --daemon_type=rgw | awk '{print $1}'")
-        rgw_process_names = out.split()
+        out = utils.exec_shell_cmd("ceph orch ps --daemon_type=rgw --format json")
+        rgw_process_names = [d["daemon_name"] for d in json.loads(out)]
 
         with open(root_path, "r") as file:
             file_details = yaml.safe_load(file)


### PR DESCRIPTION
Fixes failure of Test rgw opslog io though s3cmd (CEPH-83575194) on extended regression pipeline.
## Problem
On the pipeline, cluster instance/hostnames contain "rgw" (e.g. ceph-rgw-ex2-f2tm-*, ceph-rgw2104-mgnm-*).
The test used `ceph orch ps | grep rgw` and took the first token as the RGW entity name.
Because mgr/mon hostnames also contain "rgw", grep matched mgr first — not the actual RGW daemon.
Opslog config was applied to mgr, the opslog socket stayed empty, and json.loads failed.
## Old code (before fix)

```
cmd = " ceph orch ps | grep rgw"
out = utils.exec_shell_cmd(cmd)
rgw_process_name = out.split()[0]
utils.exec_shell_cmd(
    f"ceph config set client.{rgw_process_name} rgw_enable_ops_log true"
)
```
Failure log — extended regression (ceph-rgw-ex2-f2tm-*)
Cluster: rgw-ex2-f2tm | Ceph 19.2.1-363 | tier-2_rgw_test_using_s3cmd

```
executing cmd:  ceph orch ps | grep rgw
# first grep match — mgr, because hostname contains "rgw":
mgr.ceph-rgw-ex2-f2tm-z9zcda-node1-installer.jawgco  ceph-rgw-ex2-f2tm-z9zcda-node1-installer  *:9283,8765  running
executing cmd: ceph config set client.mgr.ceph-rgw-ex2-f2tm-z9zcda-node1-installer.jawgco rgw_enable_ops_log true
executing cmd: ceph config set client.mgr.ceph-rgw-ex2-f2tm-z9zcda-node1-installer.jawgco rgw_log_http_headers ...
executing cmd: ceph config set client.mgr.ceph-rgw-ex2-f2tm-z9zcda-node1-installer.jawgco rgw_ops_log_socket_path /var/run/ceph/opslog
ERROR: Expecting value: line 1 column 1 (char 0)
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

Fix
Use service_name from ceph orch ls JSON and apply opslog config at service level so all RGW daemons get it regardless of hostname naming.

```
out = utils.exec_shell_cmd("ceph orch ls --service_type=rgw --format json")
service_name = json.loads(out)[0]["service_name"]
utils.exec_shell_cmd(
    f"ceph config set client.{service_name} rgw_enable_ops_log true"
)
```


failed logs: https://10.8.128.2/cephci-jenkins/ibm-cos//IBM/8.1/rhel-9/extended_regression/19.2.1-363/rgw/2/logs/Tier_2_rgw_test_using_s3cmd/
pass logs:
https://10.8.128.2/cephci-jenkins/ibm-cos//IBM/9.1/rhel-10/executor/20.2.1-294/rgw/2105/logs/tier_2_rgw_test_using_s3cmd/