### PR TITLE
adding support for testing rgw-ssl SAN entries with virtual host bucket access

### DIFF
--- a/rgw/v2/lib/curl/resource_op.py
+++ b/rgw/v2/lib/curl/resource_op.py
@@ -9,8 +9,25 @@ from v2.tests.aws import reusable as aws_reusable
 log = logging.getLogger()
 
 
+def convert_to_virtual_host_endpoint_url(endpoint_url, bucket_name, domain_name):
+    url_parts = endpoint_url.split(":")
+    protocol = url_parts[0]
+    port = url_parts[2]
+    virtual_host_endpoint_url = f"{protocol}://{bucket_name}.{domain_name}:{port}"
+    return virtual_host_endpoint_url
+
+
 class CURL:
-    def __init__(self, user_info, ssh_con, curl_silent=True, ssl=None):
+    def __init__(
+        self,
+        user_info,
+        ssh_con,
+        curl_silent=True,
+        ssl=None,
+        ssl_trusted=False,
+        virtual_host_bkt_access=False,
+        domain_name=None,
+    ):
         """
         Constructor for curl class
         user_info(dict) : user details
@@ -24,8 +41,11 @@ class CURL:
         else:
             self.prefix = f"curl --show-error --fail-with-body -v --aws-sigv4 aws:amz:us-east-1:s3 -u '{self.username}:{self.password}'"
         if ssl:
-            self.prefix = self.prefix + " --insecure"
+            if ssl_trusted is False:
+                self.prefix = self.prefix + " --insecure"
         self.prefix_for_presigned_url = f"curl --show-error --fail-with-body -v -s"
+        self.virtual_host_bkt_access = virtual_host_bkt_access
+        self.domain_name = domain_name
 
     def command(
         self,
@@ -37,6 +57,7 @@ class CURL:
         raw_data_list=None,
         head_request=None,
         presigned_url=None,
+        virtual_hosted_style_request=False,
     ):
         """
         Args:
@@ -74,9 +95,18 @@ class CURL:
         if presigned_url:
             url = presigned_url
         else:
-            url = self.endpoint_url
-            if url_suffix:
-                url = f"{url}/{url_suffix}"
+            if virtual_hosted_style_request:
+                url_suffix_contents = url_suffix.split("/", 1)
+                bucket_name = url_suffix_contents.pop(0)
+                url = convert_to_virtual_host_endpoint_url(
+                    self.endpoint_url, bucket_name, self.domain_name
+                )
+                if url_suffix_contents:
+                    url = f"{url}/{url_suffix_contents.pop(0)}"
+            else:
+                url = self.endpoint_url
+                if url_suffix:
+                    url = f"{url}/{url_suffix}"
         cmd = f"{cmd} '{url}'"
         log.info(f"CURL command created: {cmd}")
         return cmd

--- a/rgw/v2/tests/curl/configs/test_rgw_ssl_SAN_virtual_host_bkt_access.yaml
+++ b/rgw/v2/tests/curl/configs/test_rgw_ssl_SAN_virtual_host_bkt_access.yaml
@@ -1,0 +1,19 @@
+# script: test_rgw_using_curl.py
+# polarion: CEPH-83575572
+config:
+  user_count: 1
+  bucket_count: 2
+  objects_count: 20
+  objects_size_range:
+    min: 5
+    max: 15
+  local_file_delete: true
+  test_ops:
+    create_bucket: true
+    create_object: true
+    download_object: false
+    user_remove: true
+    ssl_trusted: true
+    virtual_host_bkt_access: true
+    domain_name: s3.example.com
+    install_configure_dnsmasq: true

--- a/rgw/v2/tests/curl/configs/test_rgw_ssl_SAN_virtual_host_bkt_access_multipart_upload.yaml
+++ b/rgw/v2/tests/curl/configs/test_rgw_ssl_SAN_virtual_host_bkt_access_multipart_upload.yaml
@@ -1,0 +1,21 @@
+# script: test_rgw_using_curl.py
+# polarion: CEPH-9801
+config:
+  user_count: 1
+  bucket_count: 2
+  objects_count: 10
+  objects_size_range:
+    min: 10M
+    max: 20M
+  local_file_delete: true
+  test_ops:
+    create_bucket: true
+    create_object: true
+    upload_type: multipart
+    download_object: true
+    delete_bucket_object: true
+    user_remove: true
+    ssl_trusted: true
+    virtual_host_bkt_access: true
+    domain_name: s3.example.com
+    install_configure_dnsmasq: true

--- a/rgw/v2/tests/curl/reusable.py
+++ b/rgw/v2/tests/curl/reusable.py
@@ -198,7 +198,10 @@ def create_bucket(curl_auth, bucket_name, endpoint, retries=3, wait_time=5):
         "x-amz-content-sha256": "UNSIGNED-PAYLOAD",
     }
     command = curl_auth.command(
-        http_method="PUT", headers=headers, url_suffix=bucket_name
+        http_method="PUT",
+        headers=headers,
+        url_suffix=bucket_name,
+        virtual_hosted_style_request=curl_auth.virtual_host_bkt_access,
     )
     bucket_creation_status = utils.exec_shell_cmd(command)
     if bucket_creation_status is False:
@@ -278,6 +281,7 @@ def upload_object(
         input_file=s3_object_path,
         url_suffix=f"{bucket_name}/{s3_object_name}",
         presigned_url=presigned_url,
+        virtual_hosted_style_request=curl_auth.virtual_host_bkt_access,
     )
     upload_object_status = utils.exec_shell_cmd(command)
     if upload_object_status is False:
@@ -318,6 +322,7 @@ def put_cors_object(
         headers=headers,
         input_file=s3_object_path,
         url_suffix=f"{bucket_name}/{s3_object_name}",
+        virtual_hosted_style_request=curl_auth.virtual_host_bkt_access,
     )
     upload_object_status, err = utils.exec_shell_cmd(command, debug_info=True)
     log.info(upload_object_status)
@@ -359,6 +364,7 @@ def download_object(
         headers=headers,
         output_file=s3_object_download_path,
         url_suffix=f"{bucket_name}/{s3_object_name}",
+        virtual_hosted_style_request=curl_auth.virtual_host_bkt_access,
     )
     upload_object_status = utils.exec_shell_cmd(command)
     if upload_object_status is False:
@@ -396,6 +402,7 @@ def delete_object(curl_auth, bucket_name, s3_object_name, cors_origin=None):
         http_method="DELETE",
         headers=headers,
         url_suffix=f"{bucket_name}/{s3_object_name}",
+        virtual_hosted_style_request=curl_auth.virtual_host_bkt_access,
     )
     delete_object_status = utils.exec_shell_cmd(command)
     if delete_object_status is False:
@@ -417,7 +424,10 @@ def delete_bucket(curl_auth, bucket_name):
         "x-amz-content-sha256": "UNSIGNED-PAYLOAD",
     }
     command = curl_auth.command(
-        http_method="DELETE", headers=headers, url_suffix=f"{bucket_name}"
+        http_method="DELETE",
+        headers=headers,
+        url_suffix=f"{bucket_name}",
+        virtual_hosted_style_request=curl_auth.virtual_host_bkt_access,
     )
     delete_bucket_status = utils.exec_shell_cmd(command)
     if delete_bucket_status is False:
@@ -608,7 +618,10 @@ def head_bucket(curl_auth, bucket_name):
         "x-amz-content-sha256": "UNSIGNED-PAYLOAD",
     }
     command = curl_auth.command(
-        headers=headers, url_suffix=f"{bucket_name}", head_request=True
+        headers=headers,
+        url_suffix=f"{bucket_name}",
+        head_request=True,
+        virtual_hosted_style_request=curl_auth.virtual_host_bkt_access,
     )
     cmd_output = utils.exec_shell_cmd(command)
     log.info(f"head bucket result: {cmd_output}")
@@ -662,6 +675,7 @@ def create_multipart_upload(curl_auth, bucket_name, s3_object_name):
         http_method="POST",
         headers=headers,
         url_suffix=f"{bucket_name}/{s3_object_name}?uploads=true",
+        virtual_hosted_style_request=curl_auth.virtual_host_bkt_access,
     )
     create_mpu_output = utils.exec_shell_cmd(command)
     if create_mpu_output is False:
@@ -704,6 +718,7 @@ def upload_part(
         headers=headers,
         input_file=body,
         url_suffix=f"{bucket_name}/{s3_object_name}?partNumber={part_number}&uploadId={upload_id}",
+        virtual_hosted_style_request=curl_auth.virtual_host_bkt_access,
     )
     upload_part_output, verbose_output = utils.exec_shell_cmd(command, debug_info=True)
     if upload_part_output is False:
@@ -748,6 +763,7 @@ def complete_multipart_upload(
         headers=headers,
         raw_data_list=[complete_mpu_string],
         url_suffix=f"{bucket_name}/{s3_object_name}?uploadId={upload_id}",
+        virtual_hosted_style_request=curl_auth.virtual_host_bkt_access,
     )
     complete_mpu_output = utils.exec_shell_cmd(command)
     if complete_mpu_output is False:

--- a/rgw/v2/tests/curl/test_rgw_using_curl.py
+++ b/rgw/v2/tests/curl/test_rgw_using_curl.py
@@ -64,6 +64,10 @@ def test_exec(config, ssh_con):
     all_users_info = resource_op.create_users(no_of_users_to_create=config.user_count)
     endpoint = aws_reusable.get_endpoint(ssh_con, ssl=config.ssl)
 
+    if config.test_ops.get("install_configure_dnsmasq"):
+        domain_name = config.test_ops.get("domain_name", False)
+        ip_address = endpoint.split(":")[1][2:]
+        utils.install_configure_dnsmasq(domain_name, ip_address)
     if (
         config.test_ops.get("test_rgw_user_cap_user_info_without_keys")
         and user_info_without_keys_cap_available
@@ -73,7 +77,12 @@ def test_exec(config, ssh_con):
         user1_id = user1["user_id"]
         user2 = all_users_info[1]
         user2_id = user2["user_id"]
-        curl_auth = CURL(user1, ssh_con, ssl=config.ssl)
+        curl_auth = CURL(
+            user1,
+            ssh_con,
+            ssl=config.ssl,
+            ssl_trusted=config.test_ops.get("ssl_trusted", False),
+        )
 
         utils.exec_shell_cmd(
             f"radosgw-admin caps add --uid={user1_id} --caps='users=write'"
@@ -108,10 +117,23 @@ def test_exec(config, ssh_con):
         user_name = each_user["user_id"]
         log.info(user_name)
 
-        curl_auth = CURL(each_user, ssh_con, ssl=config.ssl)
+        curl_auth = CURL(
+            each_user,
+            ssh_con,
+            ssl=config.ssl,
+            ssl_trusted=config.test_ops.get("ssl_trusted", False),
+            virtual_host_bkt_access=config.test_ops.get(
+                "virtual_host_bkt_access", False
+            ),
+            domain_name=config.test_ops.get("domain_name", False),
+        )
 
         for bc in range(config.bucket_count):
             bucket_name = utils.gen_bucket_name_from_userid(user_name, rand_no=bc)
+            if config.test_ops.get("virtual_host_bkt_access", False):
+                # replace dots in bucket_name with hyphens
+                # because they break virtual-hosted-style HTTPS access due to SSL wildcard certificate limits
+                bucket_name = bucket_name.replace(".", "-")
             curl_reusable.create_bucket(curl_auth, bucket_name, endpoint)
             log.info(f"Bucket {bucket_name} created")
 

--- a/rgw/v2/utils/utils.py
+++ b/rgw/v2/utils/utils.py
@@ -1103,3 +1103,52 @@ def get_rgw_endpoint_url(ssh_con=None):
     endpoint_url = f"{endpoint_proto}://{endpoint_hostname_or_ip}:{endpoint_port}"
     log.info(f"RGW endpoint url from ceph orch ls: {endpoint_url}")
     return endpoint_url
+
+
+def install_configure_dnsmasq(domain, ip_address):
+    """
+    This method installs and configures dnsmasq for wildcard dns resolution.
+    also configures loopback namespace in /etc/resolve.conf for dns resolution to work properly
+    """
+
+    out = exec_shell_cmd("rpm -q dnsmasq || sudo yum install -y dnsmasq")
+    if out is False:
+        raise Exception("dnsmasq installation failed")
+
+    # Configuration variables
+    conf_file = "/etc/dnsmasq.conf"
+
+    # The dnsmasq syntax for a domain and all its subdomains
+    wildcard_line = f"address=/{domain}/{ip_address}\n"
+    wildcard_line_localhost = "address=/localhost/127.0.0.1\n"
+
+    conf_file_content = exec_shell_cmd(f"cat {conf_file} | grep -v ^# | grep -v ^$")
+    # Append the wildcard resolution line if not already exist
+    with open(conf_file, "a") as file:
+        if wildcard_line in conf_file_content:
+            log.info(f"'{wildcard_line}' already exist")
+        else:
+            file.write(wildcard_line)
+        if wildcard_line_localhost in conf_file_content:
+            log.info(f"'{wildcard_line_localhost}' already exist")
+        else:
+            file.write(wildcard_line_localhost)
+    print(f"Successfully added wildcard for {domain} to {conf_file}.")
+
+    # Add the nameserver for loopback as the first active line
+    resolve_conf_file = "/etc/resolv.conf"
+    nameserver_line = "nameserver 127.0.0.1"
+    resolve_conf_file_content = exec_shell_cmd(f"cat {resolve_conf_file}")
+    resolve_conf_file_content = resolve_conf_file_content.strip()
+    if nameserver_line not in resolve_conf_file_content:
+        resolve_conf_file_content = f"{nameserver_line}\n{resolve_conf_file_content}"
+    with open(resolve_conf_file, "w") as file:
+        file.write(resolve_conf_file_content)
+    print(
+        f"Successfully added namespace localhost as first active line to {resolve_conf_file}."
+    )
+
+    # Restart the dnsmasq service to apply changes
+    out = exec_shell_cmd("sudo systemctl restart dnsmasq")
+    if out is False:
+        raise Exception("dnsmasq restart failed")


### PR DESCRIPTION
Automation of virtual host bucket access testing with curl. rgw-ssl deployed with generate_cert and zonegroup-hostnames to allow virtual_host_bucket_access
Tests cephadm feature support SAN entries for wildcard dns.

Feature bzs:
https://bugzilla.redhat.com/show_bug.cgi?id=2249984
https://bugzilla.redhat.com/show_bug.cgi?id=2330954

polarion testcase: https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83604472

pass logs on 8.1z2:
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/SAN_virtual_host_bucket_access/cephci-run-IPULFD/

Note:
this feature is broken on latest 8.1, 9.1 and 9.2 builds. hence provided the pass logs on an older 8.1 build where the feature is working properly.
bz's filed for the issues: 
https://ibm-ceph.atlassian.net/browse/IBMCEPH-16390
https://ibm-ceph.atlassian.net/browse/IBMCEPH-16394
https://ibm-ceph.atlassian.net/browse/IBMCEPH-17328