### PR TITLE
[Close Loop Automation]: Check whether secret_keys are created for every subuser

### DIFF
--- a/rgw/v2/tests/s3_swift/test_swift_all_objects_lc.py
+++ b/rgw/v2/tests/s3_swift/test_swift_all_objects_lc.py
@@ -48,6 +48,16 @@ def test_exec(config, ssh_con):
         subuser_info = swiftlib.create_non_tenant_sub_users(
             config.container_count, user_info
         )
+        # Validate that secret_key is generated for all subusers
+        # Close loop JIRA automation https://ibm-ceph.atlassian.net/browse/IBMCEPH-12342
+        ceph_version_id, _ = utils.get_ceph_version()
+        if ceph_version_id >= "20.2":
+            for subuser in subuser_info:
+                if "key" not in subuser or not subuser["key"]:
+                    raise TestExecError(
+                        f"secret_key not generated for subuser {subuser.get('user_id', 'unknown')}"
+                    )
+                log.info(f"secret_key verified for subuser: {subuser['user_id']}")
         auth = Auth(subuser_info[-1], ssh_con, config.ssl)
         rgw = auth.do_auth_using_client()
 


### PR DESCRIPTION
[BZ#2403487] [Regression] The Subuser creation doesn't generating the secret keys automatically

Check for secret keys with every sub user of RGW greater than Ceph version 9.0.

Pass log : http://magna002.ceph.redhat.com/cephci-jenkins/tchandra/subuser_secret_check.txt