### PR TITLE
End to End SSL passthrough, support IOs via Ingress Endpoint

### DIFF
--- a/rgw/v2/lib/resource_op.py
+++ b/rgw/v2/lib/resource_op.py
@@ -454,6 +454,8 @@ class Config(object):
             "ssl",
         )
         self.haproxy = self.doc["config"].get("haproxy", False)
+        self.endpoint_ip = self.doc["config"].get("endpoint_ip")
+        self.endpoint_port = self.doc["config"].get("endpoint_port")
         self.test_sync_consistency_bucket_stats = self.doc["config"].get(
             "test_sync_consistency_bucket_stats", False
         )

--- a/rgw/v2/lib/s3/auth.py
+++ b/rgw/v2/lib/s3/auth.py
@@ -27,7 +27,14 @@ class Auth(object):
         """
         self.access_key = user_info["access_key"]
         self.secret_key = user_info["secret_key"]
-        if ssh_con is not None:
+        endpoint_ip = extra_kwargs.get("endpoint_ip")
+        endpoint_port = extra_kwargs.get("endpoint_port")
+        if endpoint_ip:
+            self.ip = endpoint_ip
+            self.port = endpoint_port or 443
+            self.hostname = endpoint_ip
+            log.info(f"Using explicit endpoint: {self.ip}:{self.port}")
+        elif ssh_con is not None:
             stdin, stdout, stderr = ssh_con.exec_command("hostname")
             self.hostname = stdout.readline().strip()
             self.port = utils.get_radosgw_port_no(ssh_con)
@@ -41,7 +48,7 @@ class Auth(object):
             self.ip = socket.gethostbyname(self.hostname)
         self.ssl = extra_kwargs.get("ssl", False)
         self.haproxy = extra_kwargs.get("haproxy", False)
-        if self.haproxy:
+        if self.haproxy and not endpoint_ip:
             self.port = 5000
         self.endpoint_url = (
             "https://{}:{}".format(self.ip, self.port)

--- a/rgw/v2/tests/go_scripts/aws_sdk_go_v2/test_checksum.go
+++ b/rgw/v2/tests/go_scripts/aws_sdk_go_v2/test_checksum.go
@@ -1,30 +1,28 @@
 package main
 
-import (
-    "flag"
-	"bytes"
-	"context"
-	"fmt"
-	"io"
-	"os"
-	"log"
-	"errors"
-	"encoding/hex"
-	"crypto/md5"
-	"crypto/sha1"
-	"crypto/sha256"
-	"hash/crc32"
-	"github.com/minio/crc64nvme"
-    "encoding/base64"
-    "encoding/binary"
-
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/credentials"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/aws/aws-sdk-go-v2/service/s3/types"
-)
-
+import "bytes"
+import "context"
+import "crypto/md5"
+import "crypto/sha1"
+import "crypto/sha256"
+import "crypto/tls"
+import "encoding/base64"
+import "encoding/binary"
+import "encoding/hex"
+import "errors"
+import "flag"
+import "fmt"
+import "github.com/aws/aws-sdk-go-v2/aws"
+import "github.com/aws/aws-sdk-go-v2/config"
+import "github.com/aws/aws-sdk-go-v2/credentials"
+import "github.com/aws/aws-sdk-go-v2/service/s3"
+import "github.com/aws/aws-sdk-go-v2/service/s3/types"
+import "github.com/minio/crc64nvme"
+import "hash/crc32"
+import "io"
+import "log"
+import "net/http"
+import "os"
 
 func main() {
 
@@ -136,8 +134,12 @@ func main() {
 
 func setupS3Client(ctx context.Context, accessKey string, secretKey string, endpointUrl string) *s3.Client {
     fmt.Println("Setting up s3 client")
-// 	awsConfig, err := config.LoadDefaultConfig(ctx, config.WithClientLogMode(aws.LogRequestWithBody|aws.LogResponseWithBody), config.WithRegion("us-east-1"), config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKey, secretKey, "")) )
-	awsConfig, err := config.LoadDefaultConfig(ctx, config.WithClientLogMode(aws.LogRequest|aws.LogResponse), config.WithRegion("us-east-1"), config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKey, secretKey, "")) )
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+	awsConfig, err := config.LoadDefaultConfig(ctx, config.WithClientLogMode(aws.LogRequest|aws.LogResponse), config.WithRegion("us-east-1"), config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKey, secretKey, "")), config.WithHTTPClient(httpClient) )
 	if err != nil {
 		fmt.Println("failed to load AWS config: %v\n", err)
 		os.Exit(1)

--- a/rgw/v2/tests/go_scripts/test_rgw_using_go.py
+++ b/rgw/v2/tests/go_scripts/test_rgw_using_go.py
@@ -13,7 +13,6 @@ the workflow is to test all permutations of:
 4. with operations - copy, download, get-object-attributes, delete
 """
 
-
 import argparse
 import json
 import logging
@@ -51,7 +50,12 @@ def test_exec(config, ssh_con, config_yaml_path):
     go_auth.install_go()
     if config.test_ops.get("use_ssl"):
         config.ssl = True
-    endpoint = aws_reusable.get_endpoint(ssh_con, ssl=config.ssl)
+    if config.endpoint_ip:
+        scheme = "https" if config.ssl else "http"
+        port = config.endpoint_port or 443
+        endpoint = f"{scheme}://{config.endpoint_ip}:{port}"
+    else:
+        endpoint = aws_reusable.get_endpoint(ssh_con, ssl=config.ssl)
     all_users_info = resource_op.create_users(no_of_users_to_create=config.user_count)
 
     # create local objects

--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -3734,10 +3734,10 @@ def get_rgw_service_port():
     return rgw_serv_port
 
 
-def get_auth(user_info, ssh_con, ssl, haproxy):
+def get_auth(user_info, ssh_con, ssl, haproxy, **kwargs):
     rgw_service_port = get_rgw_service_port()
     haproxy = False if rgw_service_port == 443 else haproxy
-    return Auth(user_info, ssh_con, ssl=ssl, haproxy=haproxy)
+    return Auth(user_info, ssh_con, ssl=ssl, haproxy=haproxy, **kwargs)
 
 
 def verify_object_accessibility(s3_client, bucket_name, object_key):

--- a/rgw/v2/tests/s3_swift/test_LargeObjGet_GC.py
+++ b/rgw/v2/tests/s3_swift/test_LargeObjGet_GC.py
@@ -42,7 +42,13 @@ def test_exec(config, ssh_con):
     # create user
     user_info = s3lib.create_users(config.user_count)
     user_info = user_info[0]
-    auth = Auth(user_info, ssh_con, ssl=config.ssl)
+    auth = Auth(
+        user_info,
+        ssh_con,
+        ssl=config.ssl,
+        endpoint_ip=config.endpoint_ip,
+        endpoint_port=config.endpoint_port,
+    )
     rgw_conn = auth.do_auth()
     rgw_conn2 = auth.do_auth_using_client()
     log.info("no of buckets to create: %s" % config.bucket_count)

--- a/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
+++ b/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
@@ -125,7 +125,14 @@ def test_exec(config, ssh_con):
             log.info("RGW service restarted")
     for each_user in all_users_info:
         # authenticate
-        auth = reusable.get_auth(each_user, ssh_con, config.ssl, config.haproxy)
+        auth = reusable.get_auth(
+            each_user,
+            ssh_con,
+            config.ssl,
+            config.haproxy,
+            endpoint_ip=config.endpoint_ip,
+            endpoint_port=config.endpoint_port,
+        )
         if config.use_aws4 is True:
             rgw_conn = auth.do_auth(**{"signature_version": "s3v4"})
         else:


### PR DESCRIPTION
Summary

Enables end-to-end SSL testing through HAProxy ingress in TCP passthrough mode (client → HTTPS → HAProxy → HTTPS → RGW). Deploys ingress with a floating IP VIP, uses nftables DNAT for cross-node reachability, and routes S3 IO through the ingress endpoint.

Changes

test_ssl_ingress_deploy.py (new) — Allocates floating IP, deploys ingress with use_tcp_mode_over_rgw: true, adds DNAT rule, saves VIP to /tmp/ingress_vip

sanity_rgw.py — Injects endpoint_ip/endpoint_port into test config when use-ingress: true

utility/utils.py — install_start_kafka now installs JDK before Kafka

conf/tentacle/rgw/tier-2_rgw_ssl_ingress.yaml (new) — 6-node cluster conf with dedicated ingress node (node5) and 2 RGW nodes (node3, node4)

ceph-qe-scripts (auth.py, resource_op.py, reusable.py, test_Mbuckets_with_Nobjects.py, test_LargeObjGet_GC.py, test_rgw_using_go.py, test_checksum.go) — Accept optional endpoint_ip/endpoint_port for routing IO via ingress; falls through to existing SSH discovery when not set

deployment logs
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ZHUS95/
IOs with Ingress endpoint logs
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-LN0K61
Regression logs
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-CJOW2Z