### PR TITLE
rgw: Add pytest-based RGW dedup full feature automation coverage.

### DIFF
--- a/rgw/requirements.txt
+++ b/rgw/requirements.txt
@@ -14,6 +14,7 @@ swiftly
 paramiko
 pandas==2.2.3
 pyarrow
+pytest
 
 # for v1
 #psutil

--- a/rgw/standalone/dedup/test_dedup_scale_pytest.py
+++ b/rgw/standalone/dedup/test_dedup_scale_pytest.py
@@ -1,0 +1,563 @@
+"""
+test_dedup_scale_pytest.py - RGW Dedup Scale & Performance Test Suite
+
+This is a STANDALONE pytest suite for scale/performance dedup scenarios that
+are too slow or resource-intensive for CI. These tests are NOT part of the
+main CI dedup suite (test_dedup_pytest.py with 58 tests) and must be run
+manually on a dedicated cluster.
+
+What it tests:
+  These 8 tests fill gaps left by the CI suite — large objects, multipart
+  uploads, cross-bucket dedup at scale, multi-RGW distribution, throttle
+  tuning, and lifecycle transitions. They exercise code paths that only
+  trigger at scale or with specific object sizes (e.g., >4MB split-head
+  dedup, >5MB multipart copy).
+
+Test matrix:
+  SC01 : Large objects >4MB — tests non-split-head dedup path
+  SC02 : Multipart objects 50MB/500MB — upload + range GETs after dedup
+  SC03 : S3 COPY of >5MB objects — multipart copy path with dedup
+  SC04 : 10K objects across multiple buckets at 50% dup rate
+  SC05 : Multi-RGW scaleout — completion time + work distribution
+  SC06 : High duplication rate (90%) — 1000 objects, measures savings
+  SC07 : Throttle control — 50 vs 500 ops/sec comparison
+  SC08 : LC transition of deduped objects to different storage class
+
+Prerequisites:
+  - A deployed Ceph cluster with RGW and dedup enabled
+  - Sufficient cluster capacity (SC02 needs ~1GB, SC04 needs ~5GB stored)
+  - The ceph-qe-scripts repo cloned with v2/lib and v2/utils available
+  - A config YAML with RGW endpoint, access/secret keys, and bucket info
+
+Usage:
+  # Run all scale tests
+  pytest test_dedup_scale_pytest.py --config <config.yaml> -v
+
+  # Run a specific test
+  pytest test_dedup_scale_pytest.py --config <config.yaml> -k "test_sc01"
+
+  # Run only scale-marked tests
+  pytest test_dedup_scale_pytest.py --config <config.yaml> -m scale
+"""
+
+import hashlib
+import json
+import logging
+import os
+import random
+import sys
+import time
+
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(__file__, "../../../..")))
+
+import v2.lib.resource_op as s3lib
+import v2.utils.utils as utils
+from v2.tests.s3_swift import reusable
+from v2.tests.s3_swift.reusables import dedup as dedup_utils
+
+log = logging.getLogger()
+
+
+# =============================================================================
+# SC01: Large objects >4MB (non-split-head dedup path)
+# =============================================================================
+
+
+@pytest.mark.sanity
+def test_sc01_large_objects_above_4mb(s3_client, bucket):
+    """SC01: Basic dedup for large objects > 4MB.
+
+    First suite (S1/S2) uses 5-10KB objects which go through split-head.
+    This test uses 5MB objects which take the regular (non-split-head) dedup path.
+    """
+    obj_count = 50
+    obj_size = 5 * 1024 * 1024  # 5MB
+
+    keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket, obj_count, obj_size, prefix="sc01-large"
+    )
+
+    dedup_utils.run_dedup_estimate()
+    estimate_stats = dedup_utils.wait_for_dedup_completion()
+    assert estimate_stats.get("completed") is True, "Estimate did not complete"
+
+    dedup_utils.run_dedup_execute()
+    exec_stats = dedup_utils.wait_for_dedup_completion()
+    assert exec_stats.get("completed") is True, "Exec did not complete"
+
+    parsed = dedup_utils.parse_dedup_stats(exec_stats)
+    assert parsed.get("deduped_count", 0) > 0, "Expected objects to be deduplicated"
+
+    parsed_full = dedup_utils.parse_dedup_stats_full(exec_stats)
+    split_head_src = parsed_full.get("split_head_src", 0)
+    log.info(f"SC01: split_head_src={split_head_src} (expect 0 for >4MB objects)")
+
+    dedup_utils.verify_all_objects_accessible(s3_client, bucket, keys)
+    dedup_utils.verify_all_objects_integrity(s3_client, bucket, keys, expected_md5)
+
+    dedup_utils.log_dedup_savings(exec_stats, obj_count * obj_size, "SC01")
+
+
+# =============================================================================
+# SC02: Multipart objects 50MB/500MB with range GETs
+# =============================================================================
+
+
+@pytest.mark.feature
+@pytest.mark.slow
+def test_sc02_multipart_large_objects(s3_client, bucket):
+    """SC02: Dedup multipart objects at 50MB and 500MB.
+
+    First suite (S6) uses 20MB multipart. This tests much larger objects
+    to stress multipart manifest handling in dedup.
+    """
+    sizes = [50 * 1024 * 1024, 500 * 1024 * 1024]  # 50MB, 500MB
+    all_keys = []
+    md5_map = {}
+
+    for size in sizes:
+        size_label = f"{size // (1024 * 1024)}MB"
+        count = 3
+        keys, md5_hash, _ = dedup_utils.upload_identical_multipart_objects(
+            s3_client, bucket, count, size, prefix=f"sc02-mp-{size_label}"
+        )
+        all_keys.extend(keys)
+        for k in keys:
+            md5_map[k] = md5_hash
+
+    dedup_utils.run_dedup_estimate()
+    estimate_stats = dedup_utils.wait_for_dedup_completion(timeout=1800)
+    assert estimate_stats.get("completed") is True, "Estimate did not complete"
+
+    dedup_utils.run_dedup_execute()
+    exec_stats = dedup_utils.wait_for_dedup_completion(timeout=1800)
+    assert exec_stats.get("completed") is True, "Exec did not complete"
+
+    parsed = dedup_utils.parse_dedup_stats(exec_stats)
+    assert (
+        parsed.get("deduped_count", 0) > 0
+    ), "Expected multipart objects to be deduplicated"
+
+    for key in all_keys:
+        dedup_utils.verify_object_integrity(s3_client, bucket, key, md5_map[key])
+        dedup_utils.verify_range_get(s3_client, bucket, key)
+
+    total_uploaded = sum(3 * s for s in sizes)
+    dedup_utils.log_dedup_savings(exec_stats, total_uploaded, "SC02")
+
+
+# =============================================================================
+# SC03: S3 COPY of >5MB objects (multipart copy path)
+# =============================================================================
+
+
+@pytest.mark.regression
+def test_sc03_s3_copy_large_objects(s3_client, bucket):
+    """SC03: S3 COPY of 10MB objects — triggers multipart copy path.
+
+    First suite (S12) copies 5KB objects which use simple copy.
+    Objects >5MB use server-side multipart copy internally, producing
+    different manifest structures that dedup must handle.
+    """
+    obj_size = 10 * 1024 * 1024  # 10MB
+    source_data = dedup_utils.generate_identical_data(obj_size)
+    expected_md5 = hashlib.md5(source_data).hexdigest()
+
+    source_key = "sc03-source-10mb"
+    s3_client.put_object(Bucket=bucket, Key=source_key, Body=source_data)
+
+    copy_keys = []
+    for i in range(20):
+        copy_key = f"sc03-copy-{i}"
+        s3_client.copy_object(
+            Bucket=bucket,
+            Key=copy_key,
+            CopySource={"Bucket": bucket, "Key": source_key},
+        )
+        copy_keys.append(copy_key)
+
+    all_keys = [source_key] + copy_keys
+
+    dedup_utils.run_dedup_estimate()
+    estimate_stats = dedup_utils.wait_for_dedup_completion()
+    assert estimate_stats.get("completed") is True, "Estimate did not complete"
+
+    dedup_utils.run_dedup_execute()
+    exec_stats = dedup_utils.wait_for_dedup_completion()
+    assert exec_stats.get("completed") is True, "Exec did not complete"
+
+    parsed = dedup_utils.parse_dedup_stats(exec_stats)
+    assert (
+        parsed.get("deduped_count", 0) > 0
+    ), "Copied >5MB objects should be deduplicated"
+
+    dedup_utils.verify_all_objects_integrity(s3_client, bucket, all_keys, expected_md5)
+
+    for key in all_keys:
+        resp = s3_client.head_object(Bucket=bucket, Key=key)
+        assert resp["ContentLength"] == obj_size, f"Size mismatch for {key}"
+
+    dedup_utils.log_dedup_savings(exec_stats, 21 * obj_size, "SC03")
+
+
+# =============================================================================
+# SC04: 10K objects across multiple buckets at 50% dup rate
+# =============================================================================
+
+
+@pytest.mark.scale
+@pytest.mark.slow
+def test_sc04_10k_objects_multi_bucket(s3_client, bucket_factory):
+    """SC04: 10K objects across 10 buckets at 50% duplication rate.
+
+    First suite (M1) does 1000 objects in 100 buckets (all identical).
+    This tests 10x the object count with mixed dup/unique content.
+    """
+    obj_size = 5 * 1024  # 5KB
+    total_objects = 10000
+    objects_per_bucket = 1000
+    num_buckets = total_objects // objects_per_bucket
+
+    identical_data = dedup_utils.generate_identical_data(obj_size)
+    dup_md5 = hashlib.md5(identical_data).hexdigest()
+
+    bucket_keys = {}
+    uploaded = 0
+
+    for b in range(num_buckets):
+        bkt = bucket_factory(prefix=f"sc04-bkt-{b}")
+        keys = []
+
+        dup_in_bucket = objects_per_bucket // 2
+        for i in range(dup_in_bucket):
+            key = f"sc04-dup-{i}"
+            s3_client.put_object(Bucket=bkt, Key=key, Body=identical_data)
+            keys.append(key)
+
+        for i in range(objects_per_bucket - dup_in_bucket):
+            key = f"sc04-uniq-{i}"
+            s3_client.put_object(Bucket=bkt, Key=key, Body=os.urandom(obj_size))
+            keys.append(key)
+
+        bucket_keys[bkt] = keys
+        uploaded += objects_per_bucket
+        log.info(
+            f"SC04: Uploaded {uploaded}/{total_objects} objects "
+            f"({b + 1}/{num_buckets} buckets)"
+        )
+
+    dedup_utils.run_dedup_estimate()
+    estimate_stats = dedup_utils.wait_for_dedup_completion(timeout=3600)
+    assert estimate_stats.get("completed") is True, "Estimate did not complete"
+
+    dedup_utils.run_dedup_execute()
+    exec_stats = dedup_utils.wait_for_dedup_completion(timeout=3600)
+    assert exec_stats.get("completed") is True, "Exec did not complete"
+
+    parsed = dedup_utils.parse_dedup_stats(exec_stats)
+    deduped = parsed.get("deduped_count", 0)
+    log.info(f"SC04: Deduped {deduped} objects out of {total_objects} (50% dup rate)")
+    assert deduped > 0, "Expected dedup to find duplicates at scale"
+
+    sample_buckets = random.sample(list(bucket_keys.keys()), min(3, len(bucket_keys)))
+    for bkt in sample_buckets:
+        sample_keys = random.sample(bucket_keys[bkt], min(10, len(bucket_keys[bkt])))
+        dedup_utils.verify_all_objects_accessible(s3_client, bkt, sample_keys)
+
+    dedup_utils.log_dedup_savings(exec_stats, total_objects * obj_size, "SC04")
+
+
+# =============================================================================
+# SC05: Multi-RGW scaleout — completion time + work distribution
+# =============================================================================
+
+
+@pytest.mark.scale
+@pytest.mark.slow
+def test_sc05_multi_rgw_scaleout(s3_client, bucket):
+    """SC05: Verify dedup with multiple RGW instances.
+
+    Measures completion time and reports work distribution across daemons.
+    No equivalent in first suite.
+    """
+    obj_size = 5 * 1024 * 1024  # 5MB
+    obj_count = 100
+
+    keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket, obj_count, obj_size, prefix="sc05-scale"
+    )
+
+    running, total = dedup_utils.verify_rgw_daemons_running()
+    log.info(f"SC05: RGW daemons running: {running}/{total}")
+
+    start_time = time.time()
+
+    dedup_utils.run_dedup_estimate()
+    estimate_stats = dedup_utils.wait_for_dedup_completion(timeout=1800)
+    assert estimate_stats.get("completed") is True, "Estimate did not complete"
+
+    dedup_utils.run_dedup_execute()
+    exec_stats = dedup_utils.wait_for_dedup_completion(timeout=1800)
+    assert exec_stats.get("completed") is True, "Exec did not complete"
+
+    elapsed = time.time() - start_time
+    log.info(f"SC05: Total dedup time with {running} RGW(s): {elapsed:.1f}s")
+
+    parsed = dedup_utils.parse_dedup_stats(exec_stats)
+    assert parsed.get("deduped_count", 0) > 0, "Expected dedup at scale"
+
+    dedup_utils.verify_all_objects_accessible(s3_client, bucket, keys)
+    dedup_utils.verify_all_objects_integrity(s3_client, bucket, keys, expected_md5)
+
+    parsed_full = dedup_utils.parse_dedup_stats_full(exec_stats)
+    log.info(f"SC05: Full stats:\n{json.dumps(parsed_full, indent=2)}")
+
+    dedup_utils.log_dedup_savings(exec_stats, obj_count * obj_size, "SC05")
+
+
+# =============================================================================
+# SC06: High duplication rate (90%) — 1000 objects
+# =============================================================================
+
+
+@pytest.mark.scale
+@pytest.mark.slow
+def test_sc06_high_duplication_rate(s3_client, bucket_factory):
+    """SC06: 1000 objects with 90% duplication rate.
+
+    No equivalent in first suite. Tests dedup efficiency at high dup ratios.
+    """
+    obj_size = 5 * 1024  # 5KB
+    total_objects = 1000
+    dup_count = 900
+    unique_count = 100
+
+    identical_data = dedup_utils.generate_identical_data(obj_size)
+    dup_md5 = hashlib.md5(identical_data).hexdigest()
+
+    bkt = bucket_factory(prefix="sc06-highdup")
+    all_keys = []
+
+    for i in range(dup_count):
+        key = f"sc06-dup-{i}"
+        s3_client.put_object(Bucket=bkt, Key=key, Body=identical_data)
+        all_keys.append(key)
+    log.info(f"SC06: Uploaded {dup_count} duplicate objects")
+
+    for i in range(unique_count):
+        key = f"sc06-uniq-{i}"
+        s3_client.put_object(Bucket=bkt, Key=key, Body=os.urandom(obj_size))
+        all_keys.append(key)
+    log.info(f"SC06: Uploaded {unique_count} unique objects")
+
+    dedup_utils.run_dedup_estimate()
+    estimate_stats = dedup_utils.wait_for_dedup_completion(timeout=1800)
+    assert estimate_stats.get("completed") is True, "Estimate did not complete"
+
+    est_parsed = dedup_utils.parse_dedup_stats_full(estimate_stats)
+    log.info(f"SC06: Estimate stats:\n{json.dumps(est_parsed, indent=2)}")
+
+    dedup_utils.run_dedup_execute()
+    exec_stats = dedup_utils.wait_for_dedup_completion(timeout=1800)
+    assert exec_stats.get("completed") is True, "Exec did not complete"
+
+    parsed = dedup_utils.parse_dedup_stats(exec_stats)
+    deduped = parsed.get("deduped_count", 0)
+    log.info(f"SC06: Deduped {deduped} out of {total_objects} objects (90% dup rate)")
+    assert deduped > 0, "Expected high dedup count with 90% duplication"
+
+    sample_dup_keys = random.sample(all_keys[:dup_count], min(20, dup_count))
+    for key in sample_dup_keys:
+        dedup_utils.verify_object_integrity(s3_client, bkt, key, dup_md5)
+
+    sample_all = random.sample(all_keys, min(50, len(all_keys)))
+    dedup_utils.verify_all_objects_accessible(s3_client, bkt, sample_all)
+
+    savings_pct = (deduped / total_objects) * 100 if total_objects > 0 else 0
+    log.info(f"SC06: Storage savings: ~{savings_pct:.1f}%")
+    dedup_utils.log_dedup_savings(exec_stats, total_objects * obj_size, "SC06")
+
+
+# =============================================================================
+# SC07: Throttle control — 50 vs 500 ops/sec comparison
+# =============================================================================
+
+
+@pytest.mark.adhoc
+@pytest.mark.slow
+def test_sc07_throttle_control(s3_client, bucket_factory):
+    """SC07: Throttle control — compare 50 vs 500 ops/sec during active workload.
+
+    No equivalent in first suite. Measures dedup speed vs foreground impact.
+    """
+    obj_size = 5 * 1024 * 1024  # 5MB
+
+    # --- Low throttle run ---
+    dedup_bucket_low = bucket_factory(prefix="sc07-low")
+    keys_low, expected_md5, _ = dedup_utils.upload_identical_objects(
+        s3_client, dedup_bucket_low, 100, obj_size, prefix="sc07-obj"
+    )
+
+    dedup_utils.set_dedup_throttle(max_bucket_index_ops=50, max_metadata_ops=50)
+    throttle_settings = dedup_utils.get_dedup_throttle()
+    log.info(f"SC07: Low throttle settings: {throttle_settings}")
+
+    dedup_utils.run_dedup_estimate()
+    dedup_utils.wait_for_dedup_completion(timeout=900)
+
+    start_low = time.time()
+    dedup_utils.run_dedup_execute()
+    exec_stats_low = dedup_utils.wait_for_dedup_completion(timeout=900)
+    time_low = time.time() - start_low
+    assert exec_stats_low.get("completed") is True, "Low-throttle exec did not complete"
+
+    parsed_low = dedup_utils.parse_dedup_stats(exec_stats_low)
+    log.info(
+        f"SC07: Low throttle (50 ops/sec) — time: {time_low:.1f}s, "
+        f"deduped: {parsed_low.get('deduped_count', 0)}"
+    )
+
+    dedup_utils.verify_all_objects_accessible(
+        s3_client, dedup_bucket_low, keys_low[:10]
+    )
+
+    # --- High throttle run ---
+    dedup_bucket_high = bucket_factory(prefix="sc07-high")
+    keys_high, _, _ = dedup_utils.upload_identical_objects(
+        s3_client, dedup_bucket_high, 100, obj_size, prefix="sc07-obj2"
+    )
+
+    dedup_utils.set_dedup_throttle(max_bucket_index_ops=500, max_metadata_ops=500)
+    throttle_settings = dedup_utils.get_dedup_throttle()
+    log.info(f"SC07: High throttle settings: {throttle_settings}")
+
+    dedup_utils.run_dedup_estimate()
+    dedup_utils.wait_for_dedup_completion(timeout=900)
+
+    start_high = time.time()
+    dedup_utils.run_dedup_execute()
+    exec_stats_high = dedup_utils.wait_for_dedup_completion(timeout=900)
+    time_high = time.time() - start_high
+    assert (
+        exec_stats_high.get("completed") is True
+    ), "High-throttle exec did not complete"
+
+    parsed_high = dedup_utils.parse_dedup_stats(exec_stats_high)
+    log.info(
+        f"SC07: High throttle (500 ops/sec) — time: {time_high:.1f}s, "
+        f"deduped: {parsed_high.get('deduped_count', 0)}"
+    )
+
+    log.info(
+        f"SC07: Throttle comparison — low: {time_low:.1f}s vs high: {time_high:.1f}s"
+    )
+
+    dedup_utils.verify_all_objects_accessible(s3_client, dedup_bucket_low, keys_low)
+    dedup_utils.verify_all_objects_integrity(
+        s3_client, dedup_bucket_low, keys_low, expected_md5
+    )
+
+    dedup_utils.log_dedup_savings(exec_stats_low, 100 * obj_size, "SC07")
+
+
+# =============================================================================
+# SC08: LC transition of deduped objects to different storage class
+# =============================================================================
+
+
+@pytest.mark.adhoc
+@pytest.mark.slow
+def test_sc08_lc_transition_deduped_objects(s3_client, bucket, ssh_con):
+    """SC08: LC transition of deduplicated objects to a different storage class.
+
+    First suite (S10) tests LC expiration (delete). This tests LC transition
+    (move to another SC) — different code path, ref counts must survive the move.
+    """
+    sc_name = "DEDUP_TRANSITION_SC"
+    pool_name = "dedup-transition-pool"
+
+    dedup_utils.setup_storage_class(sc_name, pool_name, ssh_con)
+    try:
+        dedup_utils.wait_for_rgw_ready()
+
+        utils.exec_shell_cmd("ceph config set client.rgw rgw_lc_debug_interval 30")
+        time.sleep(3)
+
+        obj_size = 5 * 1024 * 1024  # 5MB
+        keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket, 20, obj_size, prefix="sc08-trans"
+        )
+
+        dedup_utils.run_dedup_estimate()
+        estimate_stats = dedup_utils.wait_for_dedup_completion()
+        assert estimate_stats.get("completed") is True, "Estimate did not complete"
+
+        dedup_utils.run_dedup_execute()
+        exec_stats = dedup_utils.wait_for_dedup_completion()
+        assert exec_stats.get("completed") is True, "Exec did not complete"
+
+        parsed = dedup_utils.parse_dedup_stats(exec_stats)
+        assert parsed.get("deduped_count", 0) > 0, "Expected dedup before transition"
+
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket, keys)
+
+        lc_config = {
+            "Rules": [
+                {
+                    "ID": "sc08-transition",
+                    "Status": "Enabled",
+                    "Filter": {"Prefix": "sc08-trans"},
+                    "Transitions": [
+                        {
+                            "Days": 0,
+                            "StorageClass": sc_name,
+                        }
+                    ],
+                }
+            ]
+        }
+        s3_client.put_bucket_lifecycle_configuration(
+            Bucket=bucket, LifecycleConfiguration=lc_config
+        )
+        log.info(f"SC08: Set LC transition to {sc_name}")
+
+        time.sleep(120)
+
+        transitioned = 0
+        for key in keys:
+            try:
+                resp = s3_client.head_object(Bucket=bucket, Key=key)
+                sc = resp.get("StorageClass", "STANDARD")
+                if sc == sc_name:
+                    transitioned += 1
+            except Exception as e:
+                log.warning(f"SC08: head_object failed for {key}: {e}")
+
+        log.info(f"SC08: Transitioned {transitioned}/{len(keys)} objects to {sc_name}")
+
+        accessible = 0
+        for key in keys:
+            try:
+                resp = s3_client.get_object(Bucket=bucket, Key=key)
+                body = resp["Body"].read()
+                dl_md5 = hashlib.md5(body).hexdigest()
+                if dl_md5 == expected_md5:
+                    accessible += 1
+                else:
+                    log.warning(f"SC08: MD5 mismatch for {key} after transition")
+            except Exception as e:
+                log.warning(f"SC08: GET failed for {key}: {e}")
+
+        log.info(
+            f"SC08: {accessible}/{len(keys)} objects accessible + intact after transition"
+        )
+        assert accessible == len(
+            keys
+        ), f"Not all objects survived transition: {accessible}/{len(keys)}"
+
+        dedup_utils.log_dedup_savings(exec_stats, 20 * obj_size, "SC08")
+
+    finally:
+        dedup_utils.teardown_storage_class(sc_name, pool_name, ssh_con)

--- a/rgw/standalone/dedup/upload_dedup_1b_v1.py
+++ b/rgw/standalone/dedup/upload_dedup_1b_v1.py
@@ -1,0 +1,411 @@
+"""
+upload_dedup_1b_v1.py - Upload ~1 Billion objects for RGW dedup scale testing.
+
+This script creates a large-scale dedup test dataset by uploading ~1 billion
+S3 objects (4KB each) across 1000 buckets using s5cmd for high-throughput
+parallel uploads. Each unique source file is copied 127 times (the dedup
+shared-manifest limit), spread across different buckets to test cross-bucket
+dedup behavior.
+
+What it does:
+  1. Generates ~7.87M unique 4KB random files on local disk (/tmp/dedup_sources_4k/)
+  2. Creates 1000 S3 buckets (test-dedup-performance-1 .. 1000) via aws CLI
+  3. Uploads each unique file + 127 copies across buckets using s5cmd batch mode
+  4. Reports progress with obj/sec rate and ETA
+
+Layout:
+  - 1000 buckets: test-dedup-performance-1 .. test-dedup-performance-1000
+  - ~1,000,000 objects per bucket (1B total)
+  - ~7,874,016 unique source files (4KB each), each copied 127 times
+  - Unique sources distributed round-robin across buckets
+  - Object size: 4KB (4096 bytes)
+
+Capacity requirements (BEFORE running dedup):
+  +----------------------------+-------------+-------------+
+  | Metric                     | Replicated  | EC 2+2      |
+  |                            | (size=3)    | (k=2, m=2)  |
+  +----------------------------+-------------+-------------+
+  | Data stored                | 3.7 TiB     | 3.7 TiB     |
+  | Raw space used             | 11.1 TiB    | 7.4 TiB     |
+  | Bucket index overhead      | ~2-5 GB     | ~2-5 GB     |
+  | Source staging disk        | ~30 GB      | ~30 GB      |
+  | Minimum cluster raw        | ~15 TiB     | ~10 TiB     |
+  | Recommended cluster raw    | ~20+ TiB    | ~14+ TiB    |
+  +----------------------------+-------------+-------------+
+
+  After dedup (radosgw-admin dedup exec):
+  - Unique data: ~30 GB (7.87M unique x 4KB)
+  - Shared manifests point to dedup pool chunks
+  - Dedup pool (size=2): ~60 GB raw for chunk storage
+
+Bucket index considerations:
+  - 1000 buckets x 1M objects = 1B index entries
+  - Dynamic resharding (rgw_max_objs_per_shard=100K) creates ~10 shards/bucket
+  - Recommend bucket index pool PG count >= 256
+  - Monitor omap stats: ceph health detail | grep omap
+
+Prerequisites:
+  - s5cmd installed (https://github.com/peak/s5cmd)
+  - aws CLI installed (for bucket creation)
+  - RGW user with max_buckets >= 1000
+  - Sufficient cluster capacity (see table above)
+
+Usage:
+  python3 upload_dedup_1b_v1.py                              # full run
+  python3 upload_dedup_1b_v1.py --start-bucket 500           # resume from bucket 500
+  python3 upload_dedup_1b_v1.py --buckets 10 --sources 1000  # quick test
+  python3 upload_dedup_1b_v1.py --generate-only              # just create source files
+  python3 upload_dedup_1b_v1.py --skip-generate              # skip if sources exist
+
+  Resume after interrupt:
+  python3 upload_dedup_1b_v1.py --start-source 500000 --skip-generate --skip-buckets
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+import time
+
+ENDPOINT = "http://grim017:5000"
+BUCKET_PREFIX = "test-dedup-performance"
+NUM_BUCKETS = 1000
+OBJ_PER_BUCKET = 1_000_000
+COPIES = 127
+TOTAL_UNIQUE = 7_874_016  # ceil(1B / (127+1)) — each unique + 127 copies = 128
+OBJ_SIZE = 4096  # 4KB
+SOURCE_DIR = "/tmp/dedup_sources_4k"
+WORKERS = 256
+CHUNK_SIZE = 5000  # sources per s5cmd batch
+
+os.environ["AWS_ACCESS_KEY_ID"] = "dedupscale"
+os.environ["AWS_SECRET_ACCESS_KEY"] = "dedupscale"
+os.environ["AWS_DEFAULT_REGION"] = "default"
+os.environ["AWS_REGION"] = "default"
+
+
+def generate_sources(source_dir, total, obj_size, start_from=0):
+    """Generate unique random 4KB files in batched subdirectories."""
+    batch_size = 1000
+    generated = 0
+    total_to_gen = total - start_from
+
+    print(
+        f"\n[Source Generation] Creating {total_to_gen:,} unique {obj_size}B files..."
+    )
+    print(f"  Directory: {source_dir}")
+    print(f"  Disk needed: ~{(total_to_gen * obj_size) / (1024**3):.1f} GB")
+
+    t0 = time.time()
+    for i in range(start_from, total):
+        subdir = i // batch_size
+        batch_dir = os.path.join(source_dir, f"batch_{subdir:05d}")
+        os.makedirs(batch_dir, exist_ok=True)
+
+        fpath = os.path.join(batch_dir, f"obj_{i:08d}.bin")
+        if os.path.exists(fpath) and os.path.getsize(fpath) == obj_size:
+            generated += 1
+            continue
+
+        with open(fpath, "wb") as f:
+            f.write(os.urandom(obj_size))
+        generated += 1
+
+        if generated % 100_000 == 0:
+            elapsed = time.time() - t0
+            rate = generated / elapsed if elapsed > 0 else 0
+            remain = (total_to_gen - generated) / rate if rate > 0 else 0
+            print(
+                f"  [{time.strftime('%H:%M:%S')}] "
+                f"{generated:,}/{total_to_gen:,} files "
+                f"| {rate:.0f}/sec | ~{remain/60:.0f}m left",
+                flush=True,
+            )
+
+    elapsed = time.time() - t0
+    print(f"  Done: {generated:,} files in {elapsed:.0f}s\n")
+
+
+def create_buckets(endpoint, prefix, count, start_from=0):
+    """Create buckets via aws CLI (avoids s5cmd LocationConstraint issues)."""
+    print(f"\n[Bucket Creation] Creating {count - start_from} buckets via aws s3 mb...")
+    created = 0
+    skipped = 0
+    for i in range(start_from + 1, count + 1):
+        bucket = f"{prefix}-{i}"
+        result = subprocess.run(
+            [
+                "aws",
+                "--endpoint-url",
+                endpoint,
+                "s3",
+                "mb",
+                f"s3://{bucket}",
+            ],
+            capture_output=True,
+        )
+        out = result.stdout.decode().strip() if result.stdout else ""
+        err = result.stderr.decode().strip() if result.stderr else ""
+        if result.returncode == 0:
+            created += 1
+        elif "BucketAlreadyOwnedByYou" in err or "BucketAlreadyExists" in err:
+            skipped += 1
+        else:
+            print(f"  WARNING: Failed to create {bucket}: {err}")
+
+        if (i - start_from) % 100 == 0:
+            print(
+                f"  [{time.strftime('%H:%M:%S')}] "
+                f"Checked {i - start_from}/{count - start_from} buckets "
+                f"(created {created}, existed {skipped})",
+                flush=True,
+            )
+
+    print(f"  Done: {created} new, {skipped} already existed\n")
+
+
+def build_batch_file(
+    src_start, src_end, source_dir, bucket_prefix, num_buckets, copies, batch_path
+):
+    """Build s5cmd batch: each source goes to a deterministic bucket with 127 copies."""
+    with open(batch_path, "w") as f:
+        for src_idx in range(src_start, src_end):
+            subdir = src_idx // 1000
+            src_file = f"{source_dir}/batch_{subdir:05d}/obj_{src_idx:08d}.bin"
+
+            # Distribute sources round-robin across buckets
+            base_bucket_idx = src_idx % num_buckets
+            bucket_num = base_bucket_idx + 1
+            bucket = f"{bucket_prefix}-{bucket_num}"
+
+            # Original + 127 copies across nearby buckets
+            f.write(f"cp {src_file} s3://{bucket}/src_{src_idx:08d}/orig.bin\n")
+            for c in range(copies):
+                # Spread copies across different buckets for cross-bucket dedup
+                copy_bucket_idx = (base_bucket_idx + c) % num_buckets
+                copy_bucket_num = copy_bucket_idx + 1
+                copy_bucket = f"{bucket_prefix}-{copy_bucket_num}"
+                f.write(
+                    f"cp {src_file} "
+                    f"s3://{copy_bucket}/src_{src_idx:08d}/copy_{c:03d}.bin\n"
+                )
+
+
+def run_s5cmd(batch_path, endpoint, workers):
+    result = subprocess.run(
+        [
+            "s5cmd",
+            "--endpoint-url",
+            endpoint,
+            "--numworkers",
+            str(workers),
+            "run",
+            batch_path,
+        ],
+        capture_output=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+    )
+    errors = ""
+    if result.returncode != 0 and result.stderr:
+        errors = result.stderr.decode().strip()
+    return errors
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Upload 1B dedup test objects across 1000 buckets via s5cmd"
+    )
+    parser.add_argument("--endpoint", default=ENDPOINT)
+    parser.add_argument("--bucket-prefix", default=BUCKET_PREFIX)
+    parser.add_argument("--buckets", type=int, default=NUM_BUCKETS)
+    parser.add_argument("--sources", type=int, default=TOTAL_UNIQUE)
+    parser.add_argument("--copies", type=int, default=COPIES)
+    parser.add_argument("--obj-size", type=int, default=OBJ_SIZE)
+    parser.add_argument("--workers", type=int, default=WORKERS)
+    parser.add_argument(
+        "--start-bucket",
+        type=int,
+        default=0,
+        help="Skip bucket creation before this number",
+    )
+    parser.add_argument(
+        "--start-source",
+        type=int,
+        default=0,
+        help="Resume uploads from this source index",
+    )
+    parser.add_argument("--chunk-size", type=int, default=CHUNK_SIZE)
+    parser.add_argument(
+        "--generate-only",
+        action="store_true",
+        help="Only generate source files, don't upload",
+    )
+    parser.add_argument(
+        "--skip-generate",
+        action="store_true",
+        help="Skip source generation (already done)",
+    )
+    parser.add_argument(
+        "--skip-buckets",
+        action="store_true",
+        help="Skip bucket creation (already done)",
+    )
+    args = parser.parse_args()
+
+    total_objects = args.sources * (1 + args.copies)  # orig + copies
+    total_remaining = (args.sources - args.start_source) * (1 + args.copies)
+    data_stored_tb = (total_objects * args.obj_size) / (1024 ** 4)
+    raw_tb = data_stored_tb * 2  # EC 2+2 overhead
+
+    print("=" * 65)
+    print("  s5cmd Dedup 1-Billion Object Upload v1")
+    print("=" * 65)
+    print(f"  Endpoint:       {args.endpoint}")
+    print(
+        f"  Buckets:        {args.bucket_prefix}-1 .. {args.bucket_prefix}-{args.buckets}"
+    )
+    print(f"  Unique sources: {args.sources:,}")
+    print(
+        f"  Copies/source:  {args.copies} (+ 1 original = {args.copies + 1} per source)"
+    )
+    print(f"  Total objects:  {total_objects:,}")
+    print(f"  Object size:    {args.obj_size:,} bytes")
+    print(f"  Data stored:    {data_stored_tb:.1f} TiB")
+    print(f"  Raw (x3 repl):  {raw_tb:.1f} TiB")
+    print(f"  Workers:        {args.workers}")
+    print(f"  Resume from:    source {args.start_source:,}")
+    print(f"  Remaining:      {total_remaining:,} objects")
+    print("=" * 65)
+
+    # Phase 1: Generate source files
+    if not args.skip_generate:
+        generate_sources(SOURCE_DIR, args.sources, args.obj_size)
+    else:
+        print("\n[Skipped] Source generation")
+
+    if args.generate_only:
+        print("Source generation complete. Exiting (--generate-only).")
+        return
+
+    # Verify sources exist
+    sample = os.path.join(SOURCE_DIR, "batch_00000", "obj_00000000.bin")
+    if not os.path.isfile(sample):
+        print(f"\nERROR: Source file {sample} not found!")
+        print("Run with --generate-only first, or remove --skip-generate.")
+        sys.exit(1)
+    print(f"[OK] Source files verified in {SOURCE_DIR}")
+
+    # Phase 2: Create buckets
+    if not args.skip_buckets:
+        create_buckets(
+            args.endpoint, args.bucket_prefix, args.buckets, args.start_bucket
+        )
+    else:
+        print("[Skipped] Bucket creation\n")
+
+    # Phase 3: Test upload
+    print("[Testing] Single upload to verify connectivity...")
+    test_file = "/tmp/_dedup_1b_test.bin"
+    with open(test_file, "wb") as f:
+        f.write(os.urandom(args.obj_size))
+    test_bucket = f"{args.bucket_prefix}-1"
+    result = subprocess.run(
+        [
+            "s5cmd",
+            "--endpoint-url",
+            args.endpoint,
+            "cp",
+            test_file,
+            f"s3://{test_bucket}/_test.bin",
+        ],
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        err = result.stderr.decode().strip() if result.stderr else "unknown"
+        print(f"\nERROR: Test upload failed: {err}")
+        sys.exit(1)
+    subprocess.run(
+        [
+            "s5cmd",
+            "--endpoint-url",
+            args.endpoint,
+            "rm",
+            f"s3://{test_bucket}/_test.bin",
+        ],
+        capture_output=True,
+    )
+    os.remove(test_file)
+    print("[OK] Test upload succeeded\n")
+
+    # Phase 4: Upload
+    print("[Uploading...]\n")
+    start_time = time.time()
+    uploaded = 0
+    error_count = 0
+
+    try:
+        for chunk_start in range(args.start_source, args.sources, args.chunk_size):
+            chunk_end = min(chunk_start + args.chunk_size, args.sources)
+            batch_path = f"/tmp/s5cmd_1b_batch_{chunk_start}.txt"
+
+            build_batch_file(
+                chunk_start,
+                chunk_end,
+                SOURCE_DIR,
+                args.bucket_prefix,
+                args.buckets,
+                args.copies,
+                batch_path,
+            )
+
+            batch_cmds = (chunk_end - chunk_start) * (1 + args.copies)
+            now = time.strftime("%H:%M:%S")
+            pct = (uploaded / total_remaining * 100) if total_remaining > 0 else 0
+            print(
+                f"  [{now}] Sources {chunk_start:,}-{chunk_end - 1:,}: "
+                f"{batch_cmds:,} uploads ({pct:.2f}%)...",
+                flush=True,
+            )
+
+            errors = run_s5cmd(batch_path, args.endpoint, args.workers)
+            if errors:
+                err_lines = errors.count("ERROR")
+                error_count += err_lines
+                print(f"    WARNING: {err_lines} errors (sample: {errors[:200]})")
+
+            os.remove(batch_path)
+
+            uploaded += batch_cmds
+            elapsed = time.time() - start_time
+            rate = uploaded / elapsed if elapsed > 0 else 0
+            remain = (total_remaining - uploaded) / rate if rate > 0 else 0
+            now = time.strftime("%H:%M:%S")
+            print(
+                f"  [{now}] Progress: {uploaded:,}/{total_remaining:,} "
+                f"| {rate:.0f} obj/sec "
+                f"| ~{remain / 3600:.1f}h left "
+                f"| errors: {error_count}",
+                flush=True,
+            )
+
+    except KeyboardInterrupt:
+        print(
+            f"\n\nInterrupted! Resume with: --start-source {chunk_start} --skip-generate --skip-buckets"
+        )
+        sys.exit(1)
+
+    elapsed = time.time() - start_time
+    rate = uploaded / elapsed if elapsed > 0 else 0
+    print()
+    print("=" * 65)
+    print("  DONE")
+    print(f"  Uploaded:  {uploaded:,} objects across {args.buckets} buckets")
+    print(f"  Errors:    {error_count}")
+    print(f"  Time:      {elapsed / 3600:.1f}h ({elapsed:.0f}s)")
+    print(f"  Rate:      {rate:.0f} obj/sec")
+    print("=" * 65)
+
+
+if __name__ == "__main__":
+    main()

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_admin_api.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_admin_api.yaml
@@ -1,0 +1,13 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# S3: Dedup via Admin OPS REST API
+# ISCE-4789 - Priority P0
+# Requires PR #68863 (Admin OPS REST API for dedup)
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 20
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "admin_api"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_all.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_all.yaml
@@ -1,0 +1,13 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# Run all 30 dedup tests as a single cephci entry
+# Use with: script-name: test_dedup.py, config-file-name: test_dedup_all.yaml
+config:
+  haproxy: true
+  user_count: 2
+  bucket_count: 1
+  objects_count: 50
+  objects_size_range:
+    min: 5120
+    max: 10240
+  test_ops:
+    dedup_type: "all"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_compressed_algo_switch.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_compressed_algo_switch.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# S18: Compression algorithm switch (zlib -> snappy) + dedup
+# PR #68965 - Priority P1
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 15
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "compressed_algo_switch"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_compressed_attr_mirror.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_compressed_attr_mirror.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# S21: Compression attr mirroring integrity
+# PR #68965 - Priority P1
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 30
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "compressed_attr_mirror"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_compressed_cross_mode.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_compressed_cross_mode.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# S17: Cross-compression dedup (compressed + uncompressed)
+# PR #68965 - Priority P0
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 20
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "compressed_cross_mode"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_compressed_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_compressed_multipart.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# S19: Compressed multipart object dedup
+# PR #68965 - Priority P1
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 5
+  objects_size_range:
+    min: 51200
+    max: 51200
+  test_ops:
+    dedup_type: "compressed_multipart"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_compressed_sanity.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_compressed_sanity.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# S16: Compressed object dedup sanity (zlib)
+# PR #68965 - Priority P0
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 50
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "compressed_sanity"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_compressed_skip_toggle.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_compressed_skip_toggle.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# S20: rgw_dedup_skip_compressed config toggle
+# PR #68965 - Priority P1
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 30
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "compressed_skip_toggle"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_concurrent_delete.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_concurrent_delete.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# C2: Delete during exec
+# ISCE-XXXX - Priority P2
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 100
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "concurrent_delete"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_concurrent_double_abort.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_concurrent_double_abort.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# C5: Double abort
+# ISCE-XXXX - Priority P2
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 100
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "concurrent_double_abort"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_concurrent_exec_estimate.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_concurrent_exec_estimate.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# C1: Exec during estimate
+# ISCE-XXXX - Priority P2
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 200
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "concurrent_exec_estimate"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_concurrent_ops.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_concurrent_ops.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# S15: Concurrent S3 operations during dedup
+# ISCE-4789 - Priority P0
+config:
+  user_count: 1
+  bucket_count: 2
+  objects_count: 50
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "concurrent_ops"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_concurrent_pause_resume.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_concurrent_pause_resume.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# C4: Rapid pause/resume
+# ISCE-XXXX - Priority P2
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 100
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "concurrent_pause_resume"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_concurrent_upload.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_concurrent_upload.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# C3: Upload during exec
+# ISCE-XXXX - Priority P2
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 50
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "concurrent_upload"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_copy_delete_deduped.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_copy_delete_deduped.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# B3: S3 copy deduped object then delete original
+# Bug target: set_copy_attrs() copies shared_manifest without refcount increment
+config:
+  user_count: 1
+  bucket_count: 2
+  objects_count: 5
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "copy_delete_deduped"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_cross_bucket_delete.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_cross_bucket_delete.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# B4: Cross-bucket dedup - source bucket deletion
+# Bug target: No cross-bucket reference tracking for shared tail objects
+config:
+  user_count: 1
+  bucket_count: 2
+  objects_count: 1
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "cross_bucket_delete"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_delete_source.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_delete_source.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# B2: Delete dedup source - verify refcount protection
+# Bug target: S3 delete uses GC path without cls_refcount_put()
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 10
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "delete_source"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_diff_metadata.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_diff_metadata.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# S14: Dedup objects with same content different metadata
+# ISCE-4789 - Priority P0
+config:
+  user_count: 2
+  bucket_count: 2
+  objects_count: 4
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "diff_metadata"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_edge_empty.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_edge_empty.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# D1: Empty bucket
+# ISCE-XXXX - Priority P2
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 0
+  objects_size_range:
+    min: 0
+    max: 0
+  test_ops:
+    dedup_type: "edge_empty"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_edge_max_versions.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_edge_max_versions.yaml
@@ -1,0 +1,13 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# D5: Max versions
+# ISCE-XXXX - Priority P2
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 1
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "edge_max_versions"
+    version_count: 500

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_edge_min_size.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_edge_min_size.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# D3: Min size boundary
+# ISCE-XXXX - Priority P2
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 40
+  objects_size_range:
+    min: 5119
+    max: 5120
+  test_ops:
+    dedup_type: "edge_min_size"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_edge_single_object.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_edge_single_object.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# D4: Single object
+# ISCE-XXXX - Priority P2
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 1
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "edge_single_object"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_edge_singletons.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_edge_singletons.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# D2: Singletons only
+# ISCE-XXXX - Priority P2
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 50
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "edge_singletons"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_estimate.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_estimate.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# S4: Dedup estimate (non-destructive dry-run)
+# ISCE-4789 - Priority P0
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 40
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "estimate"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_idempotency.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_idempotency.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# B5: Dedup idempotency - multiple exec runs
+# Bug target: Refcount double-increment or stats corruption on re-run
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 20
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "idempotency"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_infra_corrupt.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_infra_corrupt.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# F4: Corrupt RADOS object
+# ISCE-XXXX - Priority P1
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 50
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "infra_corrupt"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_infra_network.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_infra_network.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# F3: Network partition
+# ISCE-XXXX - Priority P1
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 100
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "infra_network"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_infra_pool_full.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_infra_pool_full.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# F1: Pool near-full
+# ISCE-XXXX - Priority P1
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 50
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "infra_pool_full"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_infra_reshard.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_infra_reshard.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# F2: Reshard during exec
+# ISCE-XXXX - Priority P1
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 100
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "infra_reshard"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_infra_time_jump.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_infra_time_jump.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# F5: Time jump
+# ISCE-XXXX - Priority P1
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 50
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "infra_time_jump"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_integrity.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_integrity.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# S5: Data integrity verification after dedup
+# ISCE-4789 - Priority P0
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 100
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "integrity"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_lc_expiration.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_lc_expiration.yaml
@@ -1,0 +1,13 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# S10: LC expiration with deduplicated objects
+# ISCE-4789 - Priority P1
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 20
+  objects_size_range:
+    min: 5120
+    max: 5120
+  rgw_lc_debug_interval: 30
+  test_ops:
+    dedup_type: "lc_expiration"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_multipart.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_multipart.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# S6: Dedup multipart objects of any size
+# ISCE-4789 - Priority P0
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 5
+  objects_size_range:
+    min: 51200
+    max: 51200
+  test_ops:
+    dedup_type: "multipart"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_overwrite_deduped.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_overwrite_deduped.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# B1: Overwrite deduped object - verify shared tail integrity
+# Bug target: GC deletes shared tails via complete_atomic_modification()
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 10
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "overwrite_deduped"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_restart_mon.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_restart_mon.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# R4: MON restart mid-exec
+# ISCE-XXXX - Priority P1
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 50
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "restart_mon"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_restart_osd.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_restart_osd.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# R3: OSD restart mid-exec
+# ISCE-XXXX - Priority P1
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 100
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "restart_osd"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_restart_rapid.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_restart_rapid.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# R5: Rapid RGW restarts
+# ISCE-XXXX - Priority P1
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 100
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "restart_rapid"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_restart_rgw.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_restart_rgw.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# R1: RGW restart mid-exec
+# ISCE-XXXX - Priority P1
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 100
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "restart_rgw"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_restart_sigkill.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_restart_sigkill.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# R2: SIGKILL RGW mid-exec
+# ISCE-XXXX - Priority P1
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 50
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "restart_sigkill"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_s3_copy.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_s3_copy.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# S12: Dedup with S3 copy object > 5MB
+# ISCE-4789 - Priority P1
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 20
+  objects_size_range:
+    min: 10240
+    max: 10240
+  test_ops:
+    dedup_type: "s3_copy"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_sanity_large.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_sanity_large.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# S1: Basic dedup for large objects > 4MB
+# ISCE-4789 - Priority P0
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 50
+  objects_size_range:
+    min: 5120
+    max: 10240
+  test_ops:
+    dedup_type: "sanity_large"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_sanity_small.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_sanity_small.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# S2: Basic dedup for small objects < 4MB (split-head mechanism)
+# ISCE-4789 - Priority P0
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 100
+  objects_size_range:
+    min: 100
+    max: 3072
+  test_ops:
+    dedup_type: "sanity_small"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_scale_100_buckets.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_scale_100_buckets.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# M1: 100 buckets cross-dedup
+# ISCE-XXXX - Priority P2
+config:
+  user_count: 1
+  bucket_count: 100
+  objects_count: 10
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "scale_100_buckets"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_scale_filters.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_scale_filters.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# M2: Bucket allow/deny
+# ISCE-XXXX - Priority P2
+config:
+  user_count: 1
+  bucket_count: 3
+  objects_count: 20
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "scale_filters"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_scale_mixed_sizes.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_scale_mixed_sizes.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# M3: Mixed sizes
+# ISCE-XXXX - Priority P2
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 60
+  objects_size_range:
+    min: 1024
+    max: 5120
+  test_ops:
+    dedup_type: "scale_mixed_sizes"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_session_lifecycle.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_session_lifecycle.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# S7: Session lifecycle controls (pause/resume/abort)
+# ISCE-4789 - Priority P0
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 100
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "session_lifecycle"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_ssec_exclusion.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_ssec_exclusion.yaml
@@ -1,0 +1,12 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# S8: SSE-C encrypted objects excluded from dedup
+# ISCE-4789 - Priority P0
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 40
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "ssec_exclusion"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_storage_class.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_storage_class.yaml
@@ -1,0 +1,13 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# S9: Dedup with different storage classes and allow/deny filters
+# ISCE-4789 - Priority P1
+# Covers PR #68575 (allow/deny bucket/storage-class lists)
+config:
+  user_count: 1
+  bucket_count: 2
+  objects_count: 20
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "storage_class_filter"

--- a/rgw/v2/tests/s3_swift/configs/test_dedup_versioned.yaml
+++ b/rgw/v2/tests/s3_swift/configs/test_dedup_versioned.yaml
@@ -1,0 +1,13 @@
+# Polarion: CEPH-83632923 — Part of the unified dedup test run via test_dedup_pytest.py
+# S11: Dedup with versioned objects in same pool
+# ISCE-4789 - Priority P1
+# Covers PR #66233 (S3 versioned object support)
+config:
+  user_count: 1
+  bucket_count: 1
+  version_count: 10
+  objects_size_range:
+    min: 5120
+    max: 5120
+  test_ops:
+    dedup_type: "versioned"

--- a/rgw/v2/tests/s3_swift/conftest.py
+++ b/rgw/v2/tests/s3_swift/conftest.py
@@ -1,0 +1,770 @@
+"""
+Pytest conftest for RGW dedup tests.
+
+Provides shared fixtures for S3 client setup, bucket management,
+and cluster configuration used across all dedup pytest tests.
+
+Usage:
+  pytest test_dedup_pytest.py -c <config.yaml> -v
+  pytest test_dedup_pytest.py -c <config.yaml> --rgw-node <hostname>
+"""
+
+import json
+import logging
+import os
+import random
+import sys
+import time
+
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(__file__, "../../../..")))
+
+import v2.lib.resource_op as s3lib
+import v2.utils.utils as utils
+from v2.lib.resource_op import Config
+from v2.lib.s3.write_io_info import BasicIOInfoStructure, IOInfoInitialize
+from v2.tests.s3_swift import reusable
+from v2.tests.s3_swift.reusables import dedup as dedup_utils
+from v2.utils.log import configure_logging
+
+log = logging.getLogger()
+
+# ---------------------------------------------------------------------------
+# Per-test resource tracking for cleanup and reporting
+# ---------------------------------------------------------------------------
+
+_test_context = {}
+_test_passed = {}
+
+
+def _get_ctx(node_id):
+    if node_id not in _test_context:
+        _test_context[node_id] = {
+            "users": [],
+            "buckets": [],
+            "bucket_markers": {},
+            "recorder": None,
+        }
+    return _test_context[node_id]
+
+
+DEDUP_TEST_SCENARIOS = {
+    "test_s1_sanity_large_objects": {
+        "id": "S1",
+        "category": "Sanity",
+        "scenario": "Upload 50 identical 5KB objects, run dedup estimate+exec, verify deduped_count>0 and data integrity",
+    },
+    "test_s2_sanity_small_objects": {
+        "id": "S2",
+        "category": "Sanity",
+        "scenario": "Upload identical objects at 5KB/8KB/10KB sizes, run dedup estimate+exec, verify ratio and integrity",
+    },
+    "test_s3_admin_ops_api": {
+        "id": "S3",
+        "category": "Sanity",
+        "scenario": "Verify dedup Admin OPS REST API endpoints (estimate, stats, exec) with S3 V1 auth",
+    },
+    "test_s4_estimate_dry_run": {
+        "id": "S4",
+        "category": "Sanity",
+        "scenario": "Run estimate only (no exec), verify ETags unchanged and no data modification",
+    },
+    "test_s5_data_integrity": {
+        "id": "S5",
+        "category": "Sanity",
+        "scenario": "Upload 100 duplicates with known MD5, run exec, verify all MD5s match post-dedup",
+    },
+    "test_s6_multipart_objects": {
+        "id": "S6",
+        "category": "Feature",
+        "scenario": "Upload 5 identical 20MB multipart objects, dedup, verify range GETs work post-dedup",
+    },
+    "test_s7_session_lifecycle": {
+        "id": "S7",
+        "category": "Feature",
+        "scenario": "Test dedup pause/resume/abort controls during exec, verify data survives each action",
+    },
+    "test_s8_ssec_exclusion": {
+        "id": "S8",
+        "category": "Feature",
+        "scenario": "SSE-C encrypted objects excluded from dedup, plain objects deduped, both accessible",
+    },
+    "test_s9_storage_class_dedup": {
+        "id": "S9",
+        "category": "Feature",
+        "scenario": "Create custom storage class with data pool, upload objects, dedup with storage class filter",
+    },
+    "test_s10_lc_expiration": {
+        "id": "S10",
+        "category": "Feature",
+        "scenario": "Dedup objects then apply lifecycle expiration, verify LC works on deduped objects",
+    },
+    "test_s11_versioned_objects": {
+        "id": "S11",
+        "category": "Feature",
+        "scenario": "Upload 10 identical versions of same key, dedup, verify all versions accessible post-dedup",
+    },
+    "test_s12_s3_copy_dedup": {
+        "id": "S12",
+        "category": "Feature",
+        "scenario": "S3 COPY to create 20 duplicates, dedup, verify all copies intact post-dedup",
+    },
+    "test_s14_same_content_diff_metadata": {
+        "id": "S14",
+        "category": "Feature",
+        "scenario": "Same content with different metadata/tags across 2 users, dedup, verify metadata preserved",
+    },
+    "test_s15_concurrent_s3_ops": {
+        "id": "S15",
+        "category": "Feature",
+        "scenario": "Run concurrent S3 workload (puts/gets/deletes) during dedup exec, verify <5% error rate",
+    },
+    "test_s16_uncompressed_to_compressed": {
+        "id": "S16",
+        "category": "Compression",
+        "scenario": "Upload uncompressed, switch to zlib, upload copies, dedup aligns all to compressed",
+    },
+    "test_s17_compressed_to_uncompressed": {
+        "id": "S17",
+        "category": "Compression",
+        "scenario": "Upload compressed, switch to none, upload copies, dedup aligns all to uncompressed",
+    },
+    "test_s18_per_sc_compression_cache": {
+        "id": "S18",
+        "category": "Compression",
+        "scenario": "Two SCs with opposite compression, flip, dedup aligns each SC independently",
+    },
+    "test_s19_inc_compressed_shared_manifest": {
+        "id": "S19",
+        "category": "Compression",
+        "scenario": "Incremental: start compressed, switch mode, shared_manifest SRC priority preserved",
+    },
+    "test_s20_inc_uncompressed_shared_manifest": {
+        "id": "S20",
+        "category": "Compression",
+        "scenario": "Incremental: start uncompressed, switch mode, shared_manifest SRC priority preserved",
+    },
+    "test_s22_filter_bucket_list_parsing": {
+        "id": "S22",
+        "category": "Filter",
+        "scenario": "Bucket filter file parsing: mutual exclusivity, missing file, empty file errors",
+    },
+    "test_s23_filter_sc_list_parsing": {
+        "id": "S23",
+        "category": "Filter",
+        "scenario": "SC filter file parsing: mutual exclusivity, missing file, empty file errors",
+    },
+    "test_s24_filter_sc_estimate": {
+        "id": "S24",
+        "category": "Filter",
+        "scenario": "Allow STANDARD estimate finds duplicates, deny STANDARD skips all via ingress_skip_filtered_sc",
+    },
+    "test_s25_filter_sc_exec": {
+        "id": "S25",
+        "category": "Filter",
+        "scenario": "Deny STANDARD exec dedupes 0, allow STANDARD exec dedupes normally",
+    },
+    "test_s26_compression_stats_counters": {
+        "id": "S26",
+        "category": "Compression",
+        "scenario": "Validate compressed_objs, compressed_bytes, deduped_compressed_objects stat counters",
+    },
+    "test_s27_cross_user_compressed_to_uncompressed": {
+        "id": "S27",
+        "category": "Compression",
+        "scenario": "Cross-user: user1 compressed bucket + user2 uncompressed bucket, dedup aligns all to uncompressed",
+    },
+    "test_s28_cross_user_uncompressed_to_compressed": {
+        "id": "S28",
+        "category": "Compression",
+        "scenario": "Cross-user: user1 uncompressed bucket + user2 compressed bucket, dedup aligns all to compressed",
+    },
+    "test_b1_overwrite_deduped_object": {
+        "id": "B1",
+        "category": "Bug",
+        "scenario": "Overwrite one deduped object with new content, verify sibling objects survive",
+    },
+    "test_b2_delete_dedup_source": {
+        "id": "B2",
+        "category": "Bug",
+        "scenario": "Delete deduped objects one-by-one, verify each remaining object survives",
+    },
+    "test_b3_s3_copy_then_delete_deduped": {
+        "id": "B3",
+        "category": "Bug",
+        "scenario": "S3 COPY deduped object (same + cross bucket), delete originals, verify copies survive",
+    },
+    "test_b4_cross_bucket_source_delete": {
+        "id": "B4",
+        "category": "Bug",
+        "scenario": "Cross-bucket dedup, delete source bucket entirely, verify target bucket objects survive",
+    },
+    "test_b5_dedup_idempotency": {
+        "id": "B5",
+        "category": "Bug",
+        "scenario": "Run dedup exec 3 times, verify run1 dedupes, runs 2-3 dedup 0 (no double-counting)",
+    },
+    "test_e1_128_limit_boundary": {
+        "id": "E1",
+        "category": "Enhancement",
+        "scenario": "200 identical objects, verify deduped<=127 (128-limit), skipped_too_many_copies>0",
+    },
+    "test_e2_versioned_boundary": {
+        "id": "E2",
+        "category": "Enhancement",
+        "scenario": "130 versions of same key (past 128 boundary), verify all versions accessible post-dedup",
+    },
+    "test_e3_multi_cycle_no_progress": {
+        "id": "E3",
+        "category": "Enhancement",
+        "scenario": "200 objects, 3 exec cycles: cycle1 dedupes, cycles 2-3 dedup 0, stable skip counts",
+    },
+    "test_e4_split_head_small_objects": {
+        "id": "E4",
+        "category": "Enhancement",
+        "scenario": "50 identical 5KB objects, verify split-head mechanism used (split_head_src>0, tgt>0)",
+    },
+    "test_e5_stats_validation": {
+        "id": "E5",
+        "category": "Enhancement",
+        "scenario": "Validate stats fields: ingress_count for estimate, total_processed for exec, ratios, skipped fields",
+    },
+    "test_r1_rgw_restart_mid_exec": {
+        "id": "R1",
+        "category": "Restart",
+        "scenario": "Restart RGW service mid-exec, verify no data corruption and dedup completes on re-run",
+    },
+    "test_r2_rgw_sigkill_mid_exec": {
+        "id": "R2",
+        "category": "Restart",
+        "scenario": "SIGKILL RGW process during split-head, verify no orphan tail objects and data intact",
+    },
+    "test_r3_osd_restart_mid_exec": {
+        "id": "R3",
+        "category": "Restart",
+        "scenario": "Restart OSD hosting bucket PG during dedup exec, verify dedup completes and data intact",
+    },
+    "test_r4_mon_restart_mid_exec": {
+        "id": "R4",
+        "category": "Restart",
+        "scenario": "Restart MON leader during dedup exec, verify dedup completes after MON election",
+    },
+    "test_r5_rapid_rgw_restarts": {
+        "id": "R5",
+        "category": "Restart",
+        "scenario": "Restart RGW 3 times in 30 seconds during exec, verify shard tokens re-acquired on re-run",
+    },
+    "test_c1_exec_during_estimate": {
+        "id": "C1",
+        "category": "Concurrent",
+        "scenario": "Fire dedup exec while estimate is still running, verify concurrent requests handled gracefully",
+    },
+    "test_c2_delete_during_exec": {
+        "id": "C2",
+        "category": "Concurrent",
+        "scenario": "Delete objects during dedup exec, verify surviving objects intact and no crash",
+    },
+    "test_c3_upload_during_exec": {
+        "id": "C3",
+        "category": "Concurrent",
+        "scenario": "Upload new objects during dedup exec, verify new objects intact, re-run dedupes them",
+    },
+    "test_c4_rapid_pause_resume": {
+        "id": "C4",
+        "category": "Concurrent",
+        "scenario": "Rapidly toggle pause/resume 10 times during exec, verify dedup completes without deadlock",
+    },
+    "test_c5_double_abort": {
+        "id": "C5",
+        "category": "Concurrent",
+        "scenario": "Send abort twice in quick succession, verify no crash and fresh exec works normally",
+    },
+    "test_d1_empty_bucket": {
+        "id": "D1",
+        "category": "Edge Case",
+        "scenario": "Run dedup estimate and exec on empty bucket, verify clean completion with all-zero counters",
+    },
+    "test_d2_singletons_only": {
+        "id": "D2",
+        "category": "Edge Case",
+        "scenario": "Upload 50 objects with unique content, verify dedup finds 0 duplicates and skips all",
+    },
+    "test_d3_min_size_boundary": {
+        "id": "D3",
+        "category": "Edge Case",
+        "scenario": "Objects at exactly min_obj_size boundary, verify threshold enforced correctly",
+    },
+    "test_d4_single_object": {
+        "id": "D4",
+        "category": "Edge Case",
+        "scenario": "Single object in bucket, verify dedup completes with 0 deduped (nothing to match)",
+    },
+    "test_d5_max_versions_500": {
+        "id": "D5",
+        "category": "Edge Case",
+        "scenario": "500 versions of same key, verify deduped<=127 (128 limit), all versions accessible",
+    },
+    "test_f1_pool_near_full": {
+        "id": "F1",
+        "category": "Infrastructure",
+        "scenario": "Set pool quota to simulate near-full, run dedup, verify graceful failure and recovery",
+    },
+    "test_f2_reshard_during_exec": {
+        "id": "F2",
+        "category": "Infrastructure",
+        "scenario": "Trigger bucket reshard during dedup exec, verify dedup handles stale index gracefully",
+    },
+    "test_f3_network_partition": {
+        "id": "F3",
+        "category": "Infrastructure",
+        "scenario": "Block MON traffic on one RGW node during dedup, verify recovery after restore",
+    },
+    "test_f4_corrupt_rados_object": {
+        "id": "F4",
+        "category": "Infrastructure",
+        "scenario": "Corrupt a RADOS object mid-dedup, verify hash mismatch detected and other objects intact",
+    },
+    "test_f5_time_jump": {
+        "id": "F5",
+        "category": "Infrastructure",
+        "scenario": "Jump system clock forward 1 hour during dedup, verify completion despite stale heartbeats",
+    },
+    "test_m1_100_buckets_cross_dedup": {
+        "id": "M1",
+        "category": "Scale",
+        "scenario": "100 buckets with identical objects, verify cross-bucket dedup and source bucket deletion survival",
+    },
+    "test_m2_bucket_allow_deny_filters": {
+        "id": "M2",
+        "category": "Scale",
+        "scenario": "3 buckets with allow/deny filter lists, verify only allowed buckets are deduped",
+    },
+    "test_m3_mixed_sizes_threshold": {
+        "id": "M3",
+        "category": "Scale",
+        "scenario": "Mix of objects above and below min_obj_size_for_dedup, verify threshold filtering",
+    },
+    # -------------------------------------------------------------------------
+    # Scale & Extended Suite (test_dedup_scale_pytest.py) — SC01-SC08
+    # Only tests NOT covered by test_dedup_pytest.py
+    # -------------------------------------------------------------------------
+    "test_sc01_large_objects_above_4mb": {
+        "id": "SC01",
+        "category": "Sanity",
+        "scenario": "Large objects >4MB (non-split-head dedup path), 50 x 5MB objects",
+    },
+    "test_sc02_multipart_large_objects": {
+        "id": "SC02",
+        "category": "Feature",
+        "scenario": "Multipart objects 50MB/500MB with range GETs (larger than S6's 20MB)",
+    },
+    "test_sc03_s3_copy_large_objects": {
+        "id": "SC03",
+        "category": "Regression",
+        "scenario": "S3 COPY of 10MB objects (>5MB triggers multipart copy path, differs from S12)",
+    },
+    "test_sc04_10k_objects_multi_bucket": {
+        "id": "SC04",
+        "category": "Scale",
+        "scenario": "10K objects across 10 buckets at 50% dup rate (10x M1 scale)",
+    },
+    "test_sc05_multi_rgw_scaleout": {
+        "id": "SC05",
+        "category": "Scale",
+        "scenario": "Multi-RGW scaleout — completion time and work distribution measurement",
+    },
+    "test_sc06_high_duplication_rate": {
+        "id": "SC06",
+        "category": "Scale",
+        "scenario": "1000 objects with 90% duplication rate, verify high storage savings",
+    },
+    "test_sc07_throttle_control": {
+        "id": "SC07",
+        "category": "Adhoc",
+        "scenario": "Throttle 50 vs 500 ops/sec comparison — speed vs foreground impact",
+    },
+    "test_sc08_lc_transition_deduped_objects": {
+        "id": "SC08",
+        "category": "Adhoc",
+        "scenario": "LC transition (not expiration) of deduped objects to different SC, ref counts preserved",
+    },
+}
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--config",
+        "-C",
+        dest="config",
+        required=True,
+        help="Path to RGW test YAML configuration file",
+    )
+    parser.addoption(
+        "--rgw-node",
+        dest="rgw_node",
+        default="",
+        help="RGW node hostname for SSH connection",
+    )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_logging():
+    configure_logging(f_name="test_dedup_pytest")
+
+
+@pytest.fixture(scope="session")
+def rgw_config(request):
+    yaml_path = request.config.getoption("config")
+    config = Config(yaml_path)
+    config.read()
+    return config
+
+
+@pytest.fixture(scope="session")
+def ssh_con(request):
+    rgw_node = request.config.getoption("rgw_node")
+    if rgw_node:
+        return utils.connect_remote(rgw_node)
+    return None
+
+
+@pytest.fixture(scope="session")
+def io_info():
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+
+@pytest.fixture
+def s3_client(rgw_config, ssh_con, io_info, request):
+    user_info = s3lib.create_users(1)[0]
+    ctx = _get_ctx(request.node.nodeid)
+    ctx["users"].append(user_info)
+    auth = reusable.get_auth(
+        user_info,
+        ssh_con,
+        rgw_config.ssl,
+        getattr(rgw_config, "haproxy", False),
+    )
+    return auth.do_auth_using_client()
+
+
+@pytest.fixture
+def s3_clients(rgw_config, ssh_con, io_info, request):
+    all_users = s3lib.create_users(2)
+    ctx = _get_ctx(request.node.nodeid)
+    for user_info in all_users:
+        ctx["users"].append(user_info)
+    clients = []
+    for user_info in all_users:
+        auth = reusable.get_auth(
+            user_info,
+            ssh_con,
+            rgw_config.ssl,
+            getattr(rgw_config, "haproxy", False),
+        )
+        clients.append(auth.do_auth_using_client())
+    return clients
+
+
+@pytest.fixture
+def bucket(s3_client, request):
+    name = f"dedup-pytest-{random.randint(1, 9999)}"
+    s3_client.create_bucket(Bucket=name)
+    ctx = _get_ctx(request.node.nodeid)
+    ctx["buckets"].append(name)
+    marker = dedup_utils.get_bucket_marker(name)
+    if marker:
+        ctx["bucket_markers"][name] = marker
+    yield name
+    dedup_utils.cleanup_bucket(s3_client, name)
+
+
+@pytest.fixture
+def bucket_factory(s3_client, request):
+    created = []
+
+    def _create(prefix="dedup-pytest"):
+        name = f"{prefix}-{random.randint(1, 9999)}"
+        s3_client.create_bucket(Bucket=name)
+        created.append(name)
+        ctx = _get_ctx(request.node.nodeid)
+        ctx["buckets"].append(name)
+        marker = dedup_utils.get_bucket_marker(name)
+        if marker:
+            ctx["bucket_markers"][name] = marker
+        return name
+
+    yield _create
+
+    for name in created:
+        dedup_utils.cleanup_bucket(s3_client, name)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def dedup_min_size_4k():
+    dedup_utils.set_dedup_config("rgw_dedup_min_obj_size_for_dedup", "4096")
+    yield
+    dedup_utils.reset_dedup_config("rgw_dedup_min_obj_size_for_dedup")
+
+
+@pytest.fixture(autouse=True)
+def dedup_session_reset():
+    """Abort any leftover dedup session before each test."""
+    try:
+        dedup_utils.run_dedup_abort()
+    except (AssertionError, Exception):
+        pass
+    time.sleep(2)
+    yield
+
+
+@pytest.fixture
+def admin_user(rgw_config, ssh_con, io_info, request):
+    import json as _json
+
+    admin_user = utils.exec_shell_cmd(
+        "radosgw-admin user create --uid=dedup-admin --display-name='Dedup Admin' "
+        "--caps='dedup=*'"
+    )
+    if admin_user is False:
+        admin_user = utils.exec_shell_cmd("radosgw-admin user info --uid=dedup-admin")
+    admin_info = _json.loads(admin_user)
+    user_info = {
+        "user_id": "dedup-admin",
+        "access_key": admin_info["keys"][0]["access_key"],
+        "secret_key": admin_info["keys"][0]["secret_key"],
+    }
+    ctx = _get_ctx(request.node.nodeid)
+    ctx["users"].append(user_info)
+    return user_info
+
+
+@pytest.fixture
+def endpoint_url(rgw_config, ssh_con, io_info, request):
+    user_info = s3lib.create_users(1)[0]
+    ctx = _get_ctx(request.node.nodeid)
+    ctx["users"].append(user_info)
+    auth = reusable.get_auth(
+        user_info,
+        ssh_con,
+        rgw_config.ssl,
+        getattr(rgw_config, "haproxy", False),
+    )
+    return auth.endpoint_url
+
+
+@pytest.fixture(autouse=True)
+def step_recorder(request):
+    test_name = request.node.name
+    scenario_info = DEDUP_TEST_SCENARIOS.get(test_name, {})
+    test_id = scenario_info.get("id", "?")
+    goal = scenario_info.get("scenario", request.node.obj.__doc__ or "No description")
+    recorder = dedup_utils.TestStepRecorder(test_id, goal)
+    ctx = _get_ctx(request.node.nodeid)
+    ctx["recorder"] = recorder
+    dedup_utils._active_recorder = recorder
+    yield recorder
+    dedup_utils._active_recorder = None
+
+
+@pytest.fixture
+def test_context(request):
+    return _get_ctx(request.node.nodeid)
+
+
+def _do_post_pass_cleanup(node_id):
+    ctx = _test_context.get(node_id)
+    if not ctx:
+        return
+    log.info("=" * 60)
+    log.info("POST-PASS CLEANUP")
+    log.info("=" * 60)
+
+    for bkt_name, marker in ctx.get("bucket_markers", {}).items():
+        log.info(f"RADOS cleanup for bucket {bkt_name} (marker={marker})")
+        dedup_utils.cleanup_rados_objects_by_marker(marker)
+
+    purged_uids = set()
+    for user_info in ctx.get("users", []):
+        uid = user_info.get("user_id", "")
+        if uid and uid not in purged_uids:
+            dedup_utils.purge_user(uid)
+            purged_uids.add(uid)
+
+    log.info("POST-PASS CLEANUP COMPLETE")
+    log.info("=" * 60)
+    _test_context.pop(node_id, None)
+
+
+# ---------------------------------------------------------------------------
+# Pytest hooks for test scenario logging and summary
+# ---------------------------------------------------------------------------
+
+_test_results = []
+
+
+def pytest_runtest_setup(item):
+    test_name = item.name
+    scenario_info = DEDUP_TEST_SCENARIOS.get(test_name, {})
+    test_id = scenario_info.get("id", "?")
+    category = scenario_info.get("category", "Unknown")
+    scenario = scenario_info.get("scenario", item.obj.__doc__ or "No description")
+    log.info("=" * 80)
+    log.info(f"TEST START: [{test_id}] {test_name}")
+    log.info(f"  Category : {category}")
+    log.info(f"  Scenario : {scenario}")
+    log.info("=" * 80)
+
+
+def pytest_runtest_makereport(item, call):
+    if call.when == "call":
+        test_name = item.name
+        node_id = item.nodeid
+        scenario_info = DEDUP_TEST_SCENARIOS.get(test_name, {})
+        test_id = scenario_info.get("id", "?")
+        category = scenario_info.get("category", "Unknown")
+        scenario = scenario_info.get("scenario", "")
+        duration = round(call.duration, 2)
+
+        if call.excinfo is None:
+            status = "PASSED"
+            error_msg = ""
+            _test_passed[node_id] = True
+        else:
+            status = "FAILED"
+            error_msg = str(call.excinfo.value)[:120]
+            _test_passed[node_id] = False
+
+        _test_results.append(
+            {
+                "id": test_id,
+                "name": test_name,
+                "category": category,
+                "scenario": scenario,
+                "status": status,
+                "duration": duration,
+                "error": error_msg,
+            }
+        )
+
+        ctx = _test_context.get(node_id, {})
+        recorder = ctx.get("recorder")
+        if recorder:
+            for line in recorder.get_report_lines(status, duration, error_msg):
+                log.info(line)
+
+        log.info("-" * 80)
+        log.info(f"TEST RESULT: [{test_id}] {test_name} => {status} ({duration}s)")
+        if error_msg:
+            log.info(f"  Error: {error_msg}")
+        log.info("-" * 80)
+
+    elif call.when == "teardown":
+        node_id = item.nodeid
+        if _test_passed.get(node_id, False):
+            _do_post_pass_cleanup(node_id)
+        else:
+            _test_context.pop(node_id, None)
+        _test_passed.pop(node_id, None)
+
+
+DEDUP_REPORT_PATH = "/tmp/dedup_test_report.json"
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Write per-test results to JSON for cephci to pick up."""
+    if not _test_results:
+        return
+
+    report = {
+        "results": [],
+        "savings": {},
+        "exit_status": exitstatus,
+    }
+
+    for r in _test_results:
+        entry = dict(r)
+        node_id = f"test_dedup_pytest.py::{r['name']}"
+        ctx = _test_context.get(node_id, {})
+        recorder = ctx.get("recorder")
+        if recorder:
+            entry["steps"] = list(recorder.steps)
+        report["results"].append(entry)
+
+    for test_id, s in dedup_utils._savings_registry.items():
+        report["savings"][test_id] = s
+
+    try:
+        with open(DEDUP_REPORT_PATH, "w") as f:
+            json.dump(report, f, indent=2, default=str)
+        log.info("Wrote dedup test report to %s", DEDUP_REPORT_PATH)
+    except Exception as e:
+        log.warning("Failed to write dedup test report JSON: %s", e)
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    if not _test_results:
+        return
+
+    passed = [r for r in _test_results if r["status"] == "PASSED"]
+    failed = [r for r in _test_results if r["status"] == "FAILED"]
+
+    summary_lines = [
+        "",
+        "=" * 100,
+        "DEDUP TEST SUITE SUMMARY",
+        "=" * 100,
+        f"{'ID':<5} {'Category':<14} {'Test Name':<42} {'Status':<8} {'Duration':<10} {'Error'}",
+        "-" * 100,
+    ]
+    for r in _test_results:
+        err_short = r["error"][:40] + "..." if len(r["error"]) > 40 else r["error"]
+        summary_lines.append(
+            f"{r['id']:<5} {r['category']:<14} {r['name']:<42} {r['status']:<8} {r['duration']:<10} {err_short}"
+        )
+    summary_lines.append("-" * 100)
+    summary_lines.append(
+        f"Total: {len(_test_results)} | Passed: {len(passed)} | Failed: {len(failed)}"
+    )
+    summary_lines.append("=" * 100)
+
+    if failed:
+        summary_lines.append("")
+        summary_lines.append("FAILED TEST DETAILS:")
+        summary_lines.append("-" * 100)
+        for r in failed:
+            summary_lines.append(f"  [{r['id']}] {r['name']}")
+            summary_lines.append(f"       Scenario: {r['scenario']}")
+            summary_lines.append(f"       Error   : {r['error']}")
+            summary_lines.append("")
+
+    if dedup_utils._savings_registry:
+        summary_lines.append("")
+        summary_lines.append("DEDUP STORAGE SAVINGS:")
+        summary_lines.append("-" * 100)
+        summary_lines.append(
+            f"{'ID':<5} {'Uploaded':<14} {'Deduped Bytes':<14} {'Savings %':<12} "
+            f"{'Ratio':<10} {'Deduped Objs':<14} {'Skipped Comp'}"
+        )
+        summary_lines.append("-" * 100)
+        for test_id, s in sorted(dedup_utils._savings_registry.items()):
+            ratio_str = f"{s['dedup_ratio']:.2f}x" if s["dedup_ratio"] > 0 else "N/A"
+            comp_str = (
+                str(s["skipped_compressed"]) if s["skipped_compressed"] > 0 else "-"
+            )
+            summary_lines.append(
+                f"{s['test_id']:<5} "
+                f"{dedup_utils._format_bytes(s['total_uploaded']):<14} "
+                f"{dedup_utils._format_bytes(s['deduped_bytes']):<14} "
+                f"{s['savings_pct']:<11.1f}% "
+                f"{ratio_str:<10} "
+                f"{s['deduped_count']:<14} "
+                f"{comp_str}"
+            )
+        summary_lines.append("=" * 100)
+
+    summary_text = "\n".join(summary_lines)
+    log.info(summary_text)
+    terminalreporter.write_line(summary_text)

--- a/rgw/v2/tests/s3_swift/pytest.ini
+++ b/rgw/v2/tests/s3_swift/pytest.ini
@@ -1,0 +1,18 @@
+[pytest]
+markers =
+    sanity: Basic dedup sanity tests (S1-S5)
+    feature: Feature tests (S6-S15)
+    compression: Compressed object dedup tests (S16-S21)
+    bug: Bug-hunting and regression tests (B1-B7)
+    enhancement: 128-limit enhancement tests (E1-E5)
+    restart: Restart/recovery scenarios (R1-R5)
+    concurrent: Concurrent/race condition scenarios (C1-C5)
+    edge_case: Data edge case scenarios (D1-D5)
+    infra: Infrastructure failure scenarios (F1-F5)
+    slow: Tests that take more than 2 minutes
+
+log_cli = true
+log_cli_level = INFO
+log_cli_format = %(asctime)s %(levelname)s %(message)s
+
+addopts = -v --tb=short

--- a/rgw/v2/tests/s3_swift/reusables/dedup.py
+++ b/rgw/v2/tests/s3_swift/reusables/dedup.py
@@ -1,0 +1,1415 @@
+"""
+Reusable helper functions for RGW dedup (deduplication) test automation.
+
+Provides wrappers around radosgw-admin dedup commands, Admin OPS API calls,
+identical object upload utilities, and integrity verification helpers.
+"""
+
+import base64
+import hashlib
+import json
+import logging
+import os
+import random
+import string
+import subprocess
+import tempfile
+import time
+from threading import Thread
+
+import v2.utils.utils as utils
+
+log = logging.getLogger()
+
+DEDUP_POLL_INTERVAL = 10
+DEDUP_DEFAULT_TIMEOUT = 600
+
+# ---------------------------------------------------------------------------
+# Step recorder for per-test structured reports
+# ---------------------------------------------------------------------------
+
+_active_recorder = None
+
+
+def _record_step(action, command="", result=""):
+    if _active_recorder is not None:
+        _active_recorder.record(action, command, result)
+
+
+class TestStepRecorder:
+    def __init__(self, test_id, goal):
+        self.test_id = test_id
+        self.goal = goal
+        self.steps = []
+
+    def record(self, action, command="", result=""):
+        self.steps.append(
+            {
+                "action": action,
+                "command": command,
+                "result": result,
+            }
+        )
+
+    def get_report_lines(self, status, duration, error=""):
+        lines = [
+            "=" * 90,
+            f"TEST REPORT: [{self.test_id}] — {status} ({duration}s)",
+            f"  Goal: {self.goal}",
+            "-" * 90,
+            "  Steps:",
+        ]
+        for i, s in enumerate(self.steps, 1):
+            lines.append(f"    {i}. {s['action']}")
+            if s["command"]:
+                lines.append(f"       cmd: {s['command']}")
+            if s["result"]:
+                lines.append(f"       result: {s['result']}")
+        lines.append("-" * 90)
+        if error:
+            lines.append(f"  FAILURE: {error}")
+        else:
+            lines.append("  Result: All assertions passed — EXPECTED")
+        lines.append("=" * 90)
+        return lines
+
+
+# ---------------------------------------------------------------------------
+# Post-test cleanup helpers
+# ---------------------------------------------------------------------------
+
+
+def get_bucket_marker(bucket_name):
+    cmd = f"radosgw-admin bucket stats --bucket={bucket_name}"
+    out = utils.exec_shell_cmd(cmd)
+    if out is False:
+        log.warning(f"Could not get marker for bucket {bucket_name}")
+        return None
+    try:
+        info = json.loads(out)
+        marker = info.get("marker", "")
+        log.info(f"Bucket {bucket_name} marker: {marker}")
+        return marker
+    except json.JSONDecodeError:
+        log.warning(f"Could not parse bucket stats for {bucket_name}")
+        return None
+
+
+def cleanup_rados_objects_by_marker(marker, pool="default.rgw.buckets.data"):
+    if not marker:
+        return
+    objects = get_rados_objects(pool, prefix=marker)
+    if not objects:
+        log.info(f"No RADOS objects found for marker {marker}")
+        return
+    log.info(f"Removing {len(objects)} RADOS objects for marker {marker}")
+    for oid in objects:
+        cmd = f"rados -p {pool} rm {oid}"
+        utils.exec_shell_cmd(cmd)
+    log.info(f"RADOS cleanup done for marker {marker}")
+
+
+def purge_user(user_id):
+    cmd = f"radosgw-admin user rm --purge-keys --purge-data --uid={user_id}"
+    log.info(f"Purging user: {cmd}")
+    out = utils.exec_shell_cmd(cmd)
+    if out is False:
+        log.warning(f"Failed to purge user {user_id} (may already be gone)")
+    else:
+        log.info(f"User {user_id} purged successfully")
+
+
+def _abort_previous_session():
+    """Abort any leftover dedup session so stats are reset for the new run."""
+    log.info("Aborting any previous dedup session to reset stats")
+    utils.exec_shell_cmd("radosgw-admin dedup abort")
+    time.sleep(2)
+
+
+def run_dedup_estimate(
+    allow_bucket_file=None,
+    deny_bucket_file=None,
+    allow_sc_file=None,
+    deny_sc_file=None,
+):
+    _abort_previous_session()
+    cmd = "radosgw-admin dedup estimate"
+    if allow_bucket_file:
+        cmd += f" --allow-bucket-list {allow_bucket_file}"
+    if deny_bucket_file:
+        cmd += f" --deny-bucket-list {deny_bucket_file}"
+    if allow_sc_file:
+        cmd += f" --allow-storage-class-list {allow_sc_file}"
+    if deny_sc_file:
+        cmd += f" --deny-storage-class-list {deny_sc_file}"
+    log.info(f"Running dedup estimate: {cmd}")
+    _record_step("Run dedup estimate", cmd)
+    out = utils.exec_shell_cmd(cmd)
+    if out is False:
+        raise AssertionError("dedup estimate command failed")
+    return out
+
+
+def run_dedup_execute(
+    allow_bucket_file=None,
+    deny_bucket_file=None,
+    allow_sc_file=None,
+    deny_sc_file=None,
+):
+    _abort_previous_session()
+    cmd = "radosgw-admin dedup exec --yes-i-really-mean-it"
+    if allow_bucket_file:
+        cmd += f" --allow-bucket-list {allow_bucket_file}"
+    if deny_bucket_file:
+        cmd += f" --deny-bucket-list {deny_bucket_file}"
+    if allow_sc_file:
+        cmd += f" --allow-storage-class-list {allow_sc_file}"
+    if deny_sc_file:
+        cmd += f" --deny-storage-class-list {deny_sc_file}"
+    log.info(f"Running dedup exec: {cmd}")
+    _record_step("Run dedup exec", cmd)
+    out = utils.exec_shell_cmd(cmd)
+    if out is False:
+        raise AssertionError("dedup exec command failed")
+    return out
+
+
+def run_dedup_pause():
+    log.info("Pausing dedup session")
+    _record_step("Pause dedup session", "radosgw-admin dedup pause")
+    out = utils.exec_shell_cmd("radosgw-admin dedup pause")
+    if out is False:
+        raise AssertionError("dedup pause command failed")
+    return out
+
+
+def run_dedup_resume():
+    log.info("Resuming dedup session")
+    _record_step("Resume dedup session", "radosgw-admin dedup resume")
+    out = utils.exec_shell_cmd("radosgw-admin dedup resume")
+    if out is False:
+        raise AssertionError("dedup resume command failed")
+    return out
+
+
+def run_dedup_abort():
+    log.info("Aborting dedup session")
+    _record_step("Abort dedup session", "radosgw-admin dedup abort")
+    out = utils.exec_shell_cmd("radosgw-admin dedup abort")
+    if out is False:
+        raise AssertionError("dedup abort command failed")
+    return out
+
+
+def get_dedup_stats():
+    log.info("Getting dedup stats")
+    out = utils.exec_shell_cmd("radosgw-admin dedup stats")
+    if out is False:
+        raise AssertionError("dedup stats command failed")
+    try:
+        stats = json.loads(out)
+    except json.JSONDecodeError:
+        log.warning(f"Could not parse dedup stats as JSON: {out}")
+        return out
+    log.info(f"Dedup stats: {json.dumps(stats, indent=2)}")
+    return stats
+
+
+def set_dedup_throttle(max_bucket_index_ops=None, max_metadata_ops=None):
+    cmd = "radosgw-admin dedup throttle"
+    if max_bucket_index_ops is not None:
+        cmd += f" --max-bucket-index-ops={max_bucket_index_ops}"
+    if max_metadata_ops is not None:
+        cmd += f" --max-metadata-ops={max_metadata_ops}"
+    log.info(f"Setting dedup throttle: {cmd}")
+    out = utils.exec_shell_cmd(cmd)
+    if out is False:
+        raise AssertionError("dedup throttle set command failed")
+    return out
+
+
+def get_dedup_throttle():
+    log.info("Getting dedup throttle settings")
+    out = utils.exec_shell_cmd("radosgw-admin dedup throttle --stat")
+    if out is False:
+        raise AssertionError("dedup throttle stat command failed")
+    return out
+
+
+def wait_for_dedup_completion(
+    timeout=DEDUP_DEFAULT_TIMEOUT, poll_interval=DEDUP_POLL_INTERVAL
+):
+    log.info(f"Waiting for dedup completion (timeout={timeout}s)")
+    start = time.time()
+
+    # Phase 1: Wait for scan to start (completed=false means scan is running)
+    log.info("Phase 1: Waiting for dedup scan to start...")
+    scan_started = False
+    while time.time() - start < timeout:
+        stats = get_dedup_stats()
+        if isinstance(stats, dict):
+            completed = stats.get("completed", False)
+            worker = stats.get("worker_stats", {}).get("main", {})
+            md5 = stats.get("md5_stats", {}).get("main", {})
+            ingress = worker.get("Ingress Objs count", 0)
+            processed = md5.get("Total processed objects", 0)
+
+            if not completed:
+                log.info(
+                    f"Scan started (completed=false): "
+                    f"ingress={ingress}, processed={processed}"
+                )
+                scan_started = True
+                break
+
+            if completed and (ingress > 0 or processed > 0):
+                log.info(
+                    f"Scan already completed with data: "
+                    f"ingress={ingress}, processed={processed}"
+                )
+                scan_started = True
+                break
+
+            elapsed_phase1 = time.time() - start
+            if elapsed_phase1 > 30:
+                log.info(
+                    "Scan shows completed=true with 0 objects after 30s — "
+                    "accepting as valid (empty bucket or instant completion)"
+                )
+                scan_started = True
+                break
+
+            log.info(
+                "Scan not started yet (completed=true, 0 objects) — "
+                "waiting for async scan to kick in..."
+            )
+        time.sleep(poll_interval)
+
+    if not scan_started:
+        raise AssertionError(f"Dedup scan did not start within {timeout}s")
+
+    # Phase 2: Wait for scan to complete (completed=true with data)
+    log.info("Phase 2: Waiting for dedup scan to complete...")
+    while time.time() - start < timeout:
+        stats = get_dedup_stats()
+        if isinstance(stats, dict):
+            completed = stats.get("completed", False)
+            worker = stats.get("worker_stats", {}).get("main", {})
+            md5 = stats.get("md5_stats", {}).get("main", {})
+            ingress = worker.get("Ingress Objs count", 0)
+            processed = md5.get("Total processed objects", 0)
+            deduped = md5.get("Deduped Obj (this cycle)", 0)
+
+            if completed:
+                elapsed = int(time.time() - start)
+                log.info(
+                    f"Dedup completed (took {elapsed}s): "
+                    f"ingress={ingress}, processed={processed}, "
+                    f"deduped={deduped}"
+                )
+                _record_step(
+                    "Dedup completed",
+                    "radosgw-admin dedup stats",
+                    f"ingress={ingress}, processed={processed}, deduped={deduped} ({elapsed}s)",
+                )
+                return stats
+
+            log.info(
+                f"Dedup in progress: ingress={ingress}, "
+                f"processed={processed}, deduped={deduped}"
+            )
+        time.sleep(poll_interval)
+    raise AssertionError(f"Dedup did not complete within {timeout}s")
+
+
+def generate_identical_data(size_bytes):
+    random.seed(42)
+    return random.randbytes(size_bytes)
+
+
+def upload_identical_objects(
+    s3_client, bucket_name, count, size_bytes, prefix="dedup-obj"
+):
+    data = generate_identical_data(size_bytes)
+    md5_hash = hashlib.md5(data).hexdigest()
+    log.info(
+        f"Uploading {count} identical objects of size {size_bytes} bytes "
+        f"(MD5: {md5_hash}) to bucket {bucket_name}"
+    )
+    _record_step(
+        f"Upload {count} identical {size_bytes}B objects to {bucket_name}",
+        f"s3_client.put_object x{count}",
+        f"MD5={md5_hash}",
+    )
+    keys = []
+    for i in range(count):
+        key = f"{prefix}-{i}"
+        s3_client.put_object(Bucket=bucket_name, Key=key, Body=data)
+        keys.append(key)
+        log.info(f"Uploaded {key}")
+    return keys, md5_hash, data
+
+
+def upload_identical_multipart_objects(
+    s3_client,
+    bucket_name,
+    count,
+    size_bytes,
+    prefix="dedup-mp",
+    part_size=5 * 1024 * 1024,
+):
+    data = generate_identical_data(size_bytes)
+    md5_hash = hashlib.md5(data).hexdigest()
+    log.info(
+        f"Uploading {count} identical multipart objects of size {size_bytes} bytes "
+        f"to bucket {bucket_name}"
+    )
+    _record_step(
+        f"Upload {count} identical multipart {size_bytes}B objects to {bucket_name}",
+        f"s3_client.create_multipart_upload x{count}",
+        f"MD5={md5_hash}",
+    )
+    keys = []
+    for i in range(count):
+        key = f"{prefix}-{i}"
+        mpu = s3_client.create_multipart_upload(Bucket=bucket_name, Key=key)
+        upload_id = mpu["UploadId"]
+
+        parts = []
+        offset = 0
+        part_number = 1
+        while offset < size_bytes:
+            end = min(offset + part_size, size_bytes)
+            part_data = data[offset:end]
+            resp = s3_client.upload_part(
+                Bucket=bucket_name,
+                Key=key,
+                UploadId=upload_id,
+                PartNumber=part_number,
+                Body=part_data,
+            )
+            parts.append({"ETag": resp["ETag"], "PartNumber": part_number})
+            offset = end
+            part_number += 1
+
+        s3_client.complete_multipart_upload(
+            Bucket=bucket_name,
+            Key=key,
+            UploadId=upload_id,
+            MultipartUpload={"Parts": parts},
+        )
+        keys.append(key)
+        log.info(f"Uploaded multipart {key} ({part_number - 1} parts)")
+    return keys, md5_hash, data
+
+
+def upload_ssec_objects(s3_client, bucket_name, count, size_bytes, prefix="dedup-ssec"):
+    data = generate_identical_data(size_bytes)
+    sse_key = os.urandom(32)
+    sse_key_b64 = base64.b64encode(sse_key).decode("utf-8")
+    sse_key_md5 = base64.b64encode(hashlib.md5(sse_key).digest()).decode("utf-8")
+    log.info(f"Uploading {count} SSE-C encrypted objects to bucket {bucket_name}")
+    _record_step(
+        f"Upload {count} SSE-C encrypted objects to {bucket_name}",
+        f"s3_client.put_object x{count} (SSE-C AES256)",
+    )
+    keys = []
+    for i in range(count):
+        key = f"{prefix}-{i}"
+        s3_client.put_object(
+            Bucket=bucket_name,
+            Key=key,
+            Body=data,
+            SSECustomerAlgorithm="AES256",
+            SSECustomerKey=sse_key_b64,
+            SSECustomerKeyMD5=sse_key_md5,
+        )
+        keys.append(key)
+        log.info(f"Uploaded SSE-C encrypted {key}")
+    return keys, sse_key_b64, sse_key_md5
+
+
+def verify_object_integrity(s3_client, bucket_name, key, expected_md5):
+    log.info(f"Verifying integrity of {bucket_name}/{key}")
+    resp = s3_client.get_object(Bucket=bucket_name, Key=key)
+    body = resp["Body"].read()
+    actual_md5 = hashlib.md5(body).hexdigest()
+    if actual_md5 != expected_md5:
+        raise AssertionError(
+            f"MD5 mismatch for {key}: expected {expected_md5}, got {actual_md5}"
+        )
+    log.info(f"Integrity OK for {key}: MD5={actual_md5}")
+    return resp.get("ETag", "").strip('"')
+
+
+def verify_all_objects_accessible(s3_client, bucket_name, keys):
+    log.info(f"Verifying all {len(keys)} objects are accessible in {bucket_name}")
+    _record_step(f"Verify {len(keys)} objects accessible in {bucket_name}")
+    for key in keys:
+        resp = s3_client.head_object(Bucket=bucket_name, Key=key)
+        status = resp["ResponseMetadata"]["HTTPStatusCode"]
+        if status != 200:
+            raise AssertionError(f"Object {key} not accessible, status: {status}")
+    log.info(f"All {len(keys)} objects accessible")
+
+
+def verify_all_objects_integrity(s3_client, bucket_name, keys, expected_md5):
+    log.info(f"Verifying integrity of {len(keys)} objects in {bucket_name}")
+    _record_step(f"Verify MD5 integrity for {len(keys)} objects in {bucket_name}")
+    etags = {}
+    for key in keys:
+        etag = verify_object_integrity(s3_client, bucket_name, key, expected_md5)
+        etags[key] = etag
+    log.info(f"All {len(keys)} objects passed integrity check")
+    return etags
+
+
+def verify_range_get(
+    s3_client, bucket_name, key, original_data, range_start, range_end
+):
+    log.info(f"Verifying range GET for {key} bytes={range_start}-{range_end}")
+    resp = s3_client.get_object(
+        Bucket=bucket_name, Key=key, Range=f"bytes={range_start}-{range_end}"
+    )
+    range_data = resp["Body"].read()
+    expected_data = original_data[range_start : range_end + 1]
+    if range_data != expected_data:
+        raise AssertionError(
+            f"Range GET mismatch for {key}: got {len(range_data)} bytes, "
+            f"expected {len(expected_data)} bytes"
+        )
+    log.info(f"Range GET OK for {key}")
+
+
+def create_filter_list_file(items, filepath=None):
+    if filepath is None:
+        fd, filepath = tempfile.mkstemp(suffix=".txt", prefix="dedup_filter_")
+        os.close(fd)
+    with open(filepath, "w") as f:
+        for item in items:
+            f.write(f"{item}\n")
+    log.info(f"Created filter list file at {filepath} with {len(items)} entries")
+    return filepath
+
+
+def ensure_dedup_caps(uid):
+    cmd = f"radosgw-admin caps add --uid={uid} --caps='dedup=*'"
+    log.info(f"Granting dedup caps: {cmd}")
+    out = utils.exec_shell_cmd(cmd)
+    if out is False:
+        log.warning(f"Failed to add dedup caps to {uid}, may already exist")
+
+
+def dedup_api_request(
+    endpoint_url, op, method=None, access_key=None, secret_key=None, params=None
+):
+    import requests
+    from botocore.auth import HmacV1Auth
+    from botocore.awsrequest import AWSRequest
+    from botocore.credentials import Credentials
+
+    if method is None:
+        method = "GET" if op in ("stats",) else "POST"
+    if op == "throttle" and method is None:
+        method = "GET"
+
+    url = f"{endpoint_url}/admin/dedup"
+    if params is None:
+        params = {}
+    params["op"] = op
+
+    log.info(f"Dedup API request: {method} {url} params={params}")
+    _record_step(f"Dedup API {method} op={op}", f"{method} {url} params={params}")
+
+    credentials = Credentials(access_key, secret_key)
+    full_url = f"{url}?{requests.compat.urlencode(params)}"
+    request = AWSRequest(method=method, url=full_url)
+    HmacV1Auth(credentials).add_auth(request)
+
+    response = requests.request(
+        method=method,
+        url=url,
+        headers=dict(request.headers),
+        params=params,
+        verify=False,
+    )
+    log.info(f"API response status: {response.status_code}")
+    log.info(f"API response body: {response.text[:500]}")
+    return response
+
+
+def run_concurrent_s3_workload(
+    s3_client, bucket_name, duration_secs=30, prefix="concurrent"
+):
+    results = {"puts": 0, "gets": 0, "deletes": 0, "errors": 0}
+    stop_flag = {"stop": False}
+
+    def workload():
+        obj_counter = 0
+        created_keys = []
+        while not stop_flag["stop"]:
+            try:
+                key = f"{prefix}-{obj_counter}"
+                data = os.urandom(random.randint(1024, 10240))
+                s3_client.put_object(Bucket=bucket_name, Key=key, Body=data)
+                results["puts"] += 1
+                created_keys.append(key)
+                obj_counter += 1
+
+                if created_keys:
+                    get_key = random.choice(created_keys)
+                    resp = s3_client.get_object(Bucket=bucket_name, Key=get_key)
+                    resp["Body"].read()
+                    resp["Body"].close()
+                    results["gets"] += 1
+
+                if len(created_keys) > 10:
+                    del_key = created_keys.pop(0)
+                    s3_client.delete_object(Bucket=bucket_name, Key=del_key)
+                    results["deletes"] += 1
+
+                time.sleep(0.05)
+            except Exception as e:
+                log.warning(f"Concurrent workload error: {e}")
+                results["errors"] += 1
+
+    thread = Thread(target=workload, daemon=True)
+    thread.start()
+    time.sleep(duration_secs)
+    stop_flag["stop"] = True
+    thread.join(timeout=10)
+
+    log.info(
+        f"Concurrent workload results: {results['puts']} puts, "
+        f"{results['gets']} gets, {results['deletes']} deletes, "
+        f"{results['errors']} errors"
+    )
+    return results
+
+
+def set_lifecycle_expiration(s3_client, bucket_name, days=1, prefix=""):
+    lc_config = {
+        "Rules": [
+            {
+                "ID": "dedup-lc-expiration",
+                "Filter": {"Prefix": prefix},
+                "Status": "Enabled",
+                "Expiration": {"Days": days},
+            }
+        ]
+    }
+    s3_client.put_bucket_lifecycle_configuration(
+        Bucket=bucket_name, LifecycleConfiguration=lc_config
+    )
+    _record_step(f"Set lifecycle expiration ({days} days) on {bucket_name}")
+    log.info(f"Set LC expiration of {days} day(s) on bucket {bucket_name}")
+
+
+def enable_bucket_versioning(s3_client, bucket_name):
+    s3_client.put_bucket_versioning(
+        Bucket=bucket_name,
+        VersioningConfiguration={"Status": "Enabled"},
+    )
+    _record_step(f"Enable versioning on {bucket_name}")
+    log.info(f"Enabled versioning on bucket {bucket_name}")
+
+
+def get_all_versions(s3_client, bucket_name, key):
+    resp = s3_client.list_object_versions(Bucket=bucket_name, Prefix=key)
+    versions = resp.get("Versions", [])
+    log.info(f"Found {len(versions)} versions of {key} in {bucket_name}")
+    return versions
+
+
+def cleanup_bucket(s3_client, bucket_name):
+    log.info(f"Cleaning up bucket {bucket_name}")
+    try:
+        resp = s3_client.list_object_versions(Bucket=bucket_name)
+        versions = resp.get("Versions", [])
+        delete_markers = resp.get("DeleteMarkers", [])
+        objects_to_delete = []
+        for v in versions:
+            objects_to_delete.append({"Key": v["Key"], "VersionId": v["VersionId"]})
+        for dm in delete_markers:
+            objects_to_delete.append({"Key": dm["Key"], "VersionId": dm["VersionId"]})
+        if objects_to_delete:
+            for i in range(0, len(objects_to_delete), 1000):
+                batch = objects_to_delete[i : i + 1000]
+                s3_client.delete_objects(Bucket=bucket_name, Delete={"Objects": batch})
+    except Exception:
+        try:
+            resp = s3_client.list_objects_v2(Bucket=bucket_name)
+            if "Contents" in resp:
+                for obj in resp["Contents"]:
+                    s3_client.delete_object(Bucket=bucket_name, Key=obj["Key"])
+        except Exception as e:
+            log.warning(f"Cleanup list/delete failed: {e}")
+    try:
+        s3_client.delete_bucket(Bucket=bucket_name)
+        log.info(f"Deleted bucket {bucket_name}")
+    except Exception as e:
+        log.warning(f"Failed to delete bucket {bucket_name}: {e}")
+
+
+# --- Compression helpers ---
+
+
+def get_zone_name():
+    out = utils.exec_shell_cmd("radosgw-admin zone get")
+    if out is False:
+        raise AssertionError("Failed to get zone info")
+    return json.loads(out).get("name")
+
+
+def enable_zone_compression(compression_type="zlib", ssh_con=None):
+    zone_name = get_zone_name()
+    cmd = (
+        f"radosgw-admin zone placement modify --rgw-zone={zone_name} "
+        f"--placement-id=default-placement "
+        f"--storage-class=STANDARD "
+        f"--compression={compression_type}"
+    )
+    log.info(f"Enabling compression: {cmd}")
+    _record_step(f"Enable {compression_type} compression on zone {zone_name}", cmd)
+    out = utils.exec_shell_cmd(cmd)
+    if out is False:
+        raise AssertionError(f"Failed to enable {compression_type} compression")
+    _commit_period()
+    _restart_rgw(ssh_con)
+    return zone_name
+
+
+def disable_zone_compression(ssh_con=None):
+    zone_name = get_zone_name()
+    cmd = (
+        f"radosgw-admin zone placement modify --rgw-zone={zone_name} "
+        f"--placement-id=default-placement "
+        f"--storage-class=STANDARD "
+        f"--compression=none"
+    )
+    log.info(f"Disabling compression: {cmd}")
+    _record_step("Disable compression", cmd)
+    out = utils.exec_shell_cmd(cmd)
+    if out is False:
+        raise AssertionError("Failed to disable compression")
+    _commit_period()
+    _restart_rgw(ssh_con)
+
+
+def _commit_period():
+    out = utils.exec_shell_cmd("radosgw-admin period update --commit")
+    if out is False:
+        log.warning("period update --commit failed (may be non-multisite, ignoring)")
+    else:
+        log.info("Period updated and committed")
+
+
+def _restart_rgw(ssh_con=None):
+    out = utils.exec_shell_cmd("ceph orch ls --service-type rgw --format json")
+    if out is False:
+        raise AssertionError("Failed to list RGW services")
+    services = json.loads(out)
+    svc_names = [s.get("service_name", "") for s in services]
+    total_expected = sum(s.get("status", {}).get("size", 0) for s in services)
+
+    ps_out = utils.exec_shell_cmd("ceph orch ps --daemon_type rgw --format json")
+    old_started = {}
+    if ps_out and ps_out is not False:
+        for d in json.loads(ps_out):
+            old_started[d["daemon_name"]] = d.get("started", "")
+
+    log.info(f"Restarting all RGW services: {svc_names} ({total_expected} daemons)")
+    for svc in svc_names:
+        utils.exec_shell_cmd(f"ceph orch restart {svc}")
+
+    timeout = max(180, total_expected * 20)
+    poll_interval = 15
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        time.sleep(poll_interval)
+        ps_out = utils.exec_shell_cmd("ceph orch ps --daemon_type rgw --format json")
+        if ps_out is False:
+            continue
+        daemons = json.loads(ps_out)
+        running = [d for d in daemons if d.get("status_desc") == "running"]
+        restarted = 0
+        for d in running:
+            name = d["daemon_name"]
+            cur_started = d.get("started", "")
+            if cur_started and cur_started != old_started.get(name, ""):
+                restarted += 1
+        log.info(
+            f"RGW restart progress: {restarted}/{total_expected} "
+            f"daemons restarted, {len(running)} running"
+        )
+        if restarted >= total_expected and len(running) >= total_expected:
+            log.info("All RGW daemons restarted successfully")
+            time.sleep(5)
+            return
+    log.warning(f"RGW restart timed out after {timeout}s — proceeding anyway")
+
+
+# --- Storage class helpers ---
+
+
+def get_zonegroup_name():
+    out = utils.exec_shell_cmd("radosgw-admin zonegroup get")
+    if out is False:
+        raise AssertionError("Failed to get zonegroup info")
+    return json.loads(out).get("name")
+
+
+def setup_storage_class(sc_name, pool_name, ssh_con=None):
+    zone = get_zone_name()
+    zonegroup = get_zonegroup_name()
+
+    log.info(f"Creating pool {pool_name}")
+    out = utils.exec_shell_cmd(f"ceph osd pool create {pool_name}")
+    if out is False:
+        raise AssertionError(f"Failed to create pool {pool_name}")
+
+    log.info(f"Enabling rgw application on pool {pool_name}")
+    out = utils.exec_shell_cmd(f"ceph osd pool application enable {pool_name} rgw")
+    if out is False:
+        raise AssertionError(f"Failed to enable rgw app on pool {pool_name}")
+
+    log.info(f"Adding storage class {sc_name} to zonegroup {zonegroup} placement")
+    out = utils.exec_shell_cmd(
+        f"radosgw-admin zonegroup placement add "
+        f"--rgw-zonegroup {zonegroup} "
+        f"--placement-id default-placement "
+        f"--storage-class {sc_name}"
+    )
+    if out is False:
+        raise AssertionError(
+            f"Failed to add storage class {sc_name} to zonegroup placement"
+        )
+
+    log.info(
+        f"Adding storage class {sc_name} to zone {zone} placement "
+        f"with data-pool {pool_name}"
+    )
+    out = utils.exec_shell_cmd(
+        f"radosgw-admin zone placement add "
+        f"--rgw-zone {zone} "
+        f"--placement-id default-placement "
+        f"--storage-class {sc_name} "
+        f"--data-pool {pool_name} "
+        f"--compression none"
+    )
+    if out is False:
+        raise AssertionError(f"Failed to add storage class {sc_name} to zone placement")
+
+    _commit_period()
+    _restart_rgw(ssh_con)
+    _record_step(f"Setup storage class {sc_name} with pool {pool_name}")
+    log.info(f"Storage class {sc_name} setup complete (pool={pool_name})")
+
+
+def teardown_storage_class(sc_name, pool_name, ssh_con=None):
+    zone = get_zone_name()
+    zonegroup = get_zonegroup_name()
+
+    log.info(f"Removing storage class {sc_name} from zone {zone} placement")
+    utils.exec_shell_cmd(
+        f"radosgw-admin zone placement rm "
+        f"--rgw-zone {zone} "
+        f"--placement-id default-placement "
+        f"--storage-class {sc_name}"
+    )
+
+    log.info(f"Removing storage class {sc_name} from zonegroup {zonegroup} placement")
+    utils.exec_shell_cmd(
+        f"radosgw-admin zonegroup placement rm "
+        f"--rgw-zonegroup {zonegroup} "
+        f"--placement-id default-placement "
+        f"--storage-class {sc_name}"
+    )
+
+    log.info(f"Removing pool {pool_name}")
+    utils.exec_shell_cmd("ceph config set mon mon_allow_pool_delete true")
+    utils.exec_shell_cmd(
+        f"ceph osd pool rm {pool_name} {pool_name} " f"--yes-i-really-really-mean-it"
+    )
+    utils.exec_shell_cmd("ceph config set mon mon_allow_pool_delete false")
+
+    _commit_period()
+    _restart_rgw(ssh_con)
+    _record_step(f"Teardown storage class {sc_name}, remove pool {pool_name}")
+    log.info(f"Storage class {sc_name} teardown complete")
+
+
+def set_storage_class_compression(sc_name, compression_type, ssh_con=None):
+    zone = get_zone_name()
+    cmd = (
+        f"radosgw-admin zone placement modify --rgw-zone={zone} "
+        f"--placement-id=default-placement --storage-class={sc_name} "
+        f"--compression={compression_type}"
+    )
+    log.info(f"Setting {sc_name} compression to {compression_type}")
+    _record_step(f"Set {sc_name} compression to {compression_type}", cmd)
+    out = utils.exec_shell_cmd(cmd)
+    if out is False:
+        raise AssertionError(
+            f"Failed to set compression {compression_type} on SC {sc_name}"
+        )
+    _commit_period()
+    _restart_rgw(ssh_con)
+
+
+def get_zone_compression_setting(sc_name="STANDARD"):
+    out = utils.exec_shell_cmd("radosgw-admin zone get")
+    if out is False:
+        raise AssertionError("Failed to get zone info")
+    zone_info = json.loads(out)
+    for placement in zone_info.get("placement_pools", []):
+        if placement.get("key") == "default-placement":
+            sc_dict = placement.get("val", {}).get("storage_classes", {})
+            if sc_name in sc_dict:
+                return sc_dict[sc_name].get("compression_type", "")
+    return ""
+
+
+def is_object_compressed(bucket_name, object_key):
+    cmd = (
+        f"radosgw-admin object stat " f"--bucket={bucket_name} --object='{object_key}'"
+    )
+    out = utils.exec_shell_cmd(cmd)
+    if out is False:
+        raise AssertionError(f"object stat failed for {bucket_name}/{object_key}")
+    obj_info = json.loads(out)
+    comp_type = obj_info.get("compression", {}).get("compression_type", "")
+    return bool(comp_type)
+
+
+def assert_all_objects_compression(bucket_name, keys, expect_compressed, tag=""):
+    compressed_count = sum(1 for k in keys if is_object_compressed(bucket_name, k))
+    uncompressed_count = len(keys) - compressed_count
+    log.info(
+        f"{tag} {bucket_name}: compressed={compressed_count}, "
+        f"uncompressed={uncompressed_count}"
+    )
+    if expect_compressed:
+        assert compressed_count == len(keys) and uncompressed_count == 0, (
+            f"{tag} {bucket_name} should be all compressed: "
+            f"compressed={compressed_count}, uncompressed={uncompressed_count}"
+        )
+    else:
+        assert uncompressed_count == len(keys) and compressed_count == 0, (
+            f"{tag} {bucket_name} should be all uncompressed: "
+            f"compressed={compressed_count}, uncompressed={uncompressed_count}"
+        )
+
+
+def upload_identical_objects_with_sc(
+    s3_client, bucket_name, count, size_bytes, storage_class, prefix="sc-obj"
+):
+    data = generate_identical_data(size_bytes)
+    md5_hash = hashlib.md5(data).hexdigest()
+    log.info(
+        f"Uploading {count} identical objects ({size_bytes}B, SC={storage_class}) "
+        f"to bucket {bucket_name}"
+    )
+    _record_step(
+        f"Upload {count} identical {size_bytes}B objects (SC={storage_class}) "
+        f"to {bucket_name}"
+    )
+    keys = []
+    for i in range(count):
+        key = f"{prefix}-{i}"
+        s3_client.put_object(
+            Bucket=bucket_name, Key=key, Body=data, StorageClass=storage_class
+        )
+        keys.append(key)
+    return keys, md5_hash, data
+
+
+def run_dedup_cmd_with_rc(cmd):
+    log.info(f"Running dedup cmd (with rc): {cmd}")
+    _record_step("Run dedup cmd (with rc)", cmd)
+    result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    return result.stdout + result.stderr, result.returncode
+
+
+def get_rgw_service_name():
+    out = utils.exec_shell_cmd("ceph orch ls --service-type rgw --format json")
+    if out is False:
+        raise AssertionError("Failed to get RGW service list")
+    services = json.loads(out)
+    if not services:
+        raise AssertionError("No RGW service found")
+    svc_name = services[0].get("service_name", "")
+    log.info(f"RGW service name: {svc_name}")
+    return svc_name
+
+
+def set_dedup_config(key, value):
+    svc_name = get_rgw_service_name()
+    config_section = f"client.{svc_name}"
+    cmd = f"ceph config set {config_section} {key} {value}"
+    log.info(f"Setting dedup config: {cmd}")
+    _record_step(f"Set dedup config {key}={value}", cmd)
+    out = utils.exec_shell_cmd(cmd)
+    if out is False:
+        raise AssertionError(f"Failed to set config {key}={value}")
+    log.info("Restarting RGW after config change")
+    utils.exec_shell_cmd(f"ceph orch restart {svc_name}")
+    time.sleep(15)
+
+
+def reset_dedup_config(key):
+    svc_name = get_rgw_service_name()
+    config_section = f"client.{svc_name}"
+    cmd = f"ceph config rm {config_section} {key}"
+    log.info(f"Removing dedup config override: {cmd}")
+    _record_step(f"Reset dedup config {key}", cmd)
+    utils.exec_shell_cmd(cmd)
+    log.info("Restarting RGW after config removal")
+    utils.exec_shell_cmd(f"ceph orch restart {svc_name}")
+    time.sleep(15)
+
+
+def get_object_content_length(s3_client, bucket_name, key):
+    resp = s3_client.head_object(Bucket=bucket_name, Key=key)
+    return resp["ContentLength"]
+
+
+def get_rados_objects(pool="default.rgw.buckets.data", prefix=None):
+    cmd = f"rados -p {pool} ls"
+    out = utils.exec_shell_cmd(cmd)
+    if out is False:
+        raise AssertionError(f"Failed to list RADOS objects in pool {pool}")
+    objects = [line.strip() for line in out.strip().split("\n") if line.strip()]
+    if prefix:
+        objects = [o for o in objects if prefix in o]
+    log.info(f"Found {len(objects)} RADOS objects in {pool} (prefix={prefix})")
+    return objects
+
+
+def get_rados_object_stat(pool, oid):
+    cmd = f"rados -p {pool} stat {oid}"
+    out = utils.exec_shell_cmd(cmd)
+    if out is False:
+        raise AssertionError(f"Failed to stat RADOS object {oid}")
+    return out
+
+
+def parse_dedup_stats(stats):
+    if not isinstance(stats, dict):
+        return {}
+    md5_main = stats.get("md5_stats", {}).get("main", {})
+    md5_skipped = stats.get("md5_stats", {}).get("skipped", {})
+    return {
+        "deduped_count": md5_main.get("Deduped Obj (this cycle)", 0),
+        "deduped_bytes": md5_main.get("Deduped Bytes(this cycle)", 0),
+        "unique_count": md5_main.get("Unique Obj", 0),
+        "duplicate_count": md5_main.get("Duplicate Obj", 0),
+        "already_deduped_bytes": md5_main.get("Already Deduped bytes (prev cycles)", 0),
+        "skipped_shared_manifest": md5_skipped.get("Skipped shared_manifest", 0),
+        "completed": stats.get("completed", False),
+    }
+
+
+def parse_dedup_stats_full(stats):
+    if not isinstance(stats, dict):
+        return {}
+    worker_main = stats.get("worker_stats", {}).get("main", {})
+    worker_skipped = stats.get("worker_stats", {}).get("skipped", {})
+    md5_main = stats.get("md5_stats", {}).get("main", {})
+    md5_skipped = stats.get("md5_stats", {}).get("skipped", {})
+    md5_notify = stats.get("md5_stats", {}).get("notify", {})
+    return {
+        "ingress_count": worker_main.get("Ingress Objs count", 0),
+        "total_processed": md5_main.get("Total processed objects", 0),
+        "deduped_count": md5_main.get("Deduped Obj (this cycle)", 0),
+        "deduped_bytes": md5_main.get("Deduped Bytes(this cycle)", 0),
+        "unique_count": md5_main.get("Unique Obj", 0),
+        "duplicate_count": md5_main.get("Duplicate Obj", 0),
+        "already_deduped_bytes": md5_main.get("Already Deduped bytes (prev cycles)", 0),
+        "skipped_shared_manifest": md5_skipped.get("Skipped shared_manifest", 0),
+        "skipped_too_many_copies": md5_skipped.get("Skipped Too Many Copies", 0),
+        "skipped_source_record": md5_skipped.get("Skipped source record", 0),
+        "skipped_compressed": worker_main.get("Skipped Compressed objs", 0),
+        "split_head_src": md5_notify.get("Split-Head Src OBJ", 0),
+        "split_head_tgt": md5_notify.get("Split-Head Tgt OBJ", 0),
+        "valid_hash_attrs": md5_notify.get("Valid HASH attrs", 0),
+        "compressed_objs": md5_notify.get("Compressed objs", 0),
+        "compressed_bytes": md5_notify.get("Compressed Bytes", 0),
+        "deduped_compressed_objects": md5_notify.get("Deduped Compressed objs", 0),
+        "set_compression_on_tgt": md5_notify.get("Set Compression on TGT", 0),
+        "clear_compression_on_tgt": md5_notify.get("Clear Compression on TGT", 0),
+        "ingress_skip_filtered_sc": worker_skipped.get(
+            "Ingress skipped filtered storage class, num objects skipped", 0
+        ),
+        "ingress_skip_filtered_bucket": worker_skipped.get(
+            "Ingress skip: filtered bucket", 0
+        ),
+        "dedup_ratio_estimate": stats.get("dedup_ratio_estimate", {}).get(
+            "dedup_ratio", 0
+        ),
+        "dedup_ratio_actual": stats.get("dedup_ratio_actual", {}).get("dedup_ratio", 0),
+        "completed": stats.get("completed", False),
+    }
+
+
+_savings_registry = {}
+
+
+def _format_bytes(size_bytes):
+    for unit in ["B", "KB", "MB", "GB"]:
+        if abs(size_bytes) < 1024.0:
+            return f"{size_bytes:.1f} {unit}"
+        size_bytes /= 1024.0
+    return f"{size_bytes:.1f} TB"
+
+
+def log_dedup_savings(exec_stats, total_uploaded_bytes, test_id):
+    parsed = parse_dedup_stats_full(exec_stats)
+    deduped_bytes = parsed["deduped_bytes"]
+    deduped_count = parsed["deduped_count"]
+    dedup_ratio = parsed.get("dedup_ratio_actual", 0)
+    skipped_compressed = parsed.get("skipped_compressed", 0)
+
+    if total_uploaded_bytes > 0 and deduped_bytes > 0:
+        savings_pct = (deduped_bytes / total_uploaded_bytes) * 100
+        effective_bytes = total_uploaded_bytes - deduped_bytes
+    else:
+        savings_pct = 0.0
+        effective_bytes = total_uploaded_bytes
+
+    savings = {
+        "test_id": test_id,
+        "total_uploaded": total_uploaded_bytes,
+        "deduped_count": deduped_count,
+        "deduped_bytes": deduped_bytes,
+        "savings_pct": savings_pct,
+        "effective_bytes": effective_bytes,
+        "dedup_ratio": dedup_ratio,
+        "skipped_compressed": skipped_compressed,
+    }
+    _savings_registry[test_id] = savings
+
+    _record_step(
+        f"Log dedup savings for {test_id}",
+        "",
+        f"savings={savings_pct:.1f}%, deduped={deduped_count} objs / {_format_bytes(deduped_bytes)}",
+    )
+    log.info(f"--- DEDUP STORAGE SAVINGS [{test_id}] ---")
+    log.info(f"  Total uploaded   : {_format_bytes(total_uploaded_bytes)}")
+    log.info(f"  Deduped objects   : {deduped_count}")
+    log.info(f"  Deduped bytes     : {_format_bytes(deduped_bytes)}")
+    log.info(f"  Storage savings   : {savings_pct:.1f}%")
+    log.info(f"  Effective storage : {_format_bytes(effective_bytes)}")
+    if dedup_ratio > 0:
+        log.info(f"  Dedup ratio       : {dedup_ratio:.2f}x")
+    if skipped_compressed > 0:
+        log.info(f"  Skipped compressed: {skipped_compressed}")
+    log.info(f"--- END SAVINGS [{test_id}] ---")
+
+    return savings
+
+
+def validate_estimate_exec_ratio(estimate_stats, exec_stats, tolerance=0.1):
+    est = parse_dedup_stats_full(estimate_stats)
+    exe = parse_dedup_stats_full(exec_stats)
+    est_ratio = est.get("dedup_ratio_estimate", 0)
+    act_ratio = exe.get("dedup_ratio_actual", 0)
+    log.info(f"Ratio validation: estimate={est_ratio:.4f}, actual={act_ratio:.4f}")
+    if est_ratio > 0 and act_ratio > 0:
+        diff = abs(est_ratio - act_ratio) / max(est_ratio, act_ratio)
+        log.info(f"Ratio difference: {diff:.4f} (tolerance={tolerance})")
+        if diff > tolerance:
+            log.warning(
+                f"Estimate/exec ratio mismatch: estimate={est_ratio:.4f}, "
+                f"actual={act_ratio:.4f}, diff={diff:.4f}"
+            )
+    return est_ratio, act_ratio
+
+
+def upload_identical_versions(s3_client, bucket_name, key, count, size_bytes):
+    enable_bucket_versioning(s3_client, bucket_name)
+    data = generate_identical_data(size_bytes)
+    md5_hash = hashlib.md5(data).hexdigest()
+    log.info(
+        f"Uploading {count} identical versions of '{key}' ({size_bytes} bytes, "
+        f"MD5: {md5_hash}) to versioned bucket {bucket_name}"
+    )
+    version_ids = []
+    for i in range(count):
+        resp = s3_client.put_object(Bucket=bucket_name, Key=key, Body=data)
+        version_ids.append(resp["VersionId"])
+        if (i + 1) % 50 == 0:
+            log.info(f"Uploaded {i + 1}/{count} versions")
+    log.info(f"Uploaded all {count} versions")
+    return version_ids, md5_hash, data
+
+
+# ---------------------------------------------------------------------------
+# Infrastructure disruption helpers (for negative/edge-case tests)
+# ---------------------------------------------------------------------------
+
+
+def restart_rgw_service(service_name=None):
+    """Restart all RGW daemons via ceph orch."""
+    if service_name is None:
+        service_name = get_rgw_service_name()
+    cmd = f"ceph orch restart {service_name}"
+    log.info(f"Restarting RGW service: {cmd}")
+    _record_step("Restart RGW service", cmd)
+    out = utils.exec_shell_cmd(cmd)
+    if out is False:
+        log.warning("RGW restart command returned false (may still succeed)")
+    time.sleep(15)
+
+
+def kill_rgw_process(node=None):
+    """Send SIGKILL to radosgw process. If node is given, uses SSH."""
+    kill_cmd = "pkill -9 radosgw"
+    if node:
+        cmd = f"ssh {node} '{kill_cmd}'"
+    else:
+        cmd = kill_cmd
+    log.info(f"Killing RGW process: {cmd}")
+    _record_step("Kill RGW process (SIGKILL)", cmd)
+    utils.exec_shell_cmd(cmd)
+    time.sleep(5)
+
+
+def restart_osd(osd_id):
+    """Restart a specific OSD daemon via ceph orch."""
+    cmd = f"ceph orch daemon restart osd.{osd_id}"
+    log.info(f"Restarting OSD: {cmd}")
+    _record_step(f"Restart OSD {osd_id}", cmd)
+    out = utils.exec_shell_cmd(cmd)
+    if out is False:
+        log.warning(f"OSD {osd_id} restart command returned false")
+    time.sleep(10)
+
+
+def get_mon_leader():
+    """Get the current MON leader name."""
+    cmd = "ceph mon stat"
+    out = utils.exec_shell_cmd(cmd)
+    if out is False:
+        raise AssertionError("Failed to get mon stat")
+    # Output contains "leader: <name>" or we parse the quorum
+    if "leader" in out:
+        for part in out.split(","):
+            if "leader" in part:
+                # format: "..., leader: mon.hostname ..."
+                leader = part.strip().split()[-1]
+                log.info(f"MON leader: {leader}")
+                return leader
+    # Fallback: parse JSON if available
+    try:
+        cmd2 = "ceph mon dump --format json"
+        out2 = utils.exec_shell_cmd(cmd2)
+        data = json.loads(out2)
+        quorum = data.get("quorum", [])
+        mons = data.get("mons", [])
+        if quorum and mons:
+            leader_rank = quorum[0]
+            for m in mons:
+                if m.get("rank") == leader_rank:
+                    log.info(f"MON leader (from dump): {m['name']}")
+                    return m["name"]
+    except Exception:
+        pass
+    raise AssertionError("Could not determine MON leader")
+
+
+def restart_mon(mon_name):
+    """Restart a specific MON daemon via ceph orch."""
+    cmd = f"ceph orch daemon restart mon.{mon_name}"
+    log.info(f"Restarting MON: {cmd}")
+    _record_step(f"Restart MON {mon_name}", cmd)
+    out = utils.exec_shell_cmd(cmd)
+    if out is False:
+        log.warning(f"MON {mon_name} restart command returned false")
+    time.sleep(15)
+
+
+def get_osd_for_bucket(bucket_name, pool="default.rgw.buckets.data"):
+    """Find an OSD that hosts PGs for the given bucket's pool."""
+    marker = get_bucket_marker(bucket_name)
+    if not marker:
+        raise AssertionError(f"Cannot get marker for bucket {bucket_name}")
+    cmd = f"ceph osd map {pool} {marker}"
+    out = utils.exec_shell_cmd(cmd)
+    if out is False:
+        raise AssertionError(f"Failed to map OSD for {pool}/{marker}")
+    # Output: "osdmap ... pool '...' (N) object '...' -> pg M.xxx ... -> up ([A,B,C], pA) ..."
+    for part in out.split():
+        if part.startswith("osd."):
+            osd_id = part.replace("osd.", "").rstrip(",).:")
+            if osd_id.isdigit():
+                log.info(f"Bucket {bucket_name} mapped to OSD {osd_id}")
+                return int(osd_id)
+    # Fallback: parse the "up" list
+    import re
+
+    match = re.search(r"up\s*\(\[(\d+)", out)
+    if match:
+        osd_id = int(match.group(1))
+        log.info(f"Bucket {bucket_name} mapped to OSD {osd_id} (from up list)")
+        return osd_id
+    raise AssertionError(f"Could not find OSD for bucket {bucket_name}: {out}")
+
+
+def wait_for_health_ok(timeout=120):
+    """Poll ceph health until HEALTH_OK or timeout."""
+    log.info(f"Waiting for cluster health OK (timeout={timeout}s)")
+    start = time.time()
+    while time.time() - start < timeout:
+        out = utils.exec_shell_cmd("ceph health")
+        if out and "HEALTH_OK" in out:
+            log.info("Cluster health is OK")
+            return True
+        time.sleep(5)
+    log.warning(f"Cluster did not reach HEALTH_OK within {timeout}s")
+    return False
+
+
+def wait_for_rgw_ready(endpoint_url=None, timeout=60):
+    """Poll RGW endpoint until it responds with 200."""
+    if endpoint_url is None:
+        endpoint_url = "http://localhost:80"
+    log.info(f"Waiting for RGW ready at {endpoint_url} (timeout={timeout}s)")
+    import requests
+
+    start = time.time()
+    while time.time() - start < timeout:
+        try:
+            resp = requests.get(endpoint_url, timeout=5)
+            if resp.status_code in (200, 403):
+                log.info(f"RGW is ready (status={resp.status_code})")
+                return True
+        except Exception:
+            pass
+        time.sleep(3)
+    log.warning(f"RGW not ready within {timeout}s")
+    return False
+
+
+def check_orphan_objects(pool="default.rgw.buckets.data", pattern="_sh_"):
+    """Check for orphaned split-head tail objects in a RADOS pool."""
+    objects = get_rados_objects(pool)
+    orphans = [o for o in objects if pattern in o]
+    log.info(f"Found {len(orphans)} potential orphan objects matching '{pattern}'")
+    return orphans
+
+
+def upload_unique_objects(
+    s3_client, bucket_name, count, size_bytes, prefix="unique-obj"
+):
+    """Upload objects each with unique random content (no duplicates)."""
+    log.info(
+        f"Uploading {count} unique objects of size {size_bytes} bytes "
+        f"to bucket {bucket_name}"
+    )
+    _record_step(
+        f"Upload {count} unique {size_bytes}B objects to {bucket_name}",
+        f"s3_client.put_object x{count} (unique content each)",
+    )
+    keys = []
+    md5s = {}
+    for i in range(count):
+        data = os.urandom(size_bytes)
+        key = f"{prefix}-{i}"
+        s3_client.put_object(Bucket=bucket_name, Key=key, Body=data)
+        md5s[key] = hashlib.md5(data).hexdigest()
+        keys.append(key)
+    log.info(f"Uploaded {count} unique objects")
+    return keys, md5s
+
+
+def run_dedup_estimate_async():
+    """Fire dedup estimate without waiting for completion. Returns immediately."""
+    cmd = "radosgw-admin dedup estimate"
+    log.info(f"Running dedup estimate (async/fire-and-forget): {cmd}")
+    _record_step("Run dedup estimate (async)", cmd)
+    import subprocess
+
+    subprocess.Popen(
+        cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+    )
+    time.sleep(1)
+
+
+def run_dedup_execute_async():
+    """Fire dedup exec without waiting for completion. Returns immediately."""
+    cmd = "radosgw-admin dedup exec --yes-i-really-mean-it"
+    log.info(f"Running dedup exec (async/fire-and-forget): {cmd}")
+    _record_step("Run dedup exec (async)", cmd)
+    import subprocess
+
+    subprocess.Popen(
+        cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+    )
+    time.sleep(1)
+
+
+def trigger_bucket_reshard(bucket_name, num_shards):
+    """Trigger manual bucket resharding."""
+    cmd = (
+        f"radosgw-admin bucket reshard --bucket={bucket_name} "
+        f"--num-shards={num_shards} --yes-i-really-mean-it"
+    )
+    log.info(f"Triggering bucket reshard: {cmd}")
+    _record_step(f"Reshard bucket {bucket_name} to {num_shards} shards", cmd)
+    out = utils.exec_shell_cmd(cmd)
+    if out is False:
+        log.warning(f"Bucket reshard command returned false for {bucket_name}")
+    return out
+
+
+def set_pool_quota(pool, max_bytes):
+    """Set a byte quota on a RADOS pool to simulate near-full conditions."""
+    cmd = f"ceph osd pool set-quota {pool} max_bytes {max_bytes}"
+    log.info(f"Setting pool quota: {cmd}")
+    _record_step(f"Set pool {pool} quota to {max_bytes} bytes", cmd)
+    out = utils.exec_shell_cmd(cmd)
+    if out is False:
+        raise AssertionError(f"Failed to set quota on pool {pool}")
+    return out
+
+
+def remove_pool_quota(pool):
+    """Remove byte quota from a RADOS pool."""
+    cmd = f"ceph osd pool set-quota {pool} max_bytes 0"
+    log.info(f"Removing pool quota: {cmd}")
+    _record_step(f"Remove pool {pool} quota", cmd)
+    out = utils.exec_shell_cmd(cmd)
+    if out is False:
+        log.warning(f"Failed to remove quota on pool {pool}")
+    return out
+
+
+def verify_rgw_daemons_running():
+    """Verify all RGW daemons are running via ceph orch ps."""
+    cmd = "ceph orch ps --daemon-type rgw --format json"
+    out = utils.exec_shell_cmd(cmd)
+    if out is False:
+        raise AssertionError("Failed to get RGW daemon status")
+    daemons = json.loads(out)
+    running = [d for d in daemons if "running" in d.get("status_desc", "")]
+    log.info(f"RGW daemons running: {len(running)}/{len(daemons)}")
+    return len(running), len(daemons)
+
+
+def corrupt_rados_object(pool, oid, data=b"CORRUPTED"):
+    """Overwrite a RADOS object with garbage data."""
+    import tempfile
+
+    fd, tmpfile = tempfile.mkstemp()
+    try:
+        os.write(fd, data)
+        os.close(fd)
+        cmd = f"rados -p {pool} put {oid} {tmpfile}"
+        log.info(f"Corrupting RADOS object: {cmd}")
+        _record_step(f"Corrupt RADOS object {oid} in {pool}", cmd)
+        out = utils.exec_shell_cmd(cmd)
+        if out is False:
+            raise AssertionError(f"Failed to corrupt object {oid}")
+    finally:
+        os.unlink(tmpfile)

--- a/rgw/v2/tests/s3_swift/run_dedup_pytest.py
+++ b/rgw/v2/tests/s3_swift/run_dedup_pytest.py
@@ -1,0 +1,67 @@
+"""
+run_dedup_pytest.py - Thin wrapper to run pytest-based dedup tests via cephci.
+
+cephci's sanity_rgw.py invokes: python run_dedup_pytest.py -c <config.yaml> --rgw-node <ip>
+This wrapper translates that into a pytest.main() call against test_dedup_pytest.py.
+
+Suite YAML entry:
+  - test:
+      name: RGW Dedup Full Suite (pytest)
+      desc: Run all 30 dedup tests via pytest framework
+      module: sanity_rgw.py
+      config:
+        script-name: run_dedup_pytest.py
+        config-file-name: test_dedup_all.yaml
+        timeout: 7200
+"""
+
+import argparse
+import os
+import sys
+
+import pytest
+
+
+def main():
+    parser = argparse.ArgumentParser(description="RGW Dedup Pytest Runner for cephci")
+    parser.add_argument("-c", dest="config", required=True, help="RGW test YAML config")
+    parser.add_argument(
+        "--rgw-node", dest="rgw_node", default="", help="RGW node hostname"
+    )
+    parser.add_argument("-log_level", dest="log_level", default="info")
+    args = parser.parse_args()
+
+    test_dir = os.path.dirname(os.path.abspath(__file__))
+    test_file = os.path.join(test_dir, "test_dedup_pytest.py")
+
+    config_path = os.path.abspath(args.config)
+
+    pytest_args = [
+        test_file,
+        f"-C={config_path}",
+        "-v",
+        "--tb=short",
+        f"--log-cli-level={args.log_level.upper()}",
+    ]
+
+    if args.rgw_node:
+        pytest_args.append(f"--rgw-node={args.rgw_node}")
+
+    marker = os.environ.get("DEDUP_PYTEST_MARKER", "")
+    if marker:
+        pytest_args.extend(["-m", marker])
+
+    keyword = os.environ.get("DEDUP_PYTEST_KEYWORD", "")
+    if keyword:
+        pytest_args.extend(["-k", keyword])
+
+    junit_path = os.environ.get("DEDUP_PYTEST_JUNIT", "")
+    if junit_path:
+        pytest_args.append(f"--junitxml={junit_path}")
+
+    exit_code = pytest.main(pytest_args)
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/rgw/v2/tests/s3_swift/test_dedup.py
+++ b/rgw/v2/tests/s3_swift/test_dedup.py
@@ -1,0 +1,4415 @@
+"""
+test_dedup.py - RGW Dedup (Deduplication) Test Automation
+
+Usage: test_dedup.py -c <input_yaml>
+
+Covers test scenarios from ISCE-4789:
+  S1:  Sanity - Basic dedup for large objects > 4MB
+  S2:  Sanity - Basic dedup for small objects < 4MB (split-head)
+  S3:  Sanity - Dedup via Admin OPS REST API
+  S4:  Sanity - Dedup estimate (non-destructive dry-run)
+  S5:  Sanity - Data integrity verification after dedup
+  S6:  Feature - Dedup multipart objects of any size
+  S7:  Feature - Session lifecycle controls (pause/resume/abort)
+  S8:  Feature - SSE-C encrypted objects excluded from dedup
+  S9:  Feature - Dedup with different storage classes and allow/deny filters
+  S10: Feature - LC expiration with deduplicated objects
+  S11: Regression - Dedup with versioned objects
+  S12: Regression - Dedup with S3 copy object > 5MB
+  S14: Regression - Same content different metadata
+  S15: Regression - Concurrent S3 operations during dedup
+
+Compressed object dedup (PR #68965):
+  S16: Compression - Compressed object dedup sanity (zlib)
+  S17: Compression - Cross-mode dedup (compressed + uncompressed)
+  S18: Compression - Algorithm switch (zlib -> snappy) + dedup
+  S19: Compression - Compressed multipart objects + range GETs
+  S20: Compression - rgw_dedup_skip_compressed config toggle
+  S21: Compression - Compression attr mirroring integrity
+
+Bug-hunting tests (data integrity after dedup):
+  B1: Overwrite deduped object - shared tail integrity (GC vs refcount)
+  B2: Delete dedup source - refcount protection
+  B3: S3 copy deduped object then delete original (shared_manifest copy)
+  B4: Cross-bucket dedup - source bucket deletion
+  B5: Dedup idempotency - multiple exec runs
+"""
+
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(__file__, "../../../..")))
+import argparse
+import hashlib
+import json
+import logging
+import random
+import string
+import time
+import traceback
+import warnings
+
+warnings.filterwarnings("ignore", category=UserWarning, module="urllib3")
+warnings.filterwarnings("ignore", message=".*HeaderParsingError.*")
+logging.getLogger("urllib3").setLevel(logging.CRITICAL)
+logging.getLogger("urllib3.connectionpool").setLevel(logging.CRITICAL)
+
+import v2.lib.resource_op as s3lib
+import v2.utils.utils as utils
+from v2.lib.exceptions import RGWBaseException, TestExecError
+from v2.lib.resource_op import Config
+from v2.lib.s3.write_io_info import BasicIOInfoStructure, IOInfoInitialize
+from v2.tests.s3_swift import reusable
+from v2.tests.s3_swift.reusables import dedup as dedup_utils
+from v2.utils.log import configure_logging
+from v2.utils.test_desc import AddTestInfo
+
+log = logging.getLogger()
+TEST_DATA_PATH = None
+
+
+def test_exec_sanity_large_objects(config, ssh_con):
+    """
+    S1: Upload 50 identical objects > 4MB, run dedup estimate then execute,
+    verify objects deduplicated and remain accessible.
+    """
+    test_info = AddTestInfo("S1: Basic dedup for large objects > 4MB")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-large-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+        log.info(f"Created bucket: {bucket_name}")
+
+        obj_count = getattr(config, "objects_count", 50)
+        obj_size = 5 * 1024 * 1024  # 5MB
+
+        keys, expected_md5, original_data = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, obj_count, obj_size, prefix="large-obj"
+        )
+
+        log.info("Running dedup estimate")
+        dedup_utils.run_dedup_estimate()
+        estimate_stats = dedup_utils.wait_for_dedup_completion()
+        log.info(
+            f"Estimate stats: {json.dumps(estimate_stats, indent=2) if isinstance(estimate_stats, dict) else estimate_stats}"
+        )
+
+        log.info("Running dedup execute")
+        dedup_utils.run_dedup_execute()
+        exec_stats = dedup_utils.wait_for_dedup_completion()
+        log.info(
+            f"Exec stats: {json.dumps(exec_stats, indent=2) if isinstance(exec_stats, dict) else exec_stats}"
+        )
+
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_name, keys)
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_name, keys, expected_md5
+        )
+
+        if isinstance(exec_stats, dict):
+            deduped = exec_stats.get(
+                "deduped_objects", exec_stats.get("deduped_obj", 0)
+            )
+            log.info(f"Objects deduplicated: {deduped}")
+            assert deduped > 0, "Expected dedup to deduplicate objects but count is 0"
+
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_sanity_small_objects(config, ssh_con):
+    """
+    S2: Upload 100 identical objects < 4MB (100KB, 1MB, 3MB sizes),
+    run dedup, verify split-head mechanism works for small objects.
+    """
+    test_info = AddTestInfo("S2: Basic dedup for small objects < 4MB (split-head)")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-small-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        sizes = [100 * 1024, 1 * 1024 * 1024, 3 * 1024 * 1024]  # 100KB, 1MB, 3MB
+        all_keys = []
+        md5_map = {}
+
+        for size in sizes:
+            size_label = f"{size // 1024}KB"
+            keys, md5_hash, _ = dedup_utils.upload_identical_objects(
+                s3_client, bucket_name, 30, size, prefix=f"small-{size_label}"
+            )
+            all_keys.extend(keys)
+            for k in keys:
+                md5_map[k] = md5_hash
+
+        log.info("Running dedup estimate")
+        dedup_utils.run_dedup_estimate()
+        dedup_utils.wait_for_dedup_completion()
+
+        log.info("Running dedup execute")
+        dedup_utils.run_dedup_execute()
+        dedup_utils.wait_for_dedup_completion()
+
+        for key in all_keys:
+            dedup_utils.verify_object_integrity(
+                s3_client, bucket_name, key, md5_map[key]
+            )
+
+        log.info(f"All {len(all_keys)} small objects verified after dedup")
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_admin_ops_api(config, ssh_con):
+    """
+    S3: Trigger dedup via Admin OPS REST API, query status and stats via API.
+    Requires PR #68863.
+    """
+    test_info = AddTestInfo("S3: Dedup via Admin OPS REST API")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+        endpoint_url = auth.endpoint_url
+
+        admin_user = utils.exec_shell_cmd(
+            "radosgw-admin user create --uid=dedup-admin --display-name='Dedup Admin' "
+            "--caps='dedup=*'"
+        )
+        if admin_user is False:
+            admin_user = utils.exec_shell_cmd(
+                "radosgw-admin user info --uid=dedup-admin"
+            )
+        admin_info = json.loads(admin_user)
+        admin_access_key = admin_info["keys"][0]["access_key"]
+        admin_secret_key = admin_info["keys"][0]["secret_key"]
+
+        bucket_name = f"dedup-api-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, 20, 5 * 1024 * 1024, prefix="api-obj"
+        )
+
+        log.info("Triggering dedup estimate via Admin OPS API")
+        resp = dedup_utils.dedup_api_request(
+            endpoint_url,
+            "estimate",
+            method="POST",
+            access_key=admin_access_key,
+            secret_key=admin_secret_key,
+        )
+        assert resp.status_code in (
+            200,
+            202,
+        ), f"Estimate API failed: {resp.status_code}"
+
+        time.sleep(5)
+
+        log.info("Querying dedup stats via Admin OPS API")
+        resp = dedup_utils.dedup_api_request(
+            endpoint_url,
+            "stats",
+            method="GET",
+            access_key=admin_access_key,
+            secret_key=admin_secret_key,
+        )
+        assert resp.status_code == 200, f"Stats API failed: {resp.status_code}"
+        log.info(f"Stats API response: {resp.text[:500]}")
+
+        dedup_utils.wait_for_dedup_completion()
+
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_name, keys)
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_estimate_dry_run(config, ssh_con):
+    """
+    S4: Upload mix of duplicate and unique objects, run estimate only,
+    verify no data changes and estimate accuracy.
+    """
+    test_info = AddTestInfo("S4: Dedup estimate non-destructive dry-run")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-estimate-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        dup_keys, dup_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, 30, 5 * 1024 * 1024, prefix="dup-obj"
+        )
+
+        unique_keys = []
+        for i in range(10):
+            key = f"unique-obj-{i}"
+            unique_data = os.urandom(5 * 1024 * 1024)
+            s3_client.put_object(Bucket=bucket_name, Key=key, Body=unique_data)
+            unique_keys.append(key)
+
+        pre_etags = {}
+        for key in dup_keys + unique_keys:
+            resp = s3_client.head_object(Bucket=bucket_name, Key=key)
+            pre_etags[key] = resp["ETag"]
+
+        log.info("Running dedup estimate (dry-run)")
+        dedup_utils.run_dedup_estimate()
+        estimate_stats = dedup_utils.wait_for_dedup_completion()
+
+        post_etags = {}
+        for key in dup_keys + unique_keys:
+            resp = s3_client.head_object(Bucket=bucket_name, Key=key)
+            post_etags[key] = resp["ETag"]
+
+        for key in dup_keys + unique_keys:
+            assert (
+                pre_etags[key] == post_etags[key]
+            ), f"ETag changed for {key} after estimate: {pre_etags[key]} -> {post_etags[key]}"
+
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_name, dup_keys, dup_md5
+        )
+        log.info("Estimate completed without modifying any objects")
+
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_data_integrity(config, ssh_con):
+    """
+    S5: Upload 100 duplicate objects with known MD5 checksums, run dedup,
+    verify all MD5s match and ETags preserved.
+    """
+    test_info = AddTestInfo("S5: Data integrity verification after dedup")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-integrity-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        obj_count = getattr(config, "objects_count", 100)
+        keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, obj_count, 5 * 1024 * 1024, prefix="integrity-obj"
+        )
+
+        pre_etags = {}
+        for key in keys:
+            resp = s3_client.head_object(Bucket=bucket_name, Key=key)
+            pre_etags[key] = resp["ETag"]
+
+        log.info("Running dedup execute")
+        dedup_utils.run_dedup_execute()
+        dedup_utils.wait_for_dedup_completion()
+
+        post_etags = dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_name, keys, expected_md5
+        )
+
+        etag_mismatches = []
+        for key in keys:
+            post_resp = s3_client.head_object(Bucket=bucket_name, Key=key)
+            if pre_etags[key] != post_resp["ETag"]:
+                etag_mismatches.append(key)
+
+        if etag_mismatches:
+            log.warning(
+                f"ETag changes detected for {len(etag_mismatches)} objects (may be expected with split-head)"
+            )
+        else:
+            log.info("All ETags preserved after dedup")
+
+        log.info(f"All {obj_count} objects passed integrity verification")
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_multipart_objects(config, ssh_con):
+    """
+    S6: Upload multipart objects of varying sizes (50MB, 500MB) with identical content,
+    run dedup, verify all parts accessible and range GETs work.
+    """
+    test_info = AddTestInfo("S6: Dedup multipart objects of any size")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-multipart-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        mp_size = 50 * 1024 * 1024  # 50MB
+        mp_count = 5
+
+        (
+            keys,
+            expected_md5,
+            original_data,
+        ) = dedup_utils.upload_identical_multipart_objects(
+            s3_client, bucket_name, mp_count, mp_size, prefix="mp-obj"
+        )
+
+        log.info("Running dedup execute on multipart objects")
+        dedup_utils.run_dedup_execute()
+        dedup_utils.wait_for_dedup_completion()
+
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_name, keys)
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_name, keys, expected_md5
+        )
+
+        for key in keys:
+            dedup_utils.verify_range_get(
+                s3_client, bucket_name, key, original_data, 0, 1024 * 1024
+            )
+            mid = mp_size // 2
+            dedup_utils.verify_range_get(
+                s3_client, bucket_name, key, original_data, mid, mid + 1024 * 1024
+            )
+
+        log.info("All multipart objects verified after dedup including range GETs")
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_session_lifecycle(config, ssh_con):
+    """
+    S7: Test dedup session lifecycle - start, pause, resume, complete,
+    then start new session and abort mid-run.
+    """
+    test_info = AddTestInfo("S7: Session lifecycle controls (pause/resume/abort)")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-lifecycle-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, 100, 5 * 1024 * 1024, prefix="lifecycle-obj"
+        )
+
+        log.info("Phase 1: Start dedup, pause, resume, complete")
+        dedup_utils.run_dedup_execute()
+        time.sleep(3)
+
+        dedup_utils.run_dedup_pause()
+        time.sleep(2)
+
+        pause_stats = dedup_utils.get_dedup_stats()
+        log.info(
+            f"Stats after pause: {json.dumps(pause_stats, indent=2) if isinstance(pause_stats, dict) else pause_stats}"
+        )
+
+        dedup_utils.run_dedup_resume()
+        exec_stats = dedup_utils.wait_for_dedup_completion()
+
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_name, keys)
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_name, keys, expected_md5
+        )
+        log.info("Phase 1 passed: pause/resume completed without data loss")
+
+        log.info("Phase 2: Start new session and abort")
+        keys2, _, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, 50, 5 * 1024 * 1024, prefix="lifecycle2-obj"
+        )
+
+        dedup_utils.run_dedup_execute()
+        time.sleep(3)
+
+        dedup_utils.run_dedup_abort()
+        time.sleep(2)
+
+        abort_stats = dedup_utils.get_dedup_stats()
+        log.info(
+            f"Stats after abort: {json.dumps(abort_stats, indent=2) if isinstance(abort_stats, dict) else abort_stats}"
+        )
+
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_name, keys + keys2)
+        log.info("Phase 2 passed: abort leaves cluster consistent")
+
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_ssec_exclusion(config, ssh_con):
+    """
+    S8: Upload SSE-C encrypted duplicate objects and unencrypted duplicates,
+    run dedup, verify SSE-C objects skipped and unencrypted objects deduplicated.
+    """
+    test_info = AddTestInfo("S8: SSE-C encrypted objects excluded from dedup")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        utils.exec_shell_cmd("ceph config set client.rgw rgw_crypt_require_ssl false")
+        time.sleep(5)
+
+        bucket_name = f"dedup-ssec-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        ssec_keys, sse_key_b64, sse_key_md5 = dedup_utils.upload_ssec_objects(
+            s3_client, bucket_name, 20, 5 * 1024 * 1024, prefix="ssec-obj"
+        )
+
+        plain_keys, plain_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, 20, 5 * 1024 * 1024, prefix="plain-obj"
+        )
+
+        log.info("Running dedup execute")
+        dedup_utils.run_dedup_execute()
+        exec_stats = dedup_utils.wait_for_dedup_completion()
+
+        if isinstance(exec_stats, dict):
+            encrypted_skipped = exec_stats.get(
+                "ingress_skip_encrypted",
+                exec_stats.get("skip_encrypted", 0),
+            )
+            log.info(f"Encrypted objects skipped: {encrypted_skipped}")
+            assert encrypted_skipped > 0, "Expected SSE-C objects to be skipped"
+
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_name, plain_keys, plain_md5
+        )
+
+        for key in ssec_keys:
+            resp = s3_client.get_object(
+                Bucket=bucket_name,
+                Key=key,
+                SSECustomerAlgorithm="AES256",
+                SSECustomerKey=sse_key_b64,
+                SSECustomerKeyMD5=sse_key_md5,
+            )
+            assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+        log.info("All SSE-C objects still accessible with correct key")
+
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_storage_class_filter(config, ssh_con):
+    """
+    S9: Test dedup with different storage classes and allow/deny bucket/storage-class filters.
+    Covers PR #68575.
+    """
+    test_info = AddTestInfo("S9: Dedup storage class filter and allow/deny lists")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_allow = f"dedup-allow-{random.randint(1, 5000)}"
+        bucket_deny = f"dedup-deny-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_allow)
+        s3_client.create_bucket(Bucket=bucket_deny)
+
+        keys_allow, md5_allow, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_allow, 20, 5 * 1024 * 1024, prefix="allow-obj"
+        )
+        keys_deny, md5_deny, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_deny, 20, 5 * 1024 * 1024, prefix="deny-obj"
+        )
+
+        allow_file = dedup_utils.create_filter_list_file([bucket_allow])
+
+        log.info(f"Running dedup with allow-bucket-list: {bucket_allow}")
+        dedup_utils.run_dedup_execute(allow_bucket_file=allow_file)
+        exec_stats = dedup_utils.wait_for_dedup_completion()
+
+        if isinstance(exec_stats, dict):
+            filtered = exec_stats.get("ingress_skip_filtered", 0)
+            log.info(f"Filtered (skipped) objects: {filtered}")
+
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_allow, keys_allow, md5_allow
+        )
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_deny, keys_deny, md5_deny
+        )
+
+        log.info("Allow/deny bucket filter test passed")
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        dedup_utils.cleanup_bucket(s3_client, bucket_allow)
+        dedup_utils.cleanup_bucket(s3_client, bucket_deny)
+        try:
+            os.remove(allow_file)
+        except Exception:
+            pass
+
+
+def test_exec_lc_expiration(config, ssh_con):
+    """
+    S10: Upload duplicate objects, dedup, set LC expiration, wait for expiration,
+    verify ref counts decrement and storage reclaimed.
+    """
+    test_info = AddTestInfo("S10: LC expiration with deduplicated objects")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        utils.exec_shell_cmd("ceph config set client.rgw rgw_lc_debug_interval 30")
+        time.sleep(3)
+
+        bucket_name = f"dedup-lc-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, 20, 5 * 1024 * 1024, prefix="lc-obj"
+        )
+
+        log.info("Running dedup execute")
+        dedup_utils.run_dedup_execute()
+        dedup_utils.wait_for_dedup_completion()
+
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_name, keys)
+
+        pre_dedup_stats = dedup_utils.get_dedup_stats()
+
+        log.info("Setting LC expiration policy (1 day)")
+        dedup_utils.set_lifecycle_expiration(s3_client, bucket_name, days=1)
+
+        lc_debug_interval = getattr(config, "rgw_lc_debug_interval", 30)
+        log.info(f"Waiting for LC processing (debug_interval={lc_debug_interval}s)")
+        time.sleep(lc_debug_interval * 3)
+
+        resp = s3_client.list_objects_v2(Bucket=bucket_name)
+        remaining = resp.get("KeyCount", 0)
+        log.info(f"Objects remaining after LC expiration: {remaining}")
+
+        post_dedup_stats = dedup_utils.get_dedup_stats()
+        log.info(
+            f"Post-LC dedup stats: {json.dumps(post_dedup_stats, indent=2) if isinstance(post_dedup_stats, dict) else post_dedup_stats}"
+        )
+
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_versioned_objects(config, ssh_con):
+    """
+    S11: Enable bucket versioning, upload same content as multiple versions,
+    run dedup, verify all versions accessible. Covers PR #66233.
+    """
+    test_info = AddTestInfo("S11: Dedup with versioned objects")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-versioned-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+        dedup_utils.enable_bucket_versioning(s3_client, bucket_name)
+
+        identical_data = dedup_utils.generate_identical_data(5 * 1024 * 1024)
+        expected_md5 = hashlib.md5(identical_data).hexdigest()
+
+        version_count = getattr(config, "version_count", 10)
+        object_key = "versioned-dedup-object"
+        version_ids = []
+
+        for i in range(version_count):
+            resp = s3_client.put_object(
+                Bucket=bucket_name, Key=object_key, Body=identical_data
+            )
+            version_ids.append(resp["VersionId"])
+            log.info(f"Uploaded version {i + 1}: {resp['VersionId']}")
+
+        log.info(f"Running dedup on {version_count} versions of same content")
+        dedup_utils.run_dedup_execute()
+        dedup_utils.wait_for_dedup_completion()
+
+        for vid in version_ids:
+            resp = s3_client.get_object(
+                Bucket=bucket_name, Key=object_key, VersionId=vid
+            )
+            body = resp["Body"].read()
+            actual_md5 = hashlib.md5(body).hexdigest()
+            assert (
+                actual_md5 == expected_md5
+            ), f"Version {vid} MD5 mismatch: expected {expected_md5}, got {actual_md5}"
+            log.info(f"Version {vid} verified OK")
+
+        versions = dedup_utils.get_all_versions(s3_client, bucket_name, object_key)
+        assert (
+            len(versions) == version_count
+        ), f"Expected {version_count} versions, found {len(versions)}"
+        log.info(f"All {version_count} versions preserved and accessible after dedup")
+
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_s3_copy_dedup(config, ssh_con):
+    """
+    S12: Upload object > 5MB, use S3 COPY to duplicate 20 times,
+    run dedup, verify all copies accessible.
+    """
+    test_info = AddTestInfo("S12: Dedup with S3 copy object > 5MB")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-copy-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        source_key = "source-large-obj"
+        source_data = dedup_utils.generate_identical_data(10 * 1024 * 1024)  # 10MB
+        expected_md5 = hashlib.md5(source_data).hexdigest()
+        s3_client.put_object(Bucket=bucket_name, Key=source_key, Body=source_data)
+        log.info(f"Uploaded source object: {source_key}")
+
+        copy_count = 20
+        copy_keys = []
+        for i in range(copy_count):
+            copy_key = f"copy-obj-{i}"
+            s3_client.copy_object(
+                Bucket=bucket_name,
+                Key=copy_key,
+                CopySource={"Bucket": bucket_name, "Key": source_key},
+            )
+            copy_keys.append(copy_key)
+            log.info(f"Copied to {copy_key}")
+
+        all_keys = [source_key] + copy_keys
+
+        log.info("Running dedup execute")
+        dedup_utils.run_dedup_execute()
+        dedup_utils.wait_for_dedup_completion()
+
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_name, all_keys, expected_md5
+        )
+
+        for key in all_keys:
+            resp = s3_client.head_object(Bucket=bucket_name, Key=key)
+            log.info(f"{key}: size={resp['ContentLength']}, ETag={resp['ETag']}")
+
+        log.info(
+            f"All {len(all_keys)} objects (source + {copy_count} copies) verified after dedup"
+        )
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_same_content_diff_metadata(config, ssh_con):
+    """
+    S14: Upload identical content with different names, buckets, users, ACLs, tags.
+    Run dedup. Verify content deduplicated but metadata independently preserved.
+    """
+    test_info = AddTestInfo("S14: Same content different metadata")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    try:
+        test_info.started_info()
+        all_users = s3lib.create_users(2)
+        user1 = all_users[0]
+        user2 = all_users[1]
+
+        auth1 = reusable.get_auth(
+            user1, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        auth2 = reusable.get_auth(
+            user2, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client1 = auth1.do_auth_using_client()
+        s3_client2 = auth2.do_auth_using_client()
+
+        bucket1 = f"dedup-meta1-{random.randint(1, 5000)}"
+        bucket2 = f"dedup-meta2-{random.randint(1, 5000)}"
+        s3_client1.create_bucket(Bucket=bucket1)
+        s3_client2.create_bucket(Bucket=bucket2)
+
+        identical_data = dedup_utils.generate_identical_data(5 * 1024 * 1024)
+        expected_md5 = hashlib.md5(identical_data).hexdigest()
+
+        s3_client1.put_object(
+            Bucket=bucket1,
+            Key="obj-user1-a",
+            Body=identical_data,
+            Metadata={"custom-key": "value-a"},
+            Tagging="env=prod",
+        )
+        s3_client1.put_object(
+            Bucket=bucket1,
+            Key="obj-user1-b",
+            Body=identical_data,
+            Metadata={"custom-key": "value-b"},
+            Tagging="env=staging",
+        )
+        s3_client2.put_object(
+            Bucket=bucket2,
+            Key="obj-user2-a",
+            Body=identical_data,
+            Metadata={"custom-key": "value-c"},
+        )
+        s3_client2.put_object(
+            Bucket=bucket2,
+            Key="obj-user2-b",
+            Body=identical_data,
+            Metadata={"custom-key": "value-d"},
+        )
+
+        log.info("Running dedup execute")
+        dedup_utils.run_dedup_execute()
+        dedup_utils.wait_for_dedup_completion()
+
+        for client, bucket, key, expected_meta_val in [
+            (s3_client1, bucket1, "obj-user1-a", "value-a"),
+            (s3_client1, bucket1, "obj-user1-b", "value-b"),
+            (s3_client2, bucket2, "obj-user2-a", "value-c"),
+            (s3_client2, bucket2, "obj-user2-b", "value-d"),
+        ]:
+            dedup_utils.verify_object_integrity(client, bucket, key, expected_md5)
+            resp = client.head_object(Bucket=bucket, Key=key)
+            actual_meta = resp.get("Metadata", {}).get("custom-key", "")
+            assert actual_meta == expected_meta_val, (
+                f"Metadata mismatch for {bucket}/{key}: "
+                f"expected '{expected_meta_val}', got '{actual_meta}'"
+            )
+            log.info(f"Metadata preserved for {bucket}/{key}: custom-key={actual_meta}")
+
+        tag_resp = s3_client1.get_object_tagging(Bucket=bucket1, Key="obj-user1-a")
+        tags = {t["Key"]: t["Value"] for t in tag_resp.get("TagSet", [])}
+        assert tags.get("env") == "prod", f"Tag mismatch for obj-user1-a: {tags}"
+
+        tag_resp = s3_client1.get_object_tagging(Bucket=bucket1, Key="obj-user1-b")
+        tags = {t["Key"]: t["Value"] for t in tag_resp.get("TagSet", [])}
+        assert tags.get("env") == "staging", f"Tag mismatch for obj-user1-b: {tags}"
+
+        log.info("All metadata, tags, and ACLs preserved after dedup")
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        dedup_utils.cleanup_bucket(s3_client1, bucket1)
+        dedup_utils.cleanup_bucket(s3_client2, bucket2)
+
+
+def test_exec_concurrent_s3_ops(config, ssh_con):
+    """
+    S15: Start dedup on large dataset while running concurrent S3 workload
+    (PUT/GET/DELETE). Verify both dedup and S3 operations succeed.
+    """
+    test_info = AddTestInfo("S15: Concurrent S3 operations during dedup")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        dedup_bucket = f"dedup-concurrent-{random.randint(1, 5000)}"
+        workload_bucket = f"workload-concurrent-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=dedup_bucket)
+        s3_client.create_bucket(Bucket=workload_bucket)
+
+        keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, dedup_bucket, 50, 5 * 1024 * 1024, prefix="concurrent-obj"
+        )
+
+        log.info("Starting dedup execute and concurrent S3 workload simultaneously")
+        dedup_utils.run_dedup_execute()
+
+        workload_results = dedup_utils.run_concurrent_s3_workload(
+            s3_client, workload_bucket, duration_secs=60, prefix="workload"
+        )
+
+        dedup_utils.wait_for_dedup_completion()
+
+        dedup_utils.verify_all_objects_accessible(s3_client, dedup_bucket, keys)
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, dedup_bucket, keys, expected_md5
+        )
+
+        assert workload_results["puts"] > 0, "Expected concurrent PUTs to succeed"
+        assert workload_results["gets"] > 0, "Expected concurrent GETs to succeed"
+        error_rate = workload_results["errors"] / max(
+            workload_results["puts"]
+            + workload_results["gets"]
+            + workload_results["deletes"],
+            1,
+        )
+        log.info(f"Concurrent workload error rate: {error_rate:.2%}")
+        assert error_rate < 0.05, f"Error rate too high: {error_rate:.2%}"
+
+        log.info("Dedup and concurrent S3 operations both succeeded")
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        dedup_utils.cleanup_bucket(s3_client, dedup_bucket)
+        dedup_utils.cleanup_bucket(s3_client, workload_bucket)
+
+
+# === Compressed object dedup tests (PR #68965) ===
+
+
+def test_exec_compressed_sanity(config, ssh_con):
+    """
+    S16: Enable zone compression (zlib), upload 50 identical 5MB objects,
+    run dedup estimate + execute, verify objects deduplicated and accessible.
+    Exercises streaming decompression hashing (BLAKE3 over uncompressed data).
+    """
+    test_info = AddTestInfo("S16: Compressed object dedup sanity")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    bucket_name = f"dedup-compressed-{random.randint(1, 5000)}"
+    compression_enabled = False
+
+    try:
+        test_info.started_info()
+
+        dedup_utils.enable_zone_compression("zlib", ssh_con)
+        compression_enabled = True
+
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        s3_client.create_bucket(Bucket=bucket_name)
+        log.info(f"Created bucket: {bucket_name}")
+
+        obj_count = getattr(config, "objects_count", 50)
+        obj_size = 5 * 1024 * 1024
+
+        keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, obj_count, obj_size, prefix="compressed-obj"
+        )
+
+        on_disk_size = dedup_utils.get_object_content_length(
+            s3_client, bucket_name, keys[0]
+        )
+        if on_disk_size < obj_size:
+            log.info(
+                f"Compression active: logical={obj_size}, on-disk={on_disk_size}, "
+                f"ratio={on_disk_size / obj_size:.2%}"
+            )
+        else:
+            log.warning("Objects may not be compressed — on-disk size >= logical size")
+
+        log.info("Running dedup estimate")
+        dedup_utils.run_dedup_estimate()
+        estimate_stats = dedup_utils.wait_for_dedup_completion()
+        log.info(
+            f"Estimate stats: {json.dumps(estimate_stats, indent=2) if isinstance(estimate_stats, dict) else estimate_stats}"
+        )
+
+        log.info("Running dedup execute")
+        dedup_utils.run_dedup_execute()
+        exec_stats = dedup_utils.wait_for_dedup_completion()
+        log.info(
+            f"Exec stats: {json.dumps(exec_stats, indent=2) if isinstance(exec_stats, dict) else exec_stats}"
+        )
+
+        if isinstance(exec_stats, dict):
+            deduped = exec_stats.get(
+                "deduped_objects", exec_stats.get("deduped_obj", 0)
+            )
+            log.info(f"Objects deduplicated: {deduped}")
+            assert (
+                deduped > 0
+            ), "Expected compressed objects to be deduplicated but count is 0"
+
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_name, keys)
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_name, keys, expected_md5
+        )
+
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        if compression_enabled:
+            dedup_utils.disable_zone_compression(ssh_con)
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_compressed_cross_mode(config, ssh_con):
+    """
+    S17: Upload identical objects both with and without compression,
+    run dedup, verify all match (cross-mode: compressed + uncompressed).
+    Tests that dedup keys use logical size and BLAKE3 hashes uncompressed data.
+    """
+    test_info = AddTestInfo("S17: Cross-compression dedup (compressed + uncompressed)")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    bucket_name = f"dedup-crossmode-{random.randint(1, 5000)}"
+    compression_enabled = False
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        log.info("Phase 1: Upload 20 objects WITHOUT compression")
+        dedup_utils.disable_zone_compression(ssh_con)
+        plain_keys, expected_md5, original_data = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, 20, 5 * 1024 * 1024, prefix="plain-obj"
+        )
+
+        plain_size = dedup_utils.get_object_content_length(
+            s3_client, bucket_name, plain_keys[0]
+        )
+        log.info(f"Plain object on-disk size: {plain_size}")
+
+        log.info("Phase 2: Enable zlib compression, upload 20 more identical objects")
+        dedup_utils.enable_zone_compression("zlib", ssh_con)
+        compression_enabled = True
+
+        compressed_keys, comp_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, 20, 5 * 1024 * 1024, prefix="compressed-obj"
+        )
+
+        assert (
+            expected_md5 == comp_md5
+        ), f"MD5 mismatch between plain and compressed batches: {expected_md5} vs {comp_md5}"
+
+        compressed_size = dedup_utils.get_object_content_length(
+            s3_client, bucket_name, compressed_keys[0]
+        )
+        log.info(f"Compressed object on-disk size: {compressed_size}")
+
+        if compressed_size < plain_size:
+            log.info("Confirmed: compressed objects are smaller on disk")
+
+        all_keys = plain_keys + compressed_keys
+        log.info(f"Total objects: {len(all_keys)} (20 plain + 20 compressed)")
+
+        log.info("Running dedup execute")
+        dedup_utils.run_dedup_execute()
+        exec_stats = dedup_utils.wait_for_dedup_completion()
+        log.info(
+            f"Exec stats: {json.dumps(exec_stats, indent=2) if isinstance(exec_stats, dict) else exec_stats}"
+        )
+
+        if isinstance(exec_stats, dict):
+            deduped = exec_stats.get(
+                "deduped_objects", exec_stats.get("deduped_obj", 0)
+            )
+            log.info(f"Objects deduplicated: {deduped}")
+            assert (
+                deduped > 0
+            ), "Expected cross-mode dedup to match compressed and uncompressed objects"
+
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_name, all_keys)
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_name, all_keys, expected_md5
+        )
+
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        if compression_enabled:
+            dedup_utils.disable_zone_compression(ssh_con)
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_compressed_algo_switch(config, ssh_con):
+    """
+    S18: Upload identical objects under zlib, switch to snappy, upload more,
+    run dedup. All should match (same logical content, different compression).
+    Tests SRC selection priority (COMPRESSION_MATCH_EXACT vs PARTIAL).
+    """
+    test_info = AddTestInfo("S18: Compression algorithm switch + dedup")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    bucket_name = f"dedup-algoswitch-{random.randint(1, 5000)}"
+    compression_enabled = False
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        log.info("Phase 1: Upload 15 objects with zlib compression")
+        dedup_utils.enable_zone_compression("zlib", ssh_con)
+        compression_enabled = True
+        zlib_keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, 15, 5 * 1024 * 1024, prefix="zlib-obj"
+        )
+
+        zlib_size = dedup_utils.get_object_content_length(
+            s3_client, bucket_name, zlib_keys[0]
+        )
+        log.info(f"zlib on-disk size: {zlib_size}")
+
+        log.info("Phase 2: Switch to snappy, upload 15 more identical objects")
+        dedup_utils.enable_zone_compression("snappy", ssh_con)
+        snappy_keys, snappy_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, 15, 5 * 1024 * 1024, prefix="snappy-obj"
+        )
+
+        assert (
+            expected_md5 == snappy_md5
+        ), f"MD5 mismatch between zlib and snappy batches: {expected_md5} vs {snappy_md5}"
+
+        snappy_size = dedup_utils.get_object_content_length(
+            s3_client, bucket_name, snappy_keys[0]
+        )
+        log.info(f"snappy on-disk size: {snappy_size}")
+
+        all_keys = zlib_keys + snappy_keys
+
+        log.info("Running dedup execute (current zone algo: snappy)")
+        dedup_utils.run_dedup_execute()
+        exec_stats = dedup_utils.wait_for_dedup_completion()
+        log.info(
+            f"Exec stats: {json.dumps(exec_stats, indent=2) if isinstance(exec_stats, dict) else exec_stats}"
+        )
+
+        if isinstance(exec_stats, dict):
+            deduped = exec_stats.get(
+                "deduped_objects", exec_stats.get("deduped_obj", 0)
+            )
+            log.info(f"Objects deduplicated: {deduped}")
+            assert (
+                deduped > 0
+            ), "Expected dedup to match objects across compression algorithms"
+
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_name, all_keys)
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_name, all_keys, expected_md5
+        )
+
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        if compression_enabled:
+            dedup_utils.disable_zone_compression(ssh_con)
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_compressed_multipart(config, ssh_con):
+    """
+    S19: Enable compression, upload 5 identical 50MB multipart objects,
+    run dedup, verify accessible including range GETs.
+    Tests out-of-line large attrs path (RGW_RECORD_FLAG_REMOTE_ATTRS).
+    """
+    test_info = AddTestInfo("S19: Compressed multipart object dedup")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    bucket_name = f"dedup-compmp-{random.randint(1, 5000)}"
+    compression_enabled = False
+
+    try:
+        test_info.started_info()
+
+        dedup_utils.enable_zone_compression("zlib", ssh_con)
+        compression_enabled = True
+
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        mp_size = 50 * 1024 * 1024
+        mp_count = 5
+
+        (
+            keys,
+            expected_md5,
+            original_data,
+        ) = dedup_utils.upload_identical_multipart_objects(
+            s3_client, bucket_name, mp_count, mp_size, prefix="compmp-obj"
+        )
+
+        log.info("Running dedup execute on compressed multipart objects")
+        dedup_utils.run_dedup_execute()
+        exec_stats = dedup_utils.wait_for_dedup_completion()
+        log.info(
+            f"Exec stats: {json.dumps(exec_stats, indent=2) if isinstance(exec_stats, dict) else exec_stats}"
+        )
+
+        if isinstance(exec_stats, dict):
+            deduped = exec_stats.get(
+                "deduped_objects", exec_stats.get("deduped_obj", 0)
+            )
+            log.info(f"Multipart objects deduplicated: {deduped}")
+            assert (
+                deduped > 0
+            ), "Expected compressed multipart objects to be deduplicated"
+
+            remote_attrs = exec_stats.get("remote_attrs_records", 0)
+            log.info(f"Remote attrs records (out-of-line): {remote_attrs}")
+
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_name, keys)
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_name, keys, expected_md5
+        )
+
+        for key in keys:
+            dedup_utils.verify_range_get(
+                s3_client, bucket_name, key, original_data, 0, 1024 * 1024
+            )
+            mid = mp_size // 2
+            dedup_utils.verify_range_get(
+                s3_client, bucket_name, key, original_data, mid, mid + 1024 * 1024
+            )
+            end_offset = mp_size - (512 * 1024)
+            dedup_utils.verify_range_get(
+                s3_client, bucket_name, key, original_data, end_offset, mp_size - 1
+            )
+
+        log.info("All compressed multipart objects verified including range GETs")
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        if compression_enabled:
+            dedup_utils.disable_zone_compression(ssh_con)
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_compressed_skip_toggle(config, ssh_con):
+    """
+    S20: Enable compression, upload objects, toggle rgw_dedup_skip_compressed.
+    When true: dedup should skip all compressed objects (0 deduplicated).
+    When false: dedup should process them normally.
+    """
+    test_info = AddTestInfo("S20: rgw_dedup_skip_compressed config toggle")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    bucket_name = f"dedup-skiptoggle-{random.randint(1, 5000)}"
+    compression_enabled = False
+    config_set = False
+
+    try:
+        test_info.started_info()
+
+        dedup_utils.enable_zone_compression("zlib", ssh_con)
+        compression_enabled = True
+
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        obj_count = 30
+        keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, obj_count, 5 * 1024 * 1024, prefix="skiptoggle-obj"
+        )
+
+        log.info("Phase 1: Set rgw_dedup_skip_compressed=true, run dedup")
+        dedup_utils.set_dedup_config("rgw_dedup_skip_compressed", "true")
+        config_set = True
+
+        dedup_utils.run_dedup_execute()
+        skip_stats = dedup_utils.wait_for_dedup_completion()
+        log.info(
+            f"Skip-mode stats: {json.dumps(skip_stats, indent=2) if isinstance(skip_stats, dict) else skip_stats}"
+        )
+
+        if isinstance(skip_stats, dict):
+            deduped_skip = skip_stats.get(
+                "deduped_objects", skip_stats.get("deduped_obj", 0)
+            )
+            log.info(f"Objects deduplicated with skip=true: {deduped_skip}")
+            assert (
+                deduped_skip == 0
+            ), f"Expected 0 objects deduplicated with skip_compressed=true, got {deduped_skip}"
+
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_name, keys)
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_name, keys, expected_md5
+        )
+        log.info("Phase 1 passed: compressed objects correctly skipped")
+
+        log.info("Phase 2: Set rgw_dedup_skip_compressed=false, run dedup again")
+        dedup_utils.set_dedup_config("rgw_dedup_skip_compressed", "false")
+
+        dedup_utils.run_dedup_execute()
+        exec_stats = dedup_utils.wait_for_dedup_completion()
+        log.info(
+            f"Process-mode stats: {json.dumps(exec_stats, indent=2) if isinstance(exec_stats, dict) else exec_stats}"
+        )
+
+        if isinstance(exec_stats, dict):
+            deduped_exec = exec_stats.get(
+                "deduped_objects", exec_stats.get("deduped_obj", 0)
+            )
+            log.info(f"Objects deduplicated with skip=false: {deduped_exec}")
+            assert (
+                deduped_exec > 0
+            ), "Expected objects to be deduplicated with skip_compressed=false"
+
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_name, keys)
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_name, keys, expected_md5
+        )
+        log.info("Phase 2 passed: compressed objects now deduplicated")
+
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        if config_set:
+            dedup_utils.reset_dedup_config("rgw_dedup_skip_compressed")
+        if compression_enabled:
+            dedup_utils.disable_zone_compression(ssh_con)
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_compressed_attr_mirror(config, ssh_con):
+    """
+    S21: Verify compression attribute mirroring after dedup.
+    Upload compressed objects, dedup, then add uncompressed copies of same data,
+    dedup again, verify all objects remain accessible and data-correct.
+    Tests RGW_ATTR_COMPRESSION setxattr/rmxattr mirroring.
+    """
+    test_info = AddTestInfo("S21: Compression attr mirroring integrity")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    bucket_name = f"dedup-attrmirror-{random.randint(1, 5000)}"
+    compression_enabled = False
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        log.info("Phase 1: Upload 30 compressed objects and dedup")
+        dedup_utils.enable_zone_compression("zlib", ssh_con)
+        compression_enabled = True
+
+        comp_keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, 30, 5 * 1024 * 1024, prefix="comp-obj"
+        )
+
+        dedup_utils.run_dedup_execute()
+        phase1_stats = dedup_utils.wait_for_dedup_completion()
+        log.info(
+            f"Phase 1 dedup stats: {json.dumps(phase1_stats, indent=2) if isinstance(phase1_stats, dict) else phase1_stats}"
+        )
+
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_name, comp_keys)
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_name, comp_keys, expected_md5
+        )
+
+        pre_sizes = {}
+        for key in comp_keys:
+            pre_sizes[key] = dedup_utils.get_object_content_length(
+                s3_client, bucket_name, key
+            )
+        log.info("Phase 1 passed: compressed objects deduplicated")
+
+        log.info(
+            "Phase 2: Disable compression, upload 10 uncompressed copies, dedup again"
+        )
+        dedup_utils.disable_zone_compression(ssh_con)
+        compression_enabled = False
+
+        plain_keys, plain_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, 10, 5 * 1024 * 1024, prefix="plain-obj"
+        )
+        assert (
+            expected_md5 == plain_md5
+        ), "MD5 mismatch between compressed and plain data"
+
+        dedup_utils.run_dedup_execute()
+        phase2_stats = dedup_utils.wait_for_dedup_completion()
+        log.info(
+            f"Phase 2 dedup stats: {json.dumps(phase2_stats, indent=2) if isinstance(phase2_stats, dict) else phase2_stats}"
+        )
+
+        all_keys = comp_keys + plain_keys
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_name, all_keys)
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_name, all_keys, expected_md5
+        )
+
+        post_sizes = {}
+        for key in all_keys:
+            post_sizes[key] = dedup_utils.get_object_content_length(
+                s3_client, bucket_name, key
+            )
+
+        size_changes = 0
+        for key in comp_keys:
+            if pre_sizes[key] != post_sizes[key]:
+                size_changes += 1
+                log.info(
+                    f"Content-Length changed for {key}: "
+                    f"{pre_sizes[key]} -> {post_sizes[key]}"
+                )
+
+        log.info(
+            f"Content-Length changes in compressed batch: {size_changes}/{len(comp_keys)} "
+            f"(changes may indicate attr mirroring shifted compression state)"
+        )
+
+        log.info("All objects data-correct after cross-compression dedup cycles")
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        if compression_enabled:
+            dedup_utils.disable_zone_compression(ssh_con)
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+# === Bug-hunting tests ===
+
+
+def test_exec_overwrite_deduped_object(config, ssh_con):
+    """
+    B1: Upload identical objects, dedup, overwrite one target with different content.
+    Verify the source and remaining targets still return original content.
+    Bug target: GC deletes shared tails when overwritten object's old manifest
+    is cleaned up via complete_atomic_modification() (rgw_rados.cc:6282).
+    """
+    test_info = AddTestInfo("B1: Overwrite deduped object - shared tail integrity")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-overwrite-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+        log.info(f"Created bucket: {bucket_name}")
+
+        obj_count = getattr(config, "objects_count", 10)
+        obj_size = 5 * 1024 * 1024
+
+        keys, expected_md5, original_data = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, obj_count, obj_size, prefix="ow-obj"
+        )
+
+        log.info("Running dedup execute")
+        dedup_utils.run_dedup_execute()
+        dedup_utils.wait_for_dedup_completion()
+
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_name, keys, expected_md5
+        )
+        log.info("All objects verified after dedup")
+
+        overwrite_key = keys[1]
+        new_size = 3 * 1024 * 1024
+        new_data = os.urandom(new_size)
+        new_md5 = hashlib.md5(new_data).hexdigest()
+        log.info(
+            f"Overwriting deduped target {overwrite_key} with {new_size} bytes of new content"
+        )
+        s3_client.put_object(Bucket=bucket_name, Key=overwrite_key, Body=new_data)
+
+        resp = s3_client.get_object(Bucket=bucket_name, Key=overwrite_key)
+        body = resp["Body"].read()
+        actual_md5 = hashlib.md5(body).hexdigest()
+        assert (
+            actual_md5 == new_md5
+        ), f"Overwritten object MD5 mismatch: expected {new_md5}, got {actual_md5}"
+        assert (
+            len(body) == new_size
+        ), f"Overwritten object size mismatch: expected {new_size}, got {len(body)}"
+        log.info(f"Overwritten object {overwrite_key} returns new content correctly")
+
+        remaining_keys = [k for k in keys if k != overwrite_key]
+        log.info(
+            f"Verifying {len(remaining_keys)} remaining deduped objects still readable"
+        )
+        for key in remaining_keys:
+            resp = s3_client.get_object(Bucket=bucket_name, Key=key)
+            body = resp["Body"].read()
+            actual_md5 = hashlib.md5(body).hexdigest()
+            assert actual_md5 == expected_md5, (
+                f"Object {key} corrupted after overwrite of sibling: "
+                f"expected {expected_md5}, got {actual_md5}"
+            )
+        log.info("All remaining deduped objects intact after overwrite")
+
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_delete_dedup_source(config, ssh_con):
+    """
+    B2: Upload identical objects, dedup, then delete objects one by one.
+    After each deletion, verify remaining objects are still readable.
+    Bug target: S3 delete uses GC path which doesn't call cls_refcount_put(),
+    potentially destroying shared tail objects.
+    """
+    test_info = AddTestInfo("B2: Delete dedup source - refcount protection")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-delsrc-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        obj_count = getattr(config, "objects_count", 10)
+        obj_size = 5 * 1024 * 1024
+
+        keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, obj_count, obj_size, prefix="delsrc-obj"
+        )
+
+        log.info("Running dedup execute")
+        dedup_utils.run_dedup_execute()
+        dedup_utils.wait_for_dedup_completion()
+
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_name, keys, expected_md5
+        )
+
+        remaining = list(keys)
+        for i, key_to_delete in enumerate(keys):
+            log.info(f"Deleting object {i + 1}/{len(keys)}: {key_to_delete}")
+            s3_client.delete_object(Bucket=bucket_name, Key=key_to_delete)
+            remaining.remove(key_to_delete)
+
+            if not remaining:
+                log.info("All objects deleted, nothing left to verify")
+                break
+
+            log.info(f"Verifying {len(remaining)} remaining objects after deletion")
+            for key in remaining:
+                resp = s3_client.get_object(Bucket=bucket_name, Key=key)
+                body = resp["Body"].read()
+                actual_md5 = hashlib.md5(body).hexdigest()
+                assert actual_md5 == expected_md5, (
+                    f"Object {key} corrupted after deleting {key_to_delete}: "
+                    f"expected {expected_md5}, got {actual_md5}"
+                )
+            log.info(
+                f"All {len(remaining)} remaining objects OK after deleting {key_to_delete}"
+            )
+
+        log.info(
+            "Sequential deletion test passed: all objects survived until their own deletion"
+        )
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_s3_copy_then_delete_deduped(config, ssh_con):
+    """
+    B3: Upload identical objects, dedup, S3 COPY a deduped object (same bucket
+    and cross-bucket), then delete the originals. Verify copies survive.
+    Bug target: set_copy_attrs() copies shared_manifest xattr without
+    incrementing refcounts on shared tail objects (rgw_rados.cc:3949).
+    """
+    test_info = AddTestInfo("B3: S3 copy deduped object then delete original")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    bucket_b = None
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_a = f"dedup-copysrc-{random.randint(1, 5000)}"
+        bucket_b = f"dedup-copydst-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_a)
+        s3_client.create_bucket(Bucket=bucket_b)
+
+        obj_size = 5 * 1024 * 1024
+        keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_a, 5, obj_size, prefix="cpsrc-obj"
+        )
+
+        log.info("Running dedup execute")
+        dedup_utils.run_dedup_execute()
+        dedup_utils.wait_for_dedup_completion()
+
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_a, keys, expected_md5
+        )
+
+        same_bucket_copy = "copy-same-bucket"
+        cross_bucket_copy = "copy-cross-bucket"
+
+        log.info(f"S3 COPY {keys[0]} -> {bucket_a}/{same_bucket_copy}")
+        s3_client.copy_object(
+            Bucket=bucket_a,
+            Key=same_bucket_copy,
+            CopySource={"Bucket": bucket_a, "Key": keys[0]},
+        )
+
+        log.info(f"S3 COPY {keys[1]} -> {bucket_b}/{cross_bucket_copy}")
+        s3_client.copy_object(
+            Bucket=bucket_b,
+            Key=cross_bucket_copy,
+            CopySource={"Bucket": bucket_a, "Key": keys[1]},
+        )
+
+        dedup_utils.verify_object_integrity(
+            s3_client, bucket_a, same_bucket_copy, expected_md5
+        )
+        dedup_utils.verify_object_integrity(
+            s3_client, bucket_b, cross_bucket_copy, expected_md5
+        )
+        log.info("Both copies verified before deletion")
+
+        log.info("Deleting all original objects from source bucket")
+        for key in keys:
+            s3_client.delete_object(Bucket=bucket_a, Key=key)
+
+        log.info("Verifying copies survive after original deletion")
+        dedup_utils.verify_object_integrity(
+            s3_client, bucket_a, same_bucket_copy, expected_md5
+        )
+        dedup_utils.verify_object_integrity(
+            s3_client, bucket_b, cross_bucket_copy, expected_md5
+        )
+
+        same_resp = s3_client.head_object(Bucket=bucket_a, Key=same_bucket_copy)
+        assert (
+            same_resp["ContentLength"] == obj_size
+        ), f"Same-bucket copy size mismatch: expected {obj_size}, got {same_resp['ContentLength']}"
+        cross_resp = s3_client.head_object(Bucket=bucket_b, Key=cross_bucket_copy)
+        assert (
+            cross_resp["ContentLength"] == obj_size
+        ), f"Cross-bucket copy size mismatch: expected {obj_size}, got {cross_resp['ContentLength']}"
+
+        log.info("Both copies survived deletion of all originals")
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        dedup_utils.cleanup_bucket(s3_client, bucket_a)
+        if bucket_b:
+            dedup_utils.cleanup_bucket(s3_client, bucket_b)
+
+
+def test_exec_cross_bucket_source_delete(config, ssh_con):
+    """
+    B4: Upload identical object to two buckets, dedup (cross-bucket),
+    delete the bucket containing the source, verify target bucket object survives.
+    Bug target: No cross-bucket reference tracking; bucket deletion may
+    destroy shared tail objects that the other bucket still references.
+    """
+    test_info = AddTestInfo("B4: Cross-bucket dedup - source bucket deletion")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    bucket_a = None
+    bucket_b = None
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_a = f"dedup-xbkt-a-{random.randint(1, 5000)}"
+        bucket_b = f"dedup-xbkt-b-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_a)
+        s3_client.create_bucket(Bucket=bucket_b)
+
+        obj_size = 5 * 1024 * 1024
+        identical_data = dedup_utils.generate_identical_data(obj_size)
+        expected_md5 = hashlib.md5(identical_data).hexdigest()
+
+        key_a = "cross-obj-a"
+        key_b = "cross-obj-b"
+        s3_client.put_object(Bucket=bucket_a, Key=key_a, Body=identical_data)
+        s3_client.put_object(Bucket=bucket_b, Key=key_b, Body=identical_data)
+        log.info(
+            f"Uploaded identical object to {bucket_a}/{key_a} and {bucket_b}/{key_b}"
+        )
+
+        log.info("Running dedup execute (cross-bucket)")
+        dedup_utils.run_dedup_execute()
+        dedup_utils.wait_for_dedup_completion()
+
+        dedup_utils.verify_object_integrity(s3_client, bucket_a, key_a, expected_md5)
+        dedup_utils.verify_object_integrity(s3_client, bucket_b, key_b, expected_md5)
+        log.info("Both objects verified after dedup")
+
+        log.info(f"Deleting source bucket {bucket_a} (object + bucket)")
+        s3_client.delete_object(Bucket=bucket_a, Key=key_a)
+        s3_client.delete_bucket(Bucket=bucket_a)
+        bucket_a = None
+        log.info("Source bucket deleted")
+
+        log.info(f"Verifying target bucket object {bucket_b}/{key_b} survives")
+        dedup_utils.verify_object_integrity(s3_client, bucket_b, key_b, expected_md5)
+
+        resp = s3_client.head_object(Bucket=bucket_b, Key=key_b)
+        assert (
+            resp["ContentLength"] == obj_size
+        ), f"Target object size mismatch: expected {obj_size}, got {resp['ContentLength']}"
+        log.info("Target bucket object survived source bucket deletion")
+
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        if bucket_a:
+            dedup_utils.cleanup_bucket(s3_client, bucket_a)
+        if bucket_b:
+            dedup_utils.cleanup_bucket(s3_client, bucket_b)
+
+
+def test_exec_dedup_idempotency(config, ssh_con):
+    """
+    B5: Upload identical objects, run dedup exec 3 times consecutively.
+    Verify no double-increment of refcounts, stats are consistent,
+    and all objects remain accessible after each run.
+    Bug target: Refcount double-increment or stats corruption on re-run.
+    """
+    test_info = AddTestInfo("B5: Dedup idempotency - multiple exec runs")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-idempotent-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        obj_count = getattr(config, "objects_count", 20)
+        obj_size = 5 * 1024 * 1024
+
+        keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, obj_count, obj_size, prefix="idemp-obj"
+        )
+
+        all_run_stats = []
+        for run_num in range(1, 4):
+            log.info(f"=== Dedup exec run {run_num}/3 ===")
+            dedup_utils.run_dedup_execute()
+            stats = dedup_utils.wait_for_dedup_completion()
+            parsed = dedup_utils.parse_dedup_stats(stats)
+            all_run_stats.append(parsed)
+            log.info(
+                f"Run {run_num}: deduped={parsed.get('deduped_count', '?')}, "
+                f"skipped_shared_manifest={parsed.get('skipped_shared_manifest', '?')}"
+            )
+
+            dedup_utils.verify_all_objects_accessible(s3_client, bucket_name, keys)
+
+        run1 = all_run_stats[0]
+        assert (
+            run1.get("deduped_count", 0) > 0
+        ), "Run 1 should have deduplicated objects"
+
+        for run_num, parsed in enumerate(all_run_stats[1:], start=2):
+            deduped = parsed.get("deduped_count", 0)
+            assert (
+                deduped == 0
+            ), f"Run {run_num} should dedup 0 objects but deduped {deduped}"
+            skipped = parsed.get("skipped_shared_manifest", 0)
+            assert (
+                skipped > 0
+            ), f"Run {run_num} should skip already-deduped objects via shared_manifest"
+            log.info(
+                f"Run {run_num} correctly skipped {skipped} already-deduped objects"
+            )
+
+        log.info("Final integrity verification")
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_name, keys, expected_md5
+        )
+
+        log.info("Idempotency test passed: 3 runs, consistent stats, no corruption")
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+# === Enhancement tests (128-limit, versioned boundary, multi-cycle) ===
+
+
+def test_exec_128_limit_boundary(config, ssh_con):
+    """
+    E1: Upload 200 identical 5KB objects exceeding the 128 MAX_COPIES_PER_OBJ limit.
+    Verify only ~127 targets are deduped, remaining are silently skipped, and
+    all objects remain accessible.
+    """
+    test_info = AddTestInfo("E1: 128-copy limit boundary test (200 identical objects)")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    config_set = False
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-128limit-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+        log.info(f"Created bucket: {bucket_name}")
+
+        dedup_utils.set_dedup_config("rgw_dedup_min_obj_size_for_dedup", "4096")
+        config_set = True
+
+        obj_count = 200
+        obj_size = 5 * 1024  # 5KB
+
+        keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, obj_count, obj_size, prefix="limit-obj"
+        )
+
+        log.info("Running dedup execute on 200 identical objects")
+        dedup_utils.run_dedup_execute()
+        exec_stats = dedup_utils.wait_for_dedup_completion()
+        log.info(
+            f"Exec stats: {json.dumps(exec_stats, indent=2) if isinstance(exec_stats, dict) else exec_stats}"
+        )
+
+        parsed = dedup_utils.parse_dedup_stats_full(exec_stats)
+        deduped = parsed["deduped_count"]
+        skipped_copies = parsed["skipped_too_many_copies"]
+        skipped_source = parsed["skipped_source_record"]
+
+        log.info(f"Deduped: {deduped}, Skipped Too Many Copies: {skipped_copies}")
+
+        assert deduped > 0, "Expected at least some objects to be deduped"
+        assert (
+            deduped <= 127
+        ), f"Expected deduped <= 127 (128 limit minus source), got {deduped}"
+        assert (
+            skipped_copies > 0
+        ), f"Expected Skipped Too Many Copies > 0 with 200 objects, got {skipped_copies}"
+
+        expected_skipped = obj_count - 1 - deduped - parsed["skipped_shared_manifest"]
+        log.info(
+            f"Accounting: {obj_count} total = 1 source + {deduped} deduped + "
+            f"{parsed['skipped_shared_manifest']} shared_manifest + {skipped_copies} skipped"
+        )
+
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_name, keys)
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_name, keys, expected_md5
+        )
+        log.info("All 200 objects accessible and data-correct after dedup")
+
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        if config_set:
+            dedup_utils.reset_dedup_config("rgw_dedup_min_obj_size_for_dedup")
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_versioned_boundary(config, ssh_con):
+    """
+    E2: Create versioned bucket, upload same key 130 times (5KB content).
+    130 versions = just past the 128 limit boundary.
+    Verify all versions accessible after dedup and data integrity preserved.
+    """
+    test_info = AddTestInfo("E2: Versioned bucket dedup boundary (130 versions)")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    config_set = False
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-verbound-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        dedup_utils.set_dedup_config("rgw_dedup_min_obj_size_for_dedup", "4096")
+        config_set = True
+
+        version_count = 130
+        object_key = "versioned-boundary-obj"
+        obj_size = 5 * 1024  # 5KB
+
+        (
+            version_ids,
+            expected_md5,
+            original_data,
+        ) = dedup_utils.upload_identical_versions(
+            s3_client, bucket_name, object_key, version_count, obj_size
+        )
+
+        log.info(f"Running dedup execute on {version_count} versions")
+        dedup_utils.run_dedup_execute()
+        exec_stats = dedup_utils.wait_for_dedup_completion()
+        log.info(
+            f"Exec stats: {json.dumps(exec_stats, indent=2) if isinstance(exec_stats, dict) else exec_stats}"
+        )
+
+        parsed = dedup_utils.parse_dedup_stats_full(exec_stats)
+        log.info(
+            f"Deduped: {parsed['deduped_count']}, Unique: {parsed['unique_count']}, "
+            f"Skipped Too Many: {parsed['skipped_too_many_copies']}"
+        )
+
+        assert (
+            parsed["deduped_count"] > 0
+        ), "Expected dedup to process versioned objects"
+        assert parsed["unique_count"] >= 1, "Expected at least 1 unique content group"
+
+        log.info(f"Verifying all {version_count} versions are accessible")
+        for vid in version_ids:
+            resp = s3_client.get_object(
+                Bucket=bucket_name, Key=object_key, VersionId=vid
+            )
+            body = resp["Body"].read()
+            actual_md5 = hashlib.md5(body).hexdigest()
+            assert (
+                actual_md5 == expected_md5
+            ), f"Version {vid} MD5 mismatch: expected {expected_md5}, got {actual_md5}"
+
+        versions = dedup_utils.get_all_versions(s3_client, bucket_name, object_key)
+        assert (
+            len(versions) == version_count
+        ), f"Expected {version_count} versions, found {len(versions)}"
+        log.info(f"All {version_count} versions preserved and data-correct after dedup")
+
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        if config_set:
+            dedup_utils.reset_dedup_config("rgw_dedup_min_obj_size_for_dedup")
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_multi_cycle_no_progress(config, ssh_con):
+    """
+    E3: Upload 200 identical 5KB objects (exceeds 128 limit), run dedup exec
+    3 consecutive times. Verify cycles 2 and 3 produce zero new deduped objects,
+    proving that multiple cycles cannot work around the 128 limit.
+    """
+    test_info = AddTestInfo("E3: Multi-cycle no progress (128-limit stuck)")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    config_set = False
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-multicycle-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        dedup_utils.set_dedup_config("rgw_dedup_min_obj_size_for_dedup", "4096")
+        config_set = True
+
+        obj_count = 200
+        obj_size = 5 * 1024  # 5KB
+
+        keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, obj_count, obj_size, prefix="cycle-obj"
+        )
+
+        all_cycle_stats = []
+        for cycle in range(1, 4):
+            log.info(f"=== Dedup exec cycle {cycle}/3 ===")
+            dedup_utils.run_dedup_execute()
+            stats = dedup_utils.wait_for_dedup_completion()
+            parsed = dedup_utils.parse_dedup_stats_full(stats)
+            all_cycle_stats.append(parsed)
+            log.info(
+                f"Cycle {cycle}: deduped={parsed['deduped_count']}, "
+                f"skipped_too_many={parsed['skipped_too_many_copies']}, "
+                f"skipped_shared_manifest={parsed['skipped_shared_manifest']}"
+            )
+
+        cycle1 = all_cycle_stats[0]
+        assert cycle1["deduped_count"] > 0, "Cycle 1 should have deduped objects"
+
+        for cycle_num, parsed in enumerate(all_cycle_stats[1:], start=2):
+            assert (
+                parsed["deduped_count"] == 0
+            ), f"Cycle {cycle_num} should dedup 0 objects but got {parsed['deduped_count']}"
+            log.info(f"Cycle {cycle_num}: correctly deduped 0 new objects")
+
+        cycle2_skipped = all_cycle_stats[1]["skipped_too_many_copies"]
+        cycle3_skipped = all_cycle_stats[2]["skipped_too_many_copies"]
+        assert cycle2_skipped == cycle3_skipped, (
+            f"Skipped Too Many Copies should be stable: cycle 2={cycle2_skipped}, "
+            f"cycle 3={cycle3_skipped}"
+        )
+        log.info(
+            f"Skipped Too Many Copies stable at {cycle2_skipped} across cycles 2-3"
+        )
+
+        for cycle_num, parsed in enumerate(all_cycle_stats[1:], start=2):
+            assert parsed["skipped_shared_manifest"] >= cycle1["deduped_count"], (
+                f"Cycle {cycle_num}: shared_manifest skipped ({parsed['skipped_shared_manifest']}) "
+                f"should be >= cycle 1 deduped ({cycle1['deduped_count']})"
+            )
+
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_name, keys)
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_name, keys, expected_md5
+        )
+        log.info("All objects accessible and data-correct after 3 cycles")
+
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        if config_set:
+            dedup_utils.reset_dedup_config("rgw_dedup_min_obj_size_for_dedup")
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_split_head_small_objects(config, ssh_con):
+    """
+    E4: Upload 50 identical 5KB single-part objects, run dedup, verify
+    split-head mechanism is used (data extracted from head to tail for
+    objects that store data inline).
+    """
+    test_info = AddTestInfo("E4: Split-head mechanism for small single-part objects")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    config_set = False
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-splithead-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        dedup_utils.set_dedup_config("rgw_dedup_min_obj_size_for_dedup", "4096")
+        config_set = True
+
+        obj_count = 50
+        obj_size = 5 * 1024  # 5KB
+
+        keys, expected_md5, original_data = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, obj_count, obj_size, prefix="splithead-obj"
+        )
+
+        log.info("Running dedup execute on 50 small single-part objects")
+        dedup_utils.run_dedup_execute()
+        exec_stats = dedup_utils.wait_for_dedup_completion()
+        log.info(
+            f"Exec stats: {json.dumps(exec_stats, indent=2) if isinstance(exec_stats, dict) else exec_stats}"
+        )
+
+        parsed = dedup_utils.parse_dedup_stats_full(exec_stats)
+        log.info(
+            f"Deduped: {parsed['deduped_count']}, "
+            f"Split-Head Src: {parsed['split_head_src']}, "
+            f"Split-Head Tgt: {parsed['split_head_tgt']}"
+        )
+
+        assert parsed["deduped_count"] > 0, "Expected objects to be deduped"
+        assert parsed["split_head_src"] > 0, (
+            f"Expected Split-Head Src OBJ > 0 for 5KB single-part objects, "
+            f"got {parsed['split_head_src']}"
+        )
+        assert (
+            parsed["split_head_tgt"] > 0
+        ), f"Expected Split-Head Tgt OBJ > 0, got {parsed['split_head_tgt']}"
+
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_name, keys)
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_name, keys, expected_md5
+        )
+
+        for key in keys[:5]:
+            dedup_utils.verify_range_get(
+                s3_client, bucket_name, key, original_data, 0, 1023
+            )
+            dedup_utils.verify_range_get(
+                s3_client, bucket_name, key, original_data, 2048, obj_size - 1
+            )
+
+        log.info("Split-head dedup verified: all objects accessible with correct data")
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        if config_set:
+            dedup_utils.reset_dedup_config("rgw_dedup_min_obj_size_for_dedup")
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_stats_validation(config, ssh_con):
+    """
+    E5: Upload 50 identical 5KB objects, run estimate then exec, validate
+    that all expected stats fields are present and have correct values.
+    """
+    test_info = AddTestInfo("E5: Dedup stats field validation (estimate + exec)")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    config_set = False
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-statsval-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        dedup_utils.set_dedup_config("rgw_dedup_min_obj_size_for_dedup", "4096")
+        config_set = True
+
+        obj_count = 50
+        obj_size = 5 * 1024  # 5KB
+
+        keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, obj_count, obj_size, prefix="stats-obj"
+        )
+
+        log.info("Phase 1: Running dedup estimate and validating stats")
+        dedup_utils.run_dedup_estimate()
+        estimate_stats = dedup_utils.wait_for_dedup_completion()
+
+        assert isinstance(estimate_stats, dict), "Estimate stats should be a dict"
+        assert (
+            estimate_stats.get("completed") is True
+        ), "Estimate should show completed=true"
+
+        est_parsed = dedup_utils.parse_dedup_stats_full(estimate_stats)
+        log.info(f"Estimate parsed: {json.dumps(est_parsed, indent=2)}")
+
+        assert (
+            est_parsed["total_processed"] == obj_count
+        ), f"Total processed should be {obj_count}, got {est_parsed['total_processed']}"
+        assert (
+            est_parsed["unique_count"] >= 1
+        ), f"Unique Obj should be >= 1, got {est_parsed['unique_count']}"
+        assert (
+            est_parsed["duplicate_count"] > 0
+        ), f"Duplicate Obj should be > 0 for identical objects, got {est_parsed['duplicate_count']}"
+        assert (
+            est_parsed["dedup_ratio_estimate"] > 1.0
+        ), f"Dedup ratio estimate should be > 1.0, got {est_parsed['dedup_ratio_estimate']}"
+
+        est_worker = estimate_stats.get("worker_stats", {}).get("main", {})
+        assert (
+            est_worker.get("Ingress Objs count") == obj_count
+        ), f"Ingress Objs count should be {obj_count}"
+
+        log.info("Phase 2: Running dedup exec and validating stats")
+        dedup_utils.run_dedup_execute()
+        exec_stats = dedup_utils.wait_for_dedup_completion()
+
+        assert isinstance(exec_stats, dict), "Exec stats should be a dict"
+        assert exec_stats.get("completed") is True, "Exec should show completed=true"
+
+        exec_parsed = dedup_utils.parse_dedup_stats_full(exec_stats)
+        log.info(f"Exec parsed: {json.dumps(exec_parsed, indent=2)}")
+
+        assert (
+            exec_parsed["total_processed"] == obj_count
+        ), f"Total processed should be {obj_count}, got {exec_parsed['total_processed']}"
+        assert (
+            exec_parsed["deduped_count"] > 0
+        ), f"Deduped Obj should be > 0, got {exec_parsed['deduped_count']}"
+        assert (
+            exec_parsed["unique_count"] >= 1
+        ), f"Unique Obj should be >= 1, got {exec_parsed['unique_count']}"
+        assert (
+            exec_parsed["dedup_ratio_actual"] > 1.0
+        ), f"Dedup ratio actual should be > 1.0, got {exec_parsed['dedup_ratio_actual']}"
+
+        required_exec_fields = ["dedup_ratio_estimate", "dedup_ratio_actual"]
+        for field in required_exec_fields:
+            assert (
+                field in exec_stats or exec_parsed.get(field, 0) > 0
+            ), f"Required field '{field}' missing or zero in exec stats"
+
+        required_skipped = [
+            "Skipped shared_manifest",
+            "Skipped purged small objs",
+            "Skipped singleton objs",
+            "Skipped source record",
+        ]
+        md5_skipped = exec_stats.get("md5_stats", {}).get("skipped", {})
+        for field in required_skipped:
+            assert (
+                field in md5_skipped
+            ), f"Skipped field '{field}' missing from exec stats"
+
+        log.info("All stats fields validated for both estimate and exec")
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        if config_set:
+            dedup_utils.reset_dedup_config("rgw_dedup_min_obj_size_for_dedup")
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+# === Restart Scenarios (R1-R5) ===
+
+
+def test_exec_restart_rgw(config, ssh_con):
+    """
+    R1: Upload 100 identical 5KB objects, run estimate, start exec async,
+    restart RGW mid-execution, re-run exec, verify all objects accessible
+    and data integrity preserved.
+    """
+    test_info = AddTestInfo("R1: RGW restart mid-exec")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    config_set = False
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-restart-rgw-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        dedup_utils.set_dedup_config("rgw_dedup_min_obj_size_for_dedup", "4096")
+        config_set = True
+
+        obj_count = getattr(config, "objects_count", 100)
+        obj_size = 5 * 1024  # 5KB
+
+        keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, obj_count, obj_size, prefix="restart-rgw-obj"
+        )
+
+        log.info("Running dedup estimate")
+        dedup_utils.run_dedup_estimate()
+        dedup_utils.wait_for_dedup_completion()
+
+        log.info("Starting dedup exec async then restarting RGW")
+        dedup_utils.run_dedup_execute_async()
+        time.sleep(5)
+
+        dedup_utils.restart_rgw_service()
+        time.sleep(30)
+
+        log.info("Re-running dedup exec after RGW restart")
+        dedup_utils.run_dedup_execute()
+        exec_stats = dedup_utils.wait_for_dedup_completion()
+
+        parsed = dedup_utils.parse_dedup_stats(exec_stats)
+        log.info(
+            f"Exec stats: deduped={parsed['deduped_count']}, "
+            f"skipped_shared={parsed['skipped_shared_manifest']}"
+        )
+
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_name, keys)
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_name, keys, expected_md5
+        )
+
+        assert (
+            parsed["deduped_count"] > 0 or parsed["skipped_shared_manifest"] > 0
+        ), "Expected deduped_count > 0 or skipped_shared_manifest > 0 after restart"
+
+        log.info("RGW restart mid-exec test passed")
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        if config_set:
+            dedup_utils.reset_dedup_config("rgw_dedup_min_obj_size_for_dedup")
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_restart_sigkill(config, ssh_con):
+    """
+    R2: Upload 50 identical 5KB objects, run estimate, start exec async,
+    SIGKILL the RGW process mid-execution, wait for recovery, re-run exec,
+    verify all objects accessible and check for orphan objects.
+    """
+    test_info = AddTestInfo("R2: SIGKILL RGW during exec")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    config_set = False
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-sigkill-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        dedup_utils.set_dedup_config("rgw_dedup_min_obj_size_for_dedup", "4096")
+        config_set = True
+
+        obj_count = 50
+        obj_size = 5 * 1024  # 5KB
+
+        keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, obj_count, obj_size, prefix="sigkill-obj"
+        )
+
+        log.info("Running dedup estimate")
+        dedup_utils.run_dedup_estimate()
+        dedup_utils.wait_for_dedup_completion()
+
+        log.info("Starting dedup exec async then sending SIGKILL")
+        dedup_utils.run_dedup_execute_async()
+        time.sleep(3)
+
+        dedup_utils.kill_rgw_process()
+        time.sleep(30)
+
+        log.info("Re-running dedup exec after SIGKILL recovery")
+        dedup_utils.run_dedup_execute()
+        dedup_utils.wait_for_dedup_completion()
+
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_name, keys)
+
+        orphans = dedup_utils.check_orphan_objects()
+        log.info(f"Orphan objects found: {len(orphans)}")
+
+        log.info("SIGKILL RGW during exec test passed")
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        if config_set:
+            dedup_utils.reset_dedup_config("rgw_dedup_min_obj_size_for_dedup")
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_restart_osd(config, ssh_con):
+    """
+    R3: Upload 100 identical 5KB objects, run estimate, start exec async,
+    restart the OSD hosting the bucket's PGs mid-execution, wait for health OK,
+    retry exec if needed, verify all objects accessible and data integrity.
+    """
+    test_info = AddTestInfo("R3: OSD restart during exec")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    config_set = False
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-restart-osd-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        dedup_utils.set_dedup_config("rgw_dedup_min_obj_size_for_dedup", "4096")
+        config_set = True
+
+        obj_count = getattr(config, "objects_count", 100)
+        obj_size = 5 * 1024  # 5KB
+
+        keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, obj_count, obj_size, prefix="osd-restart-obj"
+        )
+
+        log.info("Running dedup estimate")
+        dedup_utils.run_dedup_estimate()
+        dedup_utils.wait_for_dedup_completion()
+
+        log.info("Starting dedup exec async then restarting OSD")
+        dedup_utils.run_dedup_execute_async()
+        time.sleep(5)
+
+        osd_id = dedup_utils.get_osd_for_bucket(bucket_name)
+        dedup_utils.restart_osd(osd_id)
+        dedup_utils.wait_for_health_ok()
+
+        log.info("Waiting for exec completion (retry if needed)")
+        try:
+            dedup_utils.wait_for_dedup_completion(timeout=120)
+        except AssertionError:
+            log.info("Exec may have been interrupted, re-running")
+            dedup_utils.run_dedup_execute()
+            dedup_utils.wait_for_dedup_completion()
+
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_name, keys)
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_name, keys, expected_md5
+        )
+
+        log.info("OSD restart during exec test passed")
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        if config_set:
+            dedup_utils.reset_dedup_config("rgw_dedup_min_obj_size_for_dedup")
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_restart_mon(config, ssh_con):
+    """
+    R4: Upload 50 identical 5KB objects, run estimate, start exec async,
+    restart the MON leader mid-execution, wait and retry exec if needed,
+    verify all objects accessible.
+    """
+    test_info = AddTestInfo("R4: MON leader restart during exec")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    config_set = False
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-restart-mon-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        dedup_utils.set_dedup_config("rgw_dedup_min_obj_size_for_dedup", "4096")
+        config_set = True
+
+        obj_count = 50
+        obj_size = 5 * 1024  # 5KB
+
+        keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, obj_count, obj_size, prefix="mon-restart-obj"
+        )
+
+        log.info("Running dedup estimate")
+        dedup_utils.run_dedup_estimate()
+        dedup_utils.wait_for_dedup_completion()
+
+        log.info("Starting dedup exec async then restarting MON leader")
+        dedup_utils.run_dedup_execute_async()
+        time.sleep(3)
+
+        mon_leader = dedup_utils.get_mon_leader()
+        dedup_utils.restart_mon(mon_leader)
+        time.sleep(15)
+
+        log.info("Waiting for exec completion (retry if needed)")
+        try:
+            dedup_utils.wait_for_dedup_completion(timeout=120)
+        except AssertionError:
+            log.info("Exec may have been interrupted, re-running")
+            dedup_utils.run_dedup_execute()
+            dedup_utils.wait_for_dedup_completion()
+
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_name, keys)
+
+        log.info("MON leader restart during exec test passed")
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        if config_set:
+            dedup_utils.reset_dedup_config("rgw_dedup_min_obj_size_for_dedup")
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_restart_rapid(config, ssh_con):
+    """
+    R5: Upload 100 identical 5KB objects, run estimate, start exec async,
+    perform 3 rapid RGW restarts with 10s gaps, re-run exec, verify all
+    objects accessible and data integrity.
+    """
+    test_info = AddTestInfo("R5: 3 rapid RGW restarts during exec")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    config_set = False
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-rapid-restart-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        dedup_utils.set_dedup_config("rgw_dedup_min_obj_size_for_dedup", "4096")
+        config_set = True
+
+        obj_count = getattr(config, "objects_count", 100)
+        obj_size = 5 * 1024  # 5KB
+
+        keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, obj_count, obj_size, prefix="rapid-restart-obj"
+        )
+
+        log.info("Running dedup estimate")
+        dedup_utils.run_dedup_estimate()
+        dedup_utils.wait_for_dedup_completion()
+
+        log.info("Starting dedup exec async then performing 3 rapid restarts")
+        dedup_utils.run_dedup_execute_async()
+
+        for i in range(3):
+            log.info(f"Rapid restart {i + 1}/3")
+            dedup_utils.restart_rgw_service()
+            time.sleep(10)
+
+        time.sleep(30)
+
+        log.info("Re-running dedup exec after rapid restarts")
+        dedup_utils.run_dedup_execute()
+        exec_stats = dedup_utils.wait_for_dedup_completion()
+
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_name, keys)
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_name, keys, expected_md5
+        )
+
+        log.info("Rapid RGW restart test passed")
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        if config_set:
+            dedup_utils.reset_dedup_config("rgw_dedup_min_obj_size_for_dedup")
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+# === Concurrent/Race Scenarios (C1-C5) ===
+
+
+def test_exec_concurrent_exec_estimate(config, ssh_con):
+    """
+    C1: Upload 200 identical 5KB objects, start estimate async, sleep 2s,
+    try to start exec (expect rejection while estimate is running).
+    Wait for estimate completion, then run exec properly and verify.
+    """
+    test_info = AddTestInfo("C1: Exec during estimate (should be rejected)")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    config_set = False
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-concurrent-est-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        dedup_utils.set_dedup_config("rgw_dedup_min_obj_size_for_dedup", "4096")
+        config_set = True
+
+        obj_count = 200
+        obj_size = 5 * 1024  # 5KB
+
+        keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, obj_count, obj_size, prefix="conc-est-obj"
+        )
+
+        log.info("Starting estimate async, then trying exec during estimate")
+        dedup_utils.run_dedup_estimate_async()
+        time.sleep(2)
+
+        try:
+            dedup_utils.run_dedup_execute()
+            log.warning(
+                "Exec did not reject during estimate — may be expected in some builds"
+            )
+        except (AssertionError, Exception) as exec_err:
+            log.info(f"Exec correctly rejected during estimate: {exec_err}")
+
+        log.info("Waiting for estimate completion")
+        dedup_utils.wait_for_dedup_completion()
+
+        log.info("Running exec properly after estimate completion")
+        dedup_utils.run_dedup_execute()
+        exec_stats = dedup_utils.wait_for_dedup_completion()
+
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_name, keys)
+
+        log.info("Concurrent exec-during-estimate test passed")
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        if config_set:
+            dedup_utils.reset_dedup_config("rgw_dedup_min_obj_size_for_dedup")
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_concurrent_delete(config, ssh_con):
+    """
+    C2: Upload 100 identical 5KB objects, run estimate, start exec async,
+    delete the second half of objects during exec. Wait for completion,
+    verify surviving first half of objects accessible and data integrity.
+    """
+    test_info = AddTestInfo("C2: Delete during exec")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    config_set = False
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-conc-delete-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        dedup_utils.set_dedup_config("rgw_dedup_min_obj_size_for_dedup", "4096")
+        config_set = True
+
+        obj_count = 100
+        obj_size = 5 * 1024  # 5KB
+
+        keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, obj_count, obj_size, prefix="conc-del-obj"
+        )
+
+        log.info("Running dedup estimate")
+        dedup_utils.run_dedup_estimate()
+        dedup_utils.wait_for_dedup_completion()
+
+        log.info("Starting dedup exec async then deleting second half of objects")
+        dedup_utils.run_dedup_execute_async()
+        time.sleep(1)
+
+        keys_to_delete = keys[50:]
+        keys_to_keep = keys[:50]
+        for key in keys_to_delete:
+            s3_client.delete_object(Bucket=bucket_name, Key=key)
+        log.info(f"Deleted {len(keys_to_delete)} objects during exec")
+
+        dedup_utils.wait_for_dedup_completion()
+
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_name, keys_to_keep)
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_name, keys_to_keep, expected_md5
+        )
+
+        log.info("Concurrent delete during exec test passed")
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        if config_set:
+            dedup_utils.reset_dedup_config("rgw_dedup_min_obj_size_for_dedup")
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_concurrent_upload(config, ssh_con):
+    """
+    C3: Upload 50 identical 5KB objects (set A), run estimate, start exec async,
+    upload 50 new objects with different content (set B) during exec. Wait,
+    verify both sets accessible and intact. Re-run exec for set B, verify all.
+    """
+    test_info = AddTestInfo("C3: Upload during exec")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    config_set = False
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-conc-upload-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        dedup_utils.set_dedup_config("rgw_dedup_min_obj_size_for_dedup", "4096")
+        config_set = True
+
+        obj_size = 5 * 1024  # 5KB
+
+        keys_a, md5_a, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, 50, obj_size, prefix="setA-obj"
+        )
+
+        log.info("Running dedup estimate")
+        dedup_utils.run_dedup_estimate()
+        dedup_utils.wait_for_dedup_completion()
+
+        log.info("Starting dedup exec async then uploading set B")
+        dedup_utils.run_dedup_execute_async()
+        time.sleep(1)
+
+        set_b_data = os.urandom(obj_size)
+        md5_b = hashlib.md5(set_b_data).hexdigest()
+        keys_b = []
+        for i in range(50):
+            key = f"setB-obj-{i}"
+            s3_client.put_object(Bucket=bucket_name, Key=key, Body=set_b_data)
+            keys_b.append(key)
+        log.info(f"Uploaded {len(keys_b)} set B objects during exec")
+
+        dedup_utils.wait_for_dedup_completion()
+
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_name, keys_a)
+        dedup_utils.verify_all_objects_integrity(s3_client, bucket_name, keys_a, md5_a)
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_name, keys_b)
+        dedup_utils.verify_all_objects_integrity(s3_client, bucket_name, keys_b, md5_b)
+
+        log.info("Re-running exec to cover set B objects")
+        dedup_utils.run_dedup_execute()
+        dedup_utils.wait_for_dedup_completion()
+
+        dedup_utils.verify_all_objects_accessible(
+            s3_client, bucket_name, keys_a + keys_b
+        )
+
+        log.info("Concurrent upload during exec test passed")
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        if config_set:
+            dedup_utils.reset_dedup_config("rgw_dedup_min_obj_size_for_dedup")
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_concurrent_pause_resume(config, ssh_con):
+    """
+    C4: Upload 100 identical 5KB objects, run estimate, start exec async,
+    rapidly pause and resume 10 times with 1s gaps. Wait for completion,
+    verify all objects accessible and deduped_count > 0.
+    """
+    test_info = AddTestInfo("C4: Rapid pause/resume 10 times during exec")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    config_set = False
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-pause-resume-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        dedup_utils.set_dedup_config("rgw_dedup_min_obj_size_for_dedup", "4096")
+        config_set = True
+
+        obj_count = 100
+        obj_size = 5 * 1024  # 5KB
+
+        keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, obj_count, obj_size, prefix="pause-resume-obj"
+        )
+
+        log.info("Running dedup estimate")
+        dedup_utils.run_dedup_estimate()
+        dedup_utils.wait_for_dedup_completion()
+
+        log.info("Starting dedup exec async then rapid pause/resume 10x")
+        dedup_utils.run_dedup_execute_async()
+        time.sleep(2)
+
+        for i in range(10):
+            log.info(f"Pause/resume cycle {i + 1}/10")
+            dedup_utils.run_dedup_pause()
+            time.sleep(1)
+            dedup_utils.run_dedup_resume()
+            time.sleep(1)
+
+        exec_stats = dedup_utils.wait_for_dedup_completion()
+
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_name, keys)
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_name, keys, expected_md5
+        )
+
+        parsed = dedup_utils.parse_dedup_stats(exec_stats)
+        assert (
+            parsed["deduped_count"] > 0
+        ), f"Expected deduped > 0 after pause/resume, got {parsed['deduped_count']}"
+
+        log.info("Rapid pause/resume test passed")
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        if config_set:
+            dedup_utils.reset_dedup_config("rgw_dedup_min_obj_size_for_dedup")
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_concurrent_double_abort(config, ssh_con):
+    """
+    C5: Upload 100 identical 5KB objects, run estimate, start exec async,
+    abort twice (second should be no-op). Verify RGW daemons are running
+    and objects are accessible. Run a fresh exec and assert deduped > 0.
+    """
+    test_info = AddTestInfo("C5: Double abort during exec")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    config_set = False
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-double-abort-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        dedup_utils.set_dedup_config("rgw_dedup_min_obj_size_for_dedup", "4096")
+        config_set = True
+
+        obj_count = 100
+        obj_size = 5 * 1024  # 5KB
+
+        keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, obj_count, obj_size, prefix="dbl-abort-obj"
+        )
+
+        log.info("Running dedup estimate")
+        dedup_utils.run_dedup_estimate()
+        dedup_utils.wait_for_dedup_completion()
+
+        log.info("Starting dedup exec async then performing double abort")
+        dedup_utils.run_dedup_execute_async()
+        time.sleep(2)
+
+        dedup_utils.run_dedup_abort()
+        log.info("First abort sent")
+
+        try:
+            dedup_utils.run_dedup_abort()
+            log.info("Second abort sent (no-op expected)")
+        except (AssertionError, Exception) as abort_err:
+            log.info(f"Second abort returned error (expected): {abort_err}")
+
+        running, total = dedup_utils.verify_rgw_daemons_running()
+        log.info(f"RGW daemons after double abort: {running}/{total} running")
+
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_name, keys)
+
+        log.info("Running fresh exec after double abort")
+        dedup_utils.run_dedup_execute()
+        exec_stats = dedup_utils.wait_for_dedup_completion()
+
+        parsed = dedup_utils.parse_dedup_stats(exec_stats)
+        assert (
+            parsed["deduped_count"] > 0
+        ), f"Expected deduped > 0 after fresh exec, got {parsed['deduped_count']}"
+
+        log.info("Double abort test passed")
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        if config_set:
+            dedup_utils.reset_dedup_config("rgw_dedup_min_obj_size_for_dedup")
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+# === Data Edge Cases (D1-D5) ===
+
+
+def test_exec_edge_empty(config, ssh_con):
+    """
+    D1: Run dedup estimate and exec on an empty bucket.
+    Assert ingress_count == 0 and deduped_count == 0.
+    """
+    test_info = AddTestInfo("D1: Empty bucket dedup")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-empty-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        log.info("Running dedup estimate on empty bucket")
+        dedup_utils.run_dedup_estimate()
+        estimate_stats = dedup_utils.wait_for_dedup_completion()
+
+        est_parsed = dedup_utils.parse_dedup_stats_full(estimate_stats)
+        assert (
+            est_parsed["ingress_count"] == 0
+        ), f"Expected ingress_count == 0 for empty bucket, got {est_parsed['ingress_count']}"
+
+        log.info("Running dedup exec on empty bucket")
+        dedup_utils.run_dedup_execute()
+        exec_stats = dedup_utils.wait_for_dedup_completion()
+
+        exec_parsed = dedup_utils.parse_dedup_stats(exec_stats)
+        assert (
+            exec_parsed["deduped_count"] == 0
+        ), f"Expected deduped_count == 0 for empty bucket, got {exec_parsed['deduped_count']}"
+
+        log.info("Empty bucket dedup test passed")
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_edge_singletons(config, ssh_con):
+    """
+    D2: Upload 50 objects each with unique content (no duplicates).
+    Run estimate and assert duplicate_count == 0, unique_count == 50.
+    Run exec and assert deduped_count == 0. Verify all accessible.
+    """
+    test_info = AddTestInfo("D2: All unique content (no duplicates)")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    config_set = False
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-singletons-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        dedup_utils.set_dedup_config("rgw_dedup_min_obj_size_for_dedup", "4096")
+        config_set = True
+
+        obj_size = 5 * 1024  # 5KB
+        keys, md5s = dedup_utils.upload_unique_objects(
+            s3_client, bucket_name, 50, obj_size, prefix="singleton-obj"
+        )
+
+        log.info("Running dedup estimate on unique objects")
+        dedup_utils.run_dedup_estimate()
+        estimate_stats = dedup_utils.wait_for_dedup_completion()
+
+        est_parsed = dedup_utils.parse_dedup_stats_full(estimate_stats)
+        assert (
+            est_parsed["duplicate_count"] == 0
+        ), f"Expected duplicate_count == 0, got {est_parsed['duplicate_count']}"
+        assert (
+            est_parsed["unique_count"] == 50
+        ), f"Expected unique_count == 50, got {est_parsed['unique_count']}"
+
+        log.info("Running dedup exec on unique objects")
+        dedup_utils.run_dedup_execute()
+        exec_stats = dedup_utils.wait_for_dedup_completion()
+
+        exec_parsed = dedup_utils.parse_dedup_stats(exec_stats)
+        assert (
+            exec_parsed["deduped_count"] == 0
+        ), f"Expected deduped_count == 0, got {exec_parsed['deduped_count']}"
+
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_name, keys)
+
+        log.info("All-unique content test passed")
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        if config_set:
+            dedup_utils.reset_dedup_config("rgw_dedup_min_obj_size_for_dedup")
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_edge_min_size(config, ssh_con):
+    """
+    D3: Upload 20 identical objects at exactly 5120 bytes (at dedup threshold)
+    and 20 identical objects at 4095 bytes (below threshold, unique data).
+    Run estimate + exec, assert deduped > 0. Verify all accessible.
+    """
+    test_info = AddTestInfo("D3: Min size boundary (at and below threshold)")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    config_set = False
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-minsize-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        dedup_utils.set_dedup_config("rgw_dedup_min_obj_size_for_dedup", "4096")
+        config_set = True
+
+        keys_at, md5_at, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, 20, 5120, prefix="at-boundary-obj"
+        )
+
+        below_data = os.urandom(4095)
+        below_md5 = hashlib.md5(below_data).hexdigest()
+        keys_below = []
+        for i in range(20):
+            key = f"below-boundary-obj-{i}"
+            s3_client.put_object(Bucket=bucket_name, Key=key, Body=below_data)
+            keys_below.append(key)
+
+        log.info("Running dedup estimate")
+        dedup_utils.run_dedup_estimate()
+        dedup_utils.wait_for_dedup_completion()
+
+        log.info("Running dedup exec")
+        dedup_utils.run_dedup_execute()
+        exec_stats = dedup_utils.wait_for_dedup_completion()
+
+        parsed = dedup_utils.parse_dedup_stats(exec_stats)
+        assert (
+            parsed["deduped_count"] > 0
+        ), f"Expected deduped > 0 for at-boundary objects, got {parsed['deduped_count']}"
+
+        dedup_utils.verify_all_objects_accessible(
+            s3_client, bucket_name, keys_at + keys_below
+        )
+
+        log.info("Min size boundary test passed")
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        if config_set:
+            dedup_utils.reset_dedup_config("rgw_dedup_min_obj_size_for_dedup")
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_edge_single_object(config, ssh_con):
+    """
+    D4: Upload a single 5KB object to a bucket. Run estimate and assert
+    ingress_count == 1. Run exec and assert deduped_count == 0 (nothing
+    to dedup with only one object). Verify integrity.
+    """
+    test_info = AddTestInfo("D4: Single object in bucket")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    config_set = False
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-single-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        dedup_utils.set_dedup_config("rgw_dedup_min_obj_size_for_dedup", "4096")
+        config_set = True
+
+        obj_size = 5 * 1024  # 5KB
+        keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, 1, obj_size, prefix="single-obj"
+        )
+
+        log.info("Running dedup estimate on single object")
+        dedup_utils.run_dedup_estimate()
+        estimate_stats = dedup_utils.wait_for_dedup_completion()
+
+        est_parsed = dedup_utils.parse_dedup_stats_full(estimate_stats)
+        assert (
+            est_parsed["ingress_count"] == 1
+        ), f"Expected ingress_count == 1, got {est_parsed['ingress_count']}"
+
+        log.info("Running dedup exec on single object")
+        dedup_utils.run_dedup_execute()
+        exec_stats = dedup_utils.wait_for_dedup_completion()
+
+        exec_parsed = dedup_utils.parse_dedup_stats(exec_stats)
+        assert (
+            exec_parsed["deduped_count"] == 0
+        ), f"Expected deduped_count == 0 for single object, got {exec_parsed['deduped_count']}"
+
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_name, keys, expected_md5
+        )
+
+        log.info("Single object test passed")
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        if config_set:
+            dedup_utils.reset_dedup_config("rgw_dedup_min_obj_size_for_dedup")
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_edge_max_versions(config, ssh_con):
+    """
+    D5: Upload 500 identical versions of the same key (5KB). Run estimate + exec,
+    assert deduped_count <= 127 (128 limit minus source). Verify all 500 versions
+    accessible by VersionId. Second exec should dedup 0 (idempotency).
+    """
+    test_info = AddTestInfo("D5: 500 versions past 128 limit")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    config_set = False
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-maxver-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        dedup_utils.set_dedup_config("rgw_dedup_min_obj_size_for_dedup", "4096")
+        config_set = True
+
+        obj_size = 5 * 1024  # 5KB
+        object_key = "max-versions-obj"
+        version_count = 500
+
+        version_ids, expected_md5, _ = dedup_utils.upload_identical_versions(
+            s3_client, bucket_name, object_key, version_count, obj_size
+        )
+
+        log.info("Running dedup estimate")
+        dedup_utils.run_dedup_estimate()
+        dedup_utils.wait_for_dedup_completion()
+
+        log.info("Running dedup exec")
+        dedup_utils.run_dedup_execute()
+        exec_stats = dedup_utils.wait_for_dedup_completion()
+
+        parsed = dedup_utils.parse_dedup_stats(exec_stats)
+        assert (
+            parsed["deduped_count"] <= 127
+        ), f"Expected deduped <= 127, got {parsed['deduped_count']}"
+        log.info(f"Deduped {parsed['deduped_count']} out of {version_count} versions")
+
+        log.info(f"Verifying all {version_count} versions accessible")
+        for vid in version_ids:
+            resp = s3_client.get_object(
+                Bucket=bucket_name, Key=object_key, VersionId=vid
+            )
+            body = resp["Body"].read()
+            actual_md5 = hashlib.md5(body).hexdigest()
+            assert (
+                actual_md5 == expected_md5
+            ), f"Version {vid} MD5 mismatch: expected {expected_md5}, got {actual_md5}"
+
+        log.info("Running second exec (idempotency check)")
+        dedup_utils.run_dedup_execute()
+        exec_stats_2 = dedup_utils.wait_for_dedup_completion()
+
+        parsed_2 = dedup_utils.parse_dedup_stats(exec_stats_2)
+        assert (
+            parsed_2["deduped_count"] == 0
+        ), f"Second exec should dedup 0, got {parsed_2['deduped_count']}"
+
+        log.info("Max versions test passed")
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        if config_set:
+            dedup_utils.reset_dedup_config("rgw_dedup_min_obj_size_for_dedup")
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+# === Infrastructure Failure Scenarios (F1-F5) ===
+
+
+def test_exec_infra_pool_full(config, ssh_con):
+    """
+    F1: Upload 50 identical 5KB objects, set a tight pool quota (1MB),
+    attempt estimate + exec (may fail). Remove quota, re-run exec,
+    verify all objects accessible and data integrity.
+    """
+    test_info = AddTestInfo("F1: Pool near full during dedup")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    config_set = False
+    quota_set = False
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-poolfull-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        dedup_utils.set_dedup_config("rgw_dedup_min_obj_size_for_dedup", "4096")
+        config_set = True
+
+        obj_count = 50
+        obj_size = 5 * 1024  # 5KB
+
+        keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, obj_count, obj_size, prefix="poolfull-obj"
+        )
+
+        log.info("Setting tight pool quota (1MB)")
+        dedup_utils.set_pool_quota("default.rgw.buckets.data", 1048576)
+        quota_set = True
+
+        log.info("Attempting estimate + exec with tight quota (may fail)")
+        try:
+            dedup_utils.run_dedup_estimate()
+            dedup_utils.wait_for_dedup_completion()
+            dedup_utils.run_dedup_execute()
+            dedup_utils.wait_for_dedup_completion()
+        except (AssertionError, Exception) as quota_err:
+            log.info(f"Dedup failed under quota (expected): {quota_err}")
+
+        log.info("Removing pool quota")
+        dedup_utils.remove_pool_quota("default.rgw.buckets.data")
+        quota_set = False
+
+        log.info("Re-running exec without quota")
+        dedup_utils.run_dedup_execute()
+        dedup_utils.wait_for_dedup_completion()
+
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_name, keys)
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_name, keys, expected_md5
+        )
+
+        log.info("Pool full test passed")
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        if quota_set:
+            dedup_utils.remove_pool_quota("default.rgw.buckets.data")
+        if config_set:
+            dedup_utils.reset_dedup_config("rgw_dedup_min_obj_size_for_dedup")
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_infra_reshard(config, ssh_con):
+    """
+    F2: Upload 100 identical 5KB objects, run estimate, start exec async,
+    trigger bucket reshard to 8 shards during exec (may fail). Wait,
+    retry exec if needed, verify all objects accessible and data integrity.
+    """
+    test_info = AddTestInfo("F2: Reshard during exec")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    config_set = False
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-reshard-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        dedup_utils.set_dedup_config("rgw_dedup_min_obj_size_for_dedup", "4096")
+        config_set = True
+
+        obj_count = getattr(config, "objects_count", 100)
+        obj_size = 5 * 1024  # 5KB
+
+        keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, obj_count, obj_size, prefix="reshard-obj"
+        )
+
+        log.info("Running dedup estimate")
+        dedup_utils.run_dedup_estimate()
+        dedup_utils.wait_for_dedup_completion()
+
+        log.info("Starting dedup exec async then triggering reshard")
+        dedup_utils.run_dedup_execute_async()
+        time.sleep(2)
+
+        try:
+            dedup_utils.trigger_bucket_reshard(bucket_name, 8)
+            log.info("Bucket reshard triggered during exec")
+        except (AssertionError, Exception) as reshard_err:
+            log.warning(f"Reshard during exec failed (may be expected): {reshard_err}")
+
+        log.info("Waiting for exec completion (retry if needed)")
+        try:
+            dedup_utils.wait_for_dedup_completion(timeout=120)
+        except AssertionError:
+            log.info("Exec may have been interrupted by reshard, re-running")
+            dedup_utils.run_dedup_execute()
+            dedup_utils.wait_for_dedup_completion()
+
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_name, keys)
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_name, keys, expected_md5
+        )
+
+        log.info("Reshard during exec test passed")
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        if config_set:
+            dedup_utils.reset_dedup_config("rgw_dedup_min_obj_size_for_dedup")
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_infra_network(config, ssh_con):
+    """
+    F3: Upload 100 identical 5KB objects, run estimate, start exec async,
+    simulate a network partition by dropping MON traffic (port 6789) via
+    iptables for 30s, then restore. Wait/retry, verify objects accessible.
+    """
+    test_info = AddTestInfo("F3: Network partition during exec")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    config_set = False
+    iptables_rule_added = False
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-network-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        dedup_utils.set_dedup_config("rgw_dedup_min_obj_size_for_dedup", "4096")
+        config_set = True
+
+        obj_count = getattr(config, "objects_count", 100)
+        obj_size = 5 * 1024  # 5KB
+
+        keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, obj_count, obj_size, prefix="network-obj"
+        )
+
+        log.info("Running dedup estimate")
+        dedup_utils.run_dedup_estimate()
+        dedup_utils.wait_for_dedup_completion()
+
+        log.info("Starting dedup exec async then simulating network partition")
+        dedup_utils.run_dedup_execute_async()
+        time.sleep(3)
+
+        log.info("Dropping MON traffic on port 6789")
+        utils.exec_shell_cmd("iptables -A INPUT -p tcp --dport 6789 -j DROP")
+        iptables_rule_added = True
+        time.sleep(30)
+
+        log.info("Restoring network (removing iptables rule)")
+        utils.exec_shell_cmd("iptables -D INPUT -p tcp --dport 6789 -j DROP")
+        iptables_rule_added = False
+
+        log.info("Waiting for exec completion (retry if needed)")
+        try:
+            dedup_utils.wait_for_dedup_completion(timeout=120)
+        except AssertionError:
+            log.info("Exec may have failed during partition, re-running")
+            dedup_utils.run_dedup_execute()
+            dedup_utils.wait_for_dedup_completion()
+
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_name, keys)
+
+        log.info("Network partition test passed")
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        if iptables_rule_added:
+            utils.exec_shell_cmd("iptables -D INPUT -p tcp --dport 6789 -j DROP")
+        if config_set:
+            dedup_utils.reset_dedup_config("rgw_dedup_min_obj_size_for_dedup")
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_infra_corrupt(config, ssh_con):
+    """
+    F4: Upload 50 identical 5KB objects, get bucket marker, find RADOS objects,
+    corrupt the first one. Run estimate + exec, verify at least len(keys)-1
+    objects are still accessible.
+    """
+    test_info = AddTestInfo("F4: Corrupt RADOS object then dedup")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    config_set = False
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-corrupt-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        dedup_utils.set_dedup_config("rgw_dedup_min_obj_size_for_dedup", "4096")
+        config_set = True
+
+        obj_count = 50
+        obj_size = 5 * 1024  # 5KB
+
+        keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, obj_count, obj_size, prefix="corrupt-obj"
+        )
+
+        marker = dedup_utils.get_bucket_marker(bucket_name)
+        rados_objects = dedup_utils.get_rados_objects(
+            pool="default.rgw.buckets.data", prefix=marker
+        )
+        if rados_objects:
+            log.info(f"Corrupting RADOS object: {rados_objects[0]}")
+            dedup_utils.corrupt_rados_object(
+                "default.rgw.buckets.data", rados_objects[0]
+            )
+        else:
+            log.warning("No RADOS objects found to corrupt, proceeding anyway")
+
+        log.info("Running dedup estimate")
+        dedup_utils.run_dedup_estimate()
+        dedup_utils.wait_for_dedup_completion()
+
+        log.info("Running dedup exec")
+        dedup_utils.run_dedup_execute()
+        dedup_utils.wait_for_dedup_completion()
+
+        accessible_count = 0
+        for key in keys:
+            try:
+                s3_client.head_object(Bucket=bucket_name, Key=key)
+                accessible_count += 1
+            except Exception:
+                log.warning(f"Object {key} not accessible (may be the corrupted one)")
+
+        log.info(f"Accessible objects: {accessible_count}/{len(keys)}")
+        assert (
+            accessible_count >= len(keys) - 1
+        ), f"Expected at least {len(keys) - 1} accessible, got {accessible_count}"
+
+        log.info("Corrupt RADOS object test passed")
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        if config_set:
+            dedup_utils.reset_dedup_config("rgw_dedup_min_obj_size_for_dedup")
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+def test_exec_infra_time_jump(config, ssh_con):
+    """
+    F5: Upload 50 identical 5KB objects, run estimate, start exec async,
+    jump clock forward 1 hour, wait for completion, restore clock via
+    chronyc, retry if needed, verify all objects accessible and data integrity.
+    """
+    test_info = AddTestInfo("F5: Clock jump during exec")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    config_set = False
+    clock_jumped = False
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-timejump-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        dedup_utils.set_dedup_config("rgw_dedup_min_obj_size_for_dedup", "4096")
+        config_set = True
+
+        obj_count = 50
+        obj_size = 5 * 1024  # 5KB
+
+        keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, obj_count, obj_size, prefix="timejump-obj"
+        )
+
+        log.info("Running dedup estimate")
+        dedup_utils.run_dedup_estimate()
+        dedup_utils.wait_for_dedup_completion()
+
+        log.info("Starting dedup exec async then jumping clock +1 hour")
+        dedup_utils.run_dedup_execute_async()
+        time.sleep(2)
+
+        utils.exec_shell_cmd("date -s '+1 hour'")
+        clock_jumped = True
+        time.sleep(5)
+
+        log.info("Waiting for exec completion")
+        try:
+            dedup_utils.wait_for_dedup_completion(timeout=120)
+        except AssertionError:
+            log.info("Exec may have failed due to clock jump")
+
+        log.info("Restoring clock via chronyc makestep")
+        utils.exec_shell_cmd("chronyc makestep")
+        clock_jumped = False
+        time.sleep(5)
+
+        log.info("Retrying exec after clock restore if needed")
+        try:
+            stats = dedup_utils.get_dedup_stats()
+            if isinstance(stats, dict) and not stats.get("completed", False):
+                dedup_utils.wait_for_dedup_completion(timeout=60)
+        except (AssertionError, Exception):
+            dedup_utils.run_dedup_execute()
+            dedup_utils.wait_for_dedup_completion()
+
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_name, keys)
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_name, keys, expected_md5
+        )
+
+        log.info("Clock jump test passed")
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        if clock_jumped:
+            utils.exec_shell_cmd("chronyc makestep")
+        if config_set:
+            dedup_utils.reset_dedup_config("rgw_dedup_min_obj_size_for_dedup")
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+# === Multi-Bucket/Scale Scenarios (M1-M3) ===
+
+
+def test_exec_scale_100_buckets(config, ssh_con):
+    """
+    M1: Create 100 buckets, each with 10 identical objects (same data across
+    all buckets). Run estimate and assert ingress >= 1000. Run exec and
+    assert deduped > 0. Verify a sample of 20 buckets. Cleanup all 100.
+    """
+    test_info = AddTestInfo("M1: 100 buckets with identical objects")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    config_set = False
+    buckets = []
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        dedup_utils.set_dedup_config("rgw_dedup_min_obj_size_for_dedup", "4096")
+        config_set = True
+
+        obj_size = 5 * 1024  # 5KB
+        identical_data = dedup_utils.generate_identical_data(obj_size)
+        expected_md5 = hashlib.md5(identical_data).hexdigest()
+
+        bucket_count = 100
+        objs_per_bucket = 10
+        all_bucket_keys = {}
+
+        for b in range(bucket_count):
+            bname = f"dedup-scale100-{b}-{random.randint(1, 5000)}"
+            s3_client.create_bucket(Bucket=bname)
+            buckets.append(bname)
+            keys = []
+            for i in range(objs_per_bucket):
+                key = f"scale-obj-{i}"
+                s3_client.put_object(Bucket=bname, Key=key, Body=identical_data)
+                keys.append(key)
+            all_bucket_keys[bname] = keys
+            if (b + 1) % 20 == 0:
+                log.info(f"Created {b + 1}/{bucket_count} buckets")
+
+        log.info("Running dedup estimate across 100 buckets")
+        dedup_utils.run_dedup_estimate()
+        estimate_stats = dedup_utils.wait_for_dedup_completion()
+
+        est_parsed = dedup_utils.parse_dedup_stats_full(estimate_stats)
+        assert (
+            est_parsed["ingress_count"] >= 1000
+        ), f"Expected ingress >= 1000, got {est_parsed['ingress_count']}"
+
+        log.info("Running dedup exec across 100 buckets")
+        dedup_utils.run_dedup_execute()
+        exec_stats = dedup_utils.wait_for_dedup_completion()
+
+        parsed = dedup_utils.parse_dedup_stats(exec_stats)
+        assert (
+            parsed["deduped_count"] > 0
+        ), f"Expected deduped > 0 across 100 buckets, got {parsed['deduped_count']}"
+
+        sample_buckets = random.sample(buckets, min(20, len(buckets)))
+        for bname in sample_buckets:
+            dedup_utils.verify_all_objects_accessible(
+                s3_client, bname, all_bucket_keys[bname]
+            )
+            dedup_utils.verify_all_objects_integrity(
+                s3_client, bname, all_bucket_keys[bname], expected_md5
+            )
+        log.info(f"Verified {len(sample_buckets)} sample buckets")
+
+        log.info("100 buckets scale test passed")
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        if config_set:
+            dedup_utils.reset_dedup_config("rgw_dedup_min_obj_size_for_dedup")
+        for bname in buckets:
+            dedup_utils.cleanup_bucket(s3_client, bname)
+
+
+def test_exec_scale_filters(config, ssh_con):
+    """
+    M2: Create 3 buckets, upload 20 identical objects to each. Create an
+    allow-bucket-list file with only 2 of the 3 buckets. Run estimate
+    with allow_bucket_file and assert ingress <= 40. Run exec with
+    allow_bucket_file. Cleanup all 3 buckets.
+    """
+    test_info = AddTestInfo("M2: Allow/deny bucket filters")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    config_set = False
+    filter_file = None
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        dedup_utils.set_dedup_config("rgw_dedup_min_obj_size_for_dedup", "4096")
+        config_set = True
+
+        obj_size = 5 * 1024  # 5KB
+
+        bucket_1 = f"dedup-filter-allowed1-{random.randint(1, 5000)}"
+        bucket_2 = f"dedup-filter-allowed2-{random.randint(1, 5000)}"
+        bucket_3 = f"dedup-filter-denied-{random.randint(1, 5000)}"
+        all_buckets = [bucket_1, bucket_2, bucket_3]
+
+        for bname in all_buckets:
+            s3_client.create_bucket(Bucket=bname)
+
+        for bname in all_buckets:
+            dedup_utils.upload_identical_objects(
+                s3_client, bname, 20, obj_size, prefix="filter-obj"
+            )
+
+        filter_file = dedup_utils.create_filter_list_file([bucket_1, bucket_2])
+        log.info(f"Allow-bucket filter file: {filter_file}")
+
+        log.info("Running dedup estimate with allow-bucket filter")
+        dedup_utils.run_dedup_estimate(allow_bucket_file=filter_file)
+        estimate_stats = dedup_utils.wait_for_dedup_completion()
+
+        est_parsed = dedup_utils.parse_dedup_stats_full(estimate_stats)
+        assert (
+            est_parsed["ingress_count"] <= 40
+        ), f"Expected ingress <= 40 with filter, got {est_parsed['ingress_count']}"
+
+        log.info("Running dedup exec with allow-bucket filter")
+        dedup_utils.run_dedup_execute(allow_bucket_file=filter_file)
+        dedup_utils.wait_for_dedup_completion()
+
+        log.info("Allow/deny filter test passed")
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        if filter_file and os.path.exists(filter_file):
+            os.unlink(filter_file)
+        if config_set:
+            dedup_utils.reset_dedup_config("rgw_dedup_min_obj_size_for_dedup")
+        for bname in [bucket_1, bucket_2, bucket_3]:
+            dedup_utils.cleanup_bucket(s3_client, bname)
+
+
+def test_exec_scale_mixed_sizes(config, ssh_con):
+    """
+    M3: Upload 20 identical 5KB objects (above threshold), 20 identical 3KB
+    objects (below, different content), and 20 identical 1KB objects (well below,
+    different content). Run estimate + exec, assert deduped > 0 for the
+    above-threshold group. Verify all 60 objects accessible.
+    """
+    test_info = AddTestInfo("M3: Mixed sizes with dedup threshold")
+    io_info_initialize = IOInfoInitialize()
+    basic_io_structure = BasicIOInfoStructure()
+    io_info_initialize.initialize(basic_io_structure.initial())
+
+    config_set = False
+
+    try:
+        test_info.started_info()
+        user_info = s3lib.create_users(1)[0]
+        auth = reusable.get_auth(
+            user_info, ssh_con, config.ssl, getattr(config, "haproxy", False)
+        )
+        s3_client = auth.do_auth_using_client()
+
+        bucket_name = f"dedup-mixed-sizes-{random.randint(1, 5000)}"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        dedup_utils.set_dedup_config("rgw_dedup_min_obj_size_for_dedup", "4096")
+        config_set = True
+
+        keys_5k, md5_5k, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_name, 20, 5 * 1024, prefix="above-obj"
+        )
+
+        data_3k = os.urandom(3 * 1024)
+        md5_3k = hashlib.md5(data_3k).hexdigest()
+        keys_3k = []
+        for i in range(20):
+            key = f"below-3k-obj-{i}"
+            s3_client.put_object(Bucket=bucket_name, Key=key, Body=data_3k)
+            keys_3k.append(key)
+
+        data_1k = os.urandom(1 * 1024)
+        md5_1k = hashlib.md5(data_1k).hexdigest()
+        keys_1k = []
+        for i in range(20):
+            key = f"below-1k-obj-{i}"
+            s3_client.put_object(Bucket=bucket_name, Key=key, Body=data_1k)
+            keys_1k.append(key)
+
+        log.info("Running dedup estimate on mixed sizes")
+        dedup_utils.run_dedup_estimate()
+        dedup_utils.wait_for_dedup_completion()
+
+        log.info("Running dedup exec on mixed sizes")
+        dedup_utils.run_dedup_execute()
+        exec_stats = dedup_utils.wait_for_dedup_completion()
+
+        parsed = dedup_utils.parse_dedup_stats(exec_stats)
+        assert (
+            parsed["deduped_count"] > 0
+        ), f"Expected deduped > 0 for above-threshold objects, got {parsed['deduped_count']}"
+
+        all_keys = keys_5k + keys_3k + keys_1k
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_name, all_keys)
+
+        log.info("Mixed sizes threshold test passed")
+        test_info.success_status("test passed")
+
+    except (RGWBaseException, AssertionError, Exception) as e:
+        log.error(f"Test failed: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+    finally:
+        if config_set:
+            dedup_utils.reset_dedup_config("rgw_dedup_min_obj_size_for_dedup")
+        dedup_utils.cleanup_bucket(s3_client, bucket_name)
+
+
+# === Run All ===
+
+
+def test_exec_all(config, ssh_con):
+    """Run all 30 dedup tests sequentially. Use dedup_type='all' in YAML config.
+    Collects pass/fail for each test and reports a summary at the end.
+    Fails if ANY test fails."""
+    test_info = AddTestInfo("ALL: Run all dedup tests")
+
+    results = {}
+    failed_tests = []
+
+    try:
+        test_info.started_info()
+
+        for test_name, test_func in TEST_DISPATCH.items():
+            if test_name == "all":
+                continue
+            log.info(f"\n{'='*60}\n  Running: {test_name}\n{'='*60}")
+            try:
+                test_func(config, ssh_con)
+                results[test_name] = "PASSED"
+                log.info(f"  {test_name}: PASSED")
+            except Exception as e:
+                results[test_name] = f"FAILED: {e}"
+                failed_tests.append(test_name)
+                log.error(f"  {test_name}: FAILED - {e}")
+
+        log.info(f"\n{'='*60}\n  DEDUP TEST SUMMARY\n{'='*60}")
+        passed = sum(1 for v in results.values() if v == "PASSED")
+        total = len(results)
+        log.info(f"  {passed}/{total} tests passed")
+        for name, result in results.items():
+            status = "PASS" if result == "PASSED" else "FAIL"
+            log.info(f"    [{status}] {name}")
+
+        if failed_tests:
+            test_info.failed_status(f"{len(failed_tests)}/{total} tests failed")
+            raise TestExecError(f"Failed tests: {', '.join(failed_tests)}")
+
+        test_info.success_status(f"All {total} tests passed")
+
+    except TestExecError:
+        raise
+    except Exception as e:
+        log.error(f"Unexpected error in test_exec_all: {e}")
+        log.error(traceback.format_exc())
+        test_info.failed_status("test failed")
+        raise
+
+
+# === Dispatcher ===
+
+TEST_DISPATCH = {
+    "sanity_large": test_exec_sanity_large_objects,
+    "sanity_small": test_exec_sanity_small_objects,
+    "admin_api": test_exec_admin_ops_api,
+    "estimate": test_exec_estimate_dry_run,
+    "integrity": test_exec_data_integrity,
+    "multipart": test_exec_multipart_objects,
+    "session_lifecycle": test_exec_session_lifecycle,
+    "ssec_exclusion": test_exec_ssec_exclusion,
+    "storage_class_filter": test_exec_storage_class_filter,
+    "lc_expiration": test_exec_lc_expiration,
+    "versioned": test_exec_versioned_objects,
+    "s3_copy": test_exec_s3_copy_dedup,
+    "diff_metadata": test_exec_same_content_diff_metadata,
+    "concurrent_ops": test_exec_concurrent_s3_ops,
+    "compressed_sanity": test_exec_compressed_sanity,
+    "compressed_cross_mode": test_exec_compressed_cross_mode,
+    "compressed_algo_switch": test_exec_compressed_algo_switch,
+    "compressed_multipart": test_exec_compressed_multipart,
+    "compressed_skip_toggle": test_exec_compressed_skip_toggle,
+    "compressed_attr_mirror": test_exec_compressed_attr_mirror,
+    "overwrite_deduped": test_exec_overwrite_deduped_object,
+    "delete_source": test_exec_delete_dedup_source,
+    "copy_delete_deduped": test_exec_s3_copy_then_delete_deduped,
+    "cross_bucket_delete": test_exec_cross_bucket_source_delete,
+    "idempotency": test_exec_dedup_idempotency,
+    "128_limit": test_exec_128_limit_boundary,
+    "versioned_boundary": test_exec_versioned_boundary,
+    "multi_cycle": test_exec_multi_cycle_no_progress,
+    "split_head": test_exec_split_head_small_objects,
+    "stats_validation": test_exec_stats_validation,
+    "restart_rgw": test_exec_restart_rgw,
+    "restart_sigkill": test_exec_restart_sigkill,
+    "restart_osd": test_exec_restart_osd,
+    "restart_mon": test_exec_restart_mon,
+    "restart_rapid": test_exec_restart_rapid,
+    "concurrent_exec_estimate": test_exec_concurrent_exec_estimate,
+    "concurrent_delete": test_exec_concurrent_delete,
+    "concurrent_upload": test_exec_concurrent_upload,
+    "concurrent_pause_resume": test_exec_concurrent_pause_resume,
+    "concurrent_double_abort": test_exec_concurrent_double_abort,
+    "edge_empty": test_exec_edge_empty,
+    "edge_singletons": test_exec_edge_singletons,
+    "edge_min_size": test_exec_edge_min_size,
+    "edge_single_object": test_exec_edge_single_object,
+    "edge_max_versions": test_exec_edge_max_versions,
+    "infra_pool_full": test_exec_infra_pool_full,
+    "infra_reshard": test_exec_infra_reshard,
+    "infra_network": test_exec_infra_network,
+    "infra_corrupt": test_exec_infra_corrupt,
+    "infra_time_jump": test_exec_infra_time_jump,
+    "scale_100_buckets": test_exec_scale_100_buckets,
+    "scale_filters": test_exec_scale_filters,
+    "scale_mixed_sizes": test_exec_scale_mixed_sizes,
+    "all": test_exec_all,
+}
+
+
+if __name__ == "__main__":
+    log_f_name = os.path.basename(os.path.splitext(__file__)[0])
+    configure_logging(f_name=log_f_name)
+    parser = argparse.ArgumentParser(description="RGW Dedup Test Automation")
+    parser.add_argument("-c", dest="config", help="RGW test yaml configuration")
+    parser.add_argument("-log_level", dest="log_level", default="info")
+    parser.add_argument("--rgw-node", dest="rgw_node", default="")
+    args = parser.parse_args()
+
+    yaml_file = args.config
+    config = Config(yaml_file)
+    config.read()
+    if args.log_level:
+        log.setLevel(args.log_level.upper())
+
+    ssh_con = None
+    if args.rgw_node:
+        ssh_con = utils.connect_remote(args.rgw_node)
+
+    test_type = getattr(config, "test_ops", {}).get("dedup_type", "sanity_large")
+    if isinstance(config.test_ops, dict):
+        test_type = config.test_ops.get("dedup_type", "sanity_large")
+
+    log.info(f"Running dedup test type: {test_type}")
+
+    test_func = TEST_DISPATCH.get(test_type)
+    if test_func is None:
+        raise TestExecError(
+            f"Unknown dedup_type: {test_type}. "
+            f"Available types: {list(TEST_DISPATCH.keys())}"
+        )
+
+    test_func(config, ssh_con)

--- a/rgw/v2/tests/s3_swift/test_dedup_pytest.py
+++ b/rgw/v2/tests/s3_swift/test_dedup_pytest.py
@@ -1,0 +1,2531 @@
+"""
+test_dedup_pytest.py - RGW Dedup Test Suite (Pytest Format)
+
+All 58 dedup test scenarios in pytest format with fixtures and markers.
+Reuses helpers from reusables/dedup.py -- no logic duplication.
+
+Usage:
+  pytest test_dedup_pytest.py -C config.yaml -v
+  pytest test_dedup_pytest.py -C config.yaml -m sanity
+  pytest test_dedup_pytest.py -C config.yaml -m enhancement
+  pytest test_dedup_pytest.py -C config.yaml -k "test_128_limit"
+
+Categories:
+  sanity       : S1-S5   (basic dedup operations)
+  feature      : S6-S15  (multipart, versioning, filters, lifecycle, etc.)
+  compression  : S16-S28 (compressed object dedup, cross-user)
+  bug          : B1-B7   (data integrity, regression, IBMCEPH-17201)
+  enhancement  : E1-E5   (128-limit boundary, multi-cycle, split-head)
+"""
+
+import hashlib
+import json
+import logging
+import os
+import random
+import sys
+import time
+
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(__file__, "../../../..")))
+
+import v2.lib.resource_op as s3lib
+import v2.utils.utils as utils
+from v2.tests.s3_swift import reusable
+from v2.tests.s3_swift.reusables import dedup as dedup_utils
+
+log = logging.getLogger()
+
+
+# =============================================================================
+# SANITY TESTS (S1-S5)
+# =============================================================================
+
+
+@pytest.mark.sanity
+def test_s1_sanity_large_objects(s3_client, bucket, rgw_config):
+    """S1: Upload 50 identical objects > 4MB, dedup, verify accessible."""
+    obj_count = getattr(rgw_config, "objects_count", None) or 50
+    obj_size = 5 * 1024
+
+    keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket, obj_count, obj_size, prefix="large-obj"
+    )
+
+    dedup_utils.run_dedup_estimate()
+    estimate_stats = dedup_utils.wait_for_dedup_completion()
+    assert estimate_stats.get("completed") is True, "Estimate did not complete"
+
+    dedup_utils.run_dedup_execute()
+    exec_stats = dedup_utils.wait_for_dedup_completion()
+    assert exec_stats.get("completed") is True, "Exec did not complete"
+
+    dedup_utils.validate_estimate_exec_ratio(estimate_stats, exec_stats)
+
+    dedup_utils.verify_all_objects_accessible(s3_client, bucket, keys)
+    dedup_utils.verify_all_objects_integrity(s3_client, bucket, keys, expected_md5)
+
+    parsed = dedup_utils.parse_dedup_stats(exec_stats)
+    assert parsed.get("deduped_count", 0) > 0, "Expected dedup to deduplicate objects"
+    dedup_utils.log_dedup_savings(exec_stats, obj_count * obj_size, "S1")
+
+
+@pytest.mark.sanity
+def test_s2_sanity_small_objects(s3_client, bucket):
+    """S2: Upload identical objects at various small sizes, dedup, verify split-head."""
+    sizes = [5 * 1024, 8 * 1024, 10 * 1024]
+    all_keys = []
+    md5_map = {}
+
+    for size in sizes:
+        size_label = f"{size // 1024}KB"
+        keys, md5_hash, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket, 30, size, prefix=f"small-{size_label}"
+        )
+        all_keys.extend(keys)
+        for k in keys:
+            md5_map[k] = md5_hash
+
+    dedup_utils.run_dedup_estimate()
+    estimate_stats = dedup_utils.wait_for_dedup_completion()
+    assert estimate_stats.get("completed") is True, "Estimate did not complete"
+
+    dedup_utils.run_dedup_execute()
+    exec_stats = dedup_utils.wait_for_dedup_completion()
+    assert exec_stats.get("completed") is True, "Exec did not complete"
+
+    dedup_utils.validate_estimate_exec_ratio(estimate_stats, exec_stats)
+
+    for key in all_keys:
+        dedup_utils.verify_object_integrity(s3_client, bucket, key, md5_map[key])
+    total_uploaded = sum(30 * s for s in sizes)
+    dedup_utils.log_dedup_savings(exec_stats, total_uploaded, "S2")
+
+
+@pytest.mark.sanity
+def test_s3_admin_ops_api(s3_client, bucket, admin_user, endpoint_url):
+    """S3: Verify dedup Admin OPS REST API (estimate, stats, exec)."""
+    ak = admin_user["access_key"]
+    sk = admin_user["secret_key"]
+    dedup_utils.ensure_dedup_caps("dedup-admin")
+
+    keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket, 20, 5 * 1024, prefix="api-obj"
+    )
+
+    resp = dedup_utils.dedup_api_request(
+        endpoint_url,
+        "estimate",
+        method="POST",
+        access_key=ak,
+        secret_key=sk,
+    )
+    assert (
+        resp.status_code == 200
+    ), f"Estimate API failed: {resp.status_code} {resp.text}"
+
+    estimate_stats = dedup_utils.wait_for_dedup_completion()
+    assert estimate_stats.get("completed") is True, "Estimate did not complete"
+
+    resp = dedup_utils.dedup_api_request(
+        endpoint_url,
+        "stats",
+        method="GET",
+        access_key=ak,
+        secret_key=sk,
+    )
+    assert resp.status_code == 200, f"Stats API failed: {resp.status_code} {resp.text}"
+    stats_json = resp.json()
+    assert "worker_stats" in stats_json, "Stats API missing worker_stats"
+    assert "md5_stats" in stats_json, "Stats API missing md5_stats"
+
+    resp = dedup_utils.dedup_api_request(
+        endpoint_url,
+        "exec",
+        method="POST",
+        access_key=ak,
+        secret_key=sk,
+        params={"yes-i-really-mean-it": ""},
+    )
+    assert resp.status_code == 200, f"Exec API failed: {resp.status_code} {resp.text}"
+
+    exec_stats = dedup_utils.wait_for_dedup_completion()
+    assert exec_stats.get("completed") is True, "Exec did not complete"
+
+    dedup_utils.validate_estimate_exec_ratio(estimate_stats, exec_stats)
+    dedup_utils.verify_all_objects_accessible(s3_client, bucket, keys)
+    dedup_utils.verify_all_objects_integrity(s3_client, bucket, keys, expected_md5)
+    dedup_utils.log_dedup_savings(exec_stats, 20 * 5 * 1024, "S3")
+
+
+@pytest.mark.sanity
+def test_s4_estimate_dry_run(s3_client, bucket):
+    """S4: Run estimate only, verify no data changes."""
+    dup_keys, dup_md5, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket, 30, 5 * 1024, prefix="dup-obj"
+    )
+
+    unique_keys = []
+    for i in range(10):
+        key = f"unique-obj-{i}"
+        s3_client.put_object(Bucket=bucket, Key=key, Body=os.urandom(5 * 1024))
+        unique_keys.append(key)
+
+    all_keys = dup_keys + unique_keys
+    pre_etags = {}
+    for key in all_keys:
+        resp = s3_client.head_object(Bucket=bucket, Key=key)
+        pre_etags[key] = resp["ETag"]
+
+    dedup_utils.run_dedup_estimate()
+    estimate_stats = dedup_utils.wait_for_dedup_completion()
+    assert estimate_stats.get("completed") is True, "Estimate did not complete"
+
+    for key in all_keys:
+        resp = s3_client.head_object(Bucket=bucket, Key=key)
+        assert pre_etags[key] == resp["ETag"], f"ETag changed for {key} after estimate"
+
+    dedup_utils.verify_all_objects_integrity(s3_client, bucket, dup_keys, dup_md5)
+
+
+@pytest.mark.sanity
+def test_s5_data_integrity(s3_client, bucket, rgw_config):
+    """S5: Upload 100 duplicates with known MD5, dedup, verify all match."""
+    obj_count = getattr(rgw_config, "objects_count", None) or 100
+    keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket, obj_count, 5 * 1024, prefix="integrity-obj"
+    )
+
+    pre_etags = {}
+    for key in keys:
+        resp = s3_client.head_object(Bucket=bucket, Key=key)
+        pre_etags[key] = resp["ETag"]
+
+    dedup_utils.run_dedup_execute()
+    exec_stats = dedup_utils.wait_for_dedup_completion()
+    assert exec_stats.get("completed") is True, "Exec did not complete"
+
+    dedup_utils.verify_all_objects_integrity(s3_client, bucket, keys, expected_md5)
+    dedup_utils.log_dedup_savings(exec_stats, obj_count * 5 * 1024, "S5")
+
+
+# =============================================================================
+# FEATURE TESTS (S6-S15)
+# =============================================================================
+
+
+@pytest.mark.feature
+@pytest.mark.slow
+def test_s6_multipart_objects(s3_client, bucket):
+    """S6: Upload 5 identical 50MB multipart objects, dedup, verify range GETs."""
+    mp_size = 20 * 1024 * 1024
+    keys, expected_md5, original_data = dedup_utils.upload_identical_multipart_objects(
+        s3_client, bucket, 5, mp_size, prefix="mp-obj"
+    )
+
+    dedup_utils.run_dedup_estimate()
+    estimate_stats = dedup_utils.wait_for_dedup_completion()
+    assert estimate_stats.get("completed") is True, "Estimate did not complete"
+
+    dedup_utils.run_dedup_execute()
+    exec_stats = dedup_utils.wait_for_dedup_completion()
+    assert exec_stats.get("completed") is True, "Exec did not complete"
+
+    dedup_utils.validate_estimate_exec_ratio(estimate_stats, exec_stats)
+
+    dedup_utils.verify_all_objects_accessible(s3_client, bucket, keys)
+    dedup_utils.verify_all_objects_integrity(s3_client, bucket, keys, expected_md5)
+
+    for key in keys:
+        dedup_utils.verify_range_get(
+            s3_client, bucket, key, original_data, 0, 1024 * 1024
+        )
+        mid = mp_size // 2
+        dedup_utils.verify_range_get(
+            s3_client, bucket, key, original_data, mid, mid + 1024 * 1024
+        )
+    dedup_utils.log_dedup_savings(exec_stats, 5 * mp_size, "S6")
+
+
+@pytest.mark.feature
+@pytest.mark.slow
+def test_s7_session_lifecycle(s3_client, bucket):
+    """S7: Test dedup pause/resume/abort controls."""
+    keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket, 100, 5 * 1024, prefix="lifecycle-obj"
+    )
+
+    dedup_utils.run_dedup_execute()
+    time.sleep(3)
+    dedup_utils.run_dedup_pause()
+    time.sleep(2)
+    dedup_utils.get_dedup_stats()
+    dedup_utils.run_dedup_resume()
+    exec_stats = dedup_utils.wait_for_dedup_completion()
+    assert exec_stats.get("completed") is True, "Exec did not complete after resume"
+
+    dedup_utils.verify_all_objects_accessible(s3_client, bucket, keys)
+    dedup_utils.verify_all_objects_integrity(s3_client, bucket, keys, expected_md5)
+    dedup_utils.log_dedup_savings(exec_stats, 100 * 5 * 1024, "S7")
+
+    keys2, _, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket, 50, 5 * 1024, prefix="lifecycle2-obj"
+    )
+    dedup_utils.run_dedup_execute()
+    time.sleep(3)
+    dedup_utils.run_dedup_abort()
+    time.sleep(2)
+
+    dedup_utils.verify_all_objects_accessible(s3_client, bucket, keys + keys2)
+
+
+@pytest.mark.feature
+def test_s8_ssec_exclusion(s3_client, bucket):
+    """S8: SSE-C encrypted objects excluded from dedup."""
+    utils.exec_shell_cmd("ceph config set client.rgw rgw_crypt_require_ssl false")
+    time.sleep(5)
+
+    ssec_keys, sse_key_b64, sse_key_md5 = dedup_utils.upload_ssec_objects(
+        s3_client, bucket, 20, 5 * 1024, prefix="ssec-obj"
+    )
+    plain_keys, plain_md5, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket, 20, 5 * 1024, prefix="plain-obj"
+    )
+
+    dedup_utils.run_dedup_estimate()
+    estimate_stats = dedup_utils.wait_for_dedup_completion()
+    assert estimate_stats.get("completed") is True, "Estimate did not complete"
+
+    dedup_utils.run_dedup_execute()
+    exec_stats = dedup_utils.wait_for_dedup_completion()
+    assert exec_stats.get("completed") is True, "Exec did not complete"
+
+    dedup_utils.validate_estimate_exec_ratio(estimate_stats, exec_stats)
+
+    dedup_utils.verify_all_objects_integrity(s3_client, bucket, plain_keys, plain_md5)
+
+    for key in ssec_keys:
+        resp = s3_client.get_object(
+            Bucket=bucket,
+            Key=key,
+            SSECustomerAlgorithm="AES256",
+            SSECustomerKey=sse_key_b64,
+            SSECustomerKeyMD5=sse_key_md5,
+        )
+        assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+    dedup_utils.log_dedup_savings(exec_stats, (20 + 20) * 5 * 1024, "S8")
+
+
+@pytest.mark.feature
+def test_s9_storage_class_dedup(s3_client, bucket, ssh_con):
+    """S9: Create storage class, upload objects to it, run dedup, verify integrity.
+
+    Steps:
+      1. Create data pool for the storage class
+      2. Enable rgw application on that pool
+      3. Add storage class to zonegroup and zone placement
+      4. Period update + restart RGW
+      5. Upload identical objects with that storage class
+      6. Run dedup estimate → wait for completed
+      7. Run dedup exec → wait for completed
+      8. Validate estimate/exec ratio match
+      9. Verify object integrity
+     10. Teardown storage class and pool
+    """
+    sc_name = "DEDUP_TEST_SC"
+    pool_name = "dedup-sc-test-pool"
+
+    dedup_utils.setup_storage_class(sc_name, pool_name, ssh_con)
+    try:
+        dedup_utils.wait_for_rgw_ready()
+        obj_count = 20
+        obj_size = 5 * 1024
+        keys, content_md5, _ = dedup_utils.upload_identical_objects_with_sc(
+            s3_client, bucket, obj_count, obj_size, sc_name, prefix="sc-obj"
+        )
+        log.info(
+            f"Uploaded {obj_count} objects to bucket {bucket} "
+            f"with StorageClass={sc_name}"
+        )
+
+        sc_file = dedup_utils.create_filter_list_file([sc_name])
+        try:
+            dedup_utils.run_dedup_estimate(allow_sc_file=sc_file)
+            estimate_stats = dedup_utils.wait_for_dedup_completion()
+            assert estimate_stats.get("completed") is True, "Estimate did not complete"
+
+            dedup_utils.run_dedup_execute(allow_sc_file=sc_file)
+            exec_stats = dedup_utils.wait_for_dedup_completion()
+            assert exec_stats.get("completed") is True, "Exec did not complete"
+
+            parsed = dedup_utils.parse_dedup_stats_full(exec_stats)
+            assert (
+                parsed["deduped_count"] > 0
+            ), f"Expected deduped_count > 0 for SC objects, got {parsed['deduped_count']}"
+            dedup_utils.validate_estimate_exec_ratio(estimate_stats, exec_stats)
+        finally:
+            os.remove(sc_file)
+
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket, keys)
+        dedup_utils.verify_all_objects_integrity(s3_client, bucket, keys, content_md5)
+        log.info("All objects in storage class verified post-dedup")
+        dedup_utils.log_dedup_savings(exec_stats, obj_count * obj_size, "S9")
+
+    finally:
+        dedup_utils.teardown_storage_class(sc_name, pool_name, ssh_con)
+
+
+@pytest.mark.feature
+@pytest.mark.slow
+def test_s10_lc_expiration(s3_client, bucket):
+    """S10: LC expiration with deduplicated objects."""
+    utils.exec_shell_cmd("ceph config set client.rgw rgw_lc_debug_interval 30")
+    time.sleep(3)
+
+    keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket, 20, 5 * 1024, prefix="lc-obj"
+    )
+
+    dedup_utils.run_dedup_estimate()
+    estimate_stats = dedup_utils.wait_for_dedup_completion()
+    assert estimate_stats.get("completed") is True, "Estimate did not complete"
+
+    dedup_utils.run_dedup_execute()
+    exec_stats = dedup_utils.wait_for_dedup_completion()
+    assert exec_stats.get("completed") is True, "Exec did not complete"
+
+    dedup_utils.validate_estimate_exec_ratio(estimate_stats, exec_stats)
+    dedup_utils.verify_all_objects_accessible(s3_client, bucket, keys)
+    dedup_utils.log_dedup_savings(exec_stats, 20 * 5 * 1024, "S10")
+
+    dedup_utils.set_lifecycle_expiration(s3_client, bucket, days=1)
+    time.sleep(90)
+
+    resp = s3_client.list_objects_v2(Bucket=bucket)
+    remaining = resp.get("KeyCount", 0)
+    log.info(f"Objects remaining after LC expiration: {remaining}")
+
+
+@pytest.mark.feature
+def test_s11_versioned_objects(s3_client, bucket, rgw_config):
+    """S11: Versioned objects dedup, verify all versions accessible."""
+    dedup_utils.enable_bucket_versioning(s3_client, bucket)
+
+    identical_data = dedup_utils.generate_identical_data(5 * 1024)
+    expected_md5 = hashlib.md5(identical_data).hexdigest()
+
+    version_count = getattr(rgw_config, "version_count", None) or 10
+    object_key = "versioned-dedup-object"
+    version_ids = []
+
+    for i in range(version_count):
+        resp = s3_client.put_object(Bucket=bucket, Key=object_key, Body=identical_data)
+        version_ids.append(resp["VersionId"])
+
+    dedup_utils.run_dedup_estimate()
+    estimate_stats = dedup_utils.wait_for_dedup_completion()
+    assert estimate_stats.get("completed") is True, "Estimate did not complete"
+
+    dedup_utils.run_dedup_execute()
+    exec_stats = dedup_utils.wait_for_dedup_completion()
+    assert exec_stats.get("completed") is True, "Exec did not complete"
+
+    dedup_utils.validate_estimate_exec_ratio(estimate_stats, exec_stats)
+
+    for vid in version_ids:
+        resp = s3_client.get_object(Bucket=bucket, Key=object_key, VersionId=vid)
+        body = resp["Body"].read()
+        actual_md5 = hashlib.md5(body).hexdigest()
+        assert actual_md5 == expected_md5, f"Version {vid} MD5 mismatch"
+
+    versions = dedup_utils.get_all_versions(s3_client, bucket, object_key)
+    assert len(versions) == version_count
+    dedup_utils.log_dedup_savings(exec_stats, version_count * 5 * 1024, "S11")
+
+
+@pytest.mark.feature
+def test_s12_s3_copy_dedup(s3_client, bucket):
+    """S12: S3 COPY to duplicate 20 times, dedup, verify all copies."""
+    source_data = dedup_utils.generate_identical_data(5 * 1024)
+    expected_md5 = hashlib.md5(source_data).hexdigest()
+
+    source_key = "source-large-obj"
+    s3_client.put_object(Bucket=bucket, Key=source_key, Body=source_data)
+
+    copy_keys = []
+    for i in range(20):
+        copy_key = f"copy-obj-{i}"
+        s3_client.copy_object(
+            Bucket=bucket,
+            Key=copy_key,
+            CopySource={"Bucket": bucket, "Key": source_key},
+        )
+        copy_keys.append(copy_key)
+
+    all_keys = [source_key] + copy_keys
+
+    dedup_utils.run_dedup_estimate()
+    estimate_stats = dedup_utils.wait_for_dedup_completion()
+    assert estimate_stats.get("completed") is True, "Estimate did not complete"
+
+    dedup_utils.run_dedup_execute()
+    exec_stats = dedup_utils.wait_for_dedup_completion()
+    assert exec_stats.get("completed") is True, "Exec did not complete"
+
+    dedup_utils.validate_estimate_exec_ratio(estimate_stats, exec_stats)
+
+    dedup_utils.verify_all_objects_integrity(s3_client, bucket, all_keys, expected_md5)
+    dedup_utils.log_dedup_savings(exec_stats, 21 * 5 * 1024, "S12")
+
+
+@pytest.mark.feature
+def test_s14_same_content_diff_metadata(s3_clients, test_context):
+    """S14: Same content, different metadata/tags/users. Metadata preserved."""
+    s3_client1, s3_client2 = s3_clients
+    bucket1 = f"dedup-meta1-{random.randint(1, 9999)}"
+    bucket2 = f"dedup-meta2-{random.randint(1, 9999)}"
+    s3_client1.create_bucket(Bucket=bucket1)
+    s3_client2.create_bucket(Bucket=bucket2)
+
+    test_context["buckets"].extend([bucket1, bucket2])
+    for bkt in [bucket1, bucket2]:
+        marker = dedup_utils.get_bucket_marker(bkt)
+        if marker:
+            test_context["bucket_markers"][bkt] = marker
+
+    try:
+        identical_data = dedup_utils.generate_identical_data(5 * 1024)
+        expected_md5 = hashlib.md5(identical_data).hexdigest()
+
+        s3_client1.put_object(
+            Bucket=bucket1,
+            Key="obj-user1-a",
+            Body=identical_data,
+            Metadata={"custom-key": "value-a"},
+            Tagging="env=prod",
+        )
+        s3_client1.put_object(
+            Bucket=bucket1,
+            Key="obj-user1-b",
+            Body=identical_data,
+            Metadata={"custom-key": "value-b"},
+            Tagging="env=staging",
+        )
+        s3_client2.put_object(
+            Bucket=bucket2,
+            Key="obj-user2-a",
+            Body=identical_data,
+            Metadata={"custom-key": "value-c"},
+        )
+        s3_client2.put_object(
+            Bucket=bucket2,
+            Key="obj-user2-b",
+            Body=identical_data,
+            Metadata={"custom-key": "value-d"},
+        )
+
+        dedup_utils.run_dedup_estimate()
+        estimate_stats = dedup_utils.wait_for_dedup_completion()
+        assert estimate_stats.get("completed") is True, "Estimate did not complete"
+
+        dedup_utils.run_dedup_execute()
+        exec_stats = dedup_utils.wait_for_dedup_completion()
+        assert exec_stats.get("completed") is True, "Exec did not complete"
+
+        dedup_utils.validate_estimate_exec_ratio(estimate_stats, exec_stats)
+
+        for client, bkt, key, expected_meta in [
+            (s3_client1, bucket1, "obj-user1-a", "value-a"),
+            (s3_client1, bucket1, "obj-user1-b", "value-b"),
+            (s3_client2, bucket2, "obj-user2-a", "value-c"),
+            (s3_client2, bucket2, "obj-user2-b", "value-d"),
+        ]:
+            dedup_utils.verify_object_integrity(client, bkt, key, expected_md5)
+            resp = client.head_object(Bucket=bkt, Key=key)
+            actual = resp.get("Metadata", {}).get("custom-key", "")
+            assert actual == expected_meta, f"Metadata mismatch for {bkt}/{key}"
+
+        tag_resp = s3_client1.get_object_tagging(Bucket=bucket1, Key="obj-user1-a")
+        tags = {t["Key"]: t["Value"] for t in tag_resp.get("TagSet", [])}
+        assert tags.get("env") == "prod"
+        dedup_utils.log_dedup_savings(exec_stats, 4 * 5 * 1024, "S14")
+    finally:
+        dedup_utils.cleanup_bucket(s3_client1, bucket1)
+        dedup_utils.cleanup_bucket(s3_client2, bucket2)
+
+
+@pytest.mark.feature
+@pytest.mark.slow
+def test_s15_concurrent_s3_ops(s3_client, bucket_factory):
+    """S15: Concurrent S3 workload during dedup."""
+    dedup_bucket = bucket_factory("dedup-concurrent")
+    workload_bucket = bucket_factory("workload-concurrent")
+
+    keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+        s3_client, dedup_bucket, 50, 5 * 1024, prefix="concurrent-obj"
+    )
+
+    dedup_utils.run_dedup_execute()
+    workload_results = dedup_utils.run_concurrent_s3_workload(
+        s3_client, workload_bucket, duration_secs=20, prefix="workload"
+    )
+    exec_stats = dedup_utils.wait_for_dedup_completion()
+    assert exec_stats.get("completed") is True, "Exec did not complete"
+
+    dedup_utils.verify_all_objects_accessible(s3_client, dedup_bucket, keys)
+    dedup_utils.verify_all_objects_integrity(
+        s3_client, dedup_bucket, keys, expected_md5
+    )
+
+    dedup_utils.log_dedup_savings(exec_stats, 50 * 5 * 1024, "S15")
+
+    assert workload_results["puts"] > 0
+    assert workload_results["gets"] > 0
+    error_rate = workload_results["errors"] / max(
+        workload_results["puts"]
+        + workload_results["gets"]
+        + workload_results["deletes"],
+        1,
+    )
+    assert error_rate < 0.05, f"Error rate too high: {error_rate:.2%}"
+
+
+# =============================================================================
+# COMPRESSION TESTS (S16-S20)
+# =============================================================================
+
+
+@pytest.mark.compression
+def test_s16_uncompressed_to_compressed(s3_client, bucket_factory, ssh_con):
+    """S16: Mode switch — upload uncompressed, switch to zlib, upload copies, dedup aligns all to compressed.
+
+    Mirrors upstream _dedup_mode_switch_test(start_compressed=False).
+    After dedup all objects in both buckets should be compressed.
+    """
+    obj_count = 20
+    obj_size = 5 * 1024
+
+    dedup_utils.disable_zone_compression(ssh_con)
+    bucket_a = bucket_factory("s16-uncomp")
+    keys_a, expected_md5, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket_a, obj_count, obj_size, prefix="mode-obj"
+    )
+    dedup_utils.assert_all_objects_compression(
+        bucket_a, keys_a, expect_compressed=False, tag="PRE-DEDUP bucket_a"
+    )
+
+    dedup_utils.enable_zone_compression("zlib", ssh_con)
+    try:
+        bucket_b = bucket_factory("s16-comp")
+        keys_b, md5_b, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_b, obj_count, obj_size, prefix="mode-obj"
+        )
+        assert expected_md5 == md5_b, "MD5 mismatch between buckets"
+        dedup_utils.assert_all_objects_compression(
+            bucket_b, keys_b, expect_compressed=True, tag="PRE-DEDUP bucket_b"
+        )
+
+        dedup_utils.run_dedup_estimate()
+        estimate_stats = dedup_utils.wait_for_dedup_completion()
+        assert estimate_stats.get("completed") is True, "Estimate did not complete"
+
+        dedup_utils.run_dedup_execute()
+        exec_stats = dedup_utils.wait_for_dedup_completion()
+        assert exec_stats.get("completed") is True, "Exec did not complete"
+
+        parsed = dedup_utils.parse_dedup_stats_full(exec_stats)
+        assert (
+            parsed["deduped_count"] > 0
+        ), f"Dedup should process objects across modes, got deduped_count={parsed['deduped_count']}"
+        assert (
+            parsed["compressed_objs"] > 0
+        ), f"Expected compressed_objs > 0, got {parsed['compressed_objs']}"
+        assert (
+            parsed["set_compression_on_tgt"] > 0
+        ), f"Expected set_compression_on_tgt > 0, got {parsed['set_compression_on_tgt']}"
+        log.info(
+            f"Mode switch dedup: deduped={parsed['deduped_count']}, "
+            f"compressed_objs={parsed['compressed_objs']}, "
+            f"set_compression_on_tgt={parsed['set_compression_on_tgt']}"
+        )
+
+        dedup_utils.assert_all_objects_compression(
+            bucket_a, keys_a, expect_compressed=True, tag="POST-DEDUP bucket_a"
+        )
+        dedup_utils.assert_all_objects_compression(
+            bucket_b, keys_b, expect_compressed=True, tag="POST-DEDUP bucket_b"
+        )
+
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_a, keys_a)
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_b, keys_b)
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_a, keys_a, expected_md5
+        )
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_b, keys_b, expected_md5
+        )
+        dedup_utils.log_dedup_savings(exec_stats, 2 * obj_count * obj_size, "S16")
+    finally:
+        dedup_utils.disable_zone_compression(ssh_con)
+
+
+@pytest.mark.compression
+def test_s17_compressed_to_uncompressed(s3_client, bucket_factory, ssh_con):
+    """S17: Mode switch — upload compressed, switch to none, upload copies, dedup aligns all to uncompressed.
+
+    Mirrors upstream _dedup_mode_switch_test(start_compressed=True).
+    After dedup all objects in both buckets should be uncompressed.
+    """
+    obj_count = 20
+    obj_size = 5 * 1024
+
+    dedup_utils.enable_zone_compression("zlib", ssh_con)
+    try:
+        bucket_a = bucket_factory("s17-comp")
+        keys_a, expected_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_a, obj_count, obj_size, prefix="mode-obj"
+        )
+        dedup_utils.assert_all_objects_compression(
+            bucket_a, keys_a, expect_compressed=True, tag="PRE-DEDUP bucket_a"
+        )
+
+        dedup_utils.disable_zone_compression(ssh_con)
+        bucket_b = bucket_factory("s17-uncomp")
+        keys_b, md5_b, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_b, obj_count, obj_size, prefix="mode-obj"
+        )
+        assert expected_md5 == md5_b, "MD5 mismatch between buckets"
+        dedup_utils.assert_all_objects_compression(
+            bucket_b, keys_b, expect_compressed=False, tag="PRE-DEDUP bucket_b"
+        )
+
+        dedup_utils.run_dedup_estimate()
+        estimate_stats = dedup_utils.wait_for_dedup_completion()
+        assert estimate_stats.get("completed") is True, "Estimate did not complete"
+
+        dedup_utils.run_dedup_execute()
+        exec_stats = dedup_utils.wait_for_dedup_completion()
+        assert exec_stats.get("completed") is True, "Exec did not complete"
+
+        parsed = dedup_utils.parse_dedup_stats_full(exec_stats)
+        assert (
+            parsed["deduped_count"] > 0
+        ), f"Dedup should process objects across modes, got deduped_count={parsed['deduped_count']}"
+        assert (
+            parsed["compressed_objs"] > 0
+        ), f"Expected compressed_objs > 0, got {parsed['compressed_objs']}"
+        assert (
+            parsed["clear_compression_on_tgt"] > 0
+        ), f"Expected clear_compression_on_tgt > 0, got {parsed['clear_compression_on_tgt']}"
+        log.info(
+            f"Mode switch dedup: deduped={parsed['deduped_count']}, "
+            f"compressed_objs={parsed['compressed_objs']}, "
+            f"clear_compression_on_tgt={parsed['clear_compression_on_tgt']}"
+        )
+
+        dedup_utils.assert_all_objects_compression(
+            bucket_a, keys_a, expect_compressed=False, tag="POST-DEDUP bucket_a"
+        )
+        dedup_utils.assert_all_objects_compression(
+            bucket_b, keys_b, expect_compressed=False, tag="POST-DEDUP bucket_b"
+        )
+
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_a, keys_a)
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_b, keys_b)
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_a, keys_a, expected_md5
+        )
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_b, keys_b, expected_md5
+        )
+        dedup_utils.log_dedup_savings(exec_stats, 2 * obj_count * obj_size, "S17")
+    finally:
+        dedup_utils.disable_zone_compression(ssh_con)
+
+
+@pytest.mark.compression
+def test_s18_per_sc_compression_cache(s3_client, bucket_factory, ssh_con):
+    """S18: Two storage classes with opposite compression, flip, dedup aligns each SC independently.
+
+    Mirrors upstream test_dedup_placement_compression_cache_per_storage_class.
+    SC1=STANDARD (none), SC2=LUKEWARM (zlib) -> upload copy-0 to each.
+    Flip: SC1=zlib, SC2=none -> upload copy-1 to each.
+    After dedup: SC1 all compressed, SC2 all uncompressed.
+    """
+    sc_name = "LUKEWARM"
+    pool_name = "lukewarm-test-pool"
+    obj_count = 10
+    obj_size = 5 * 1024
+
+    dedup_utils.setup_storage_class(sc_name, pool_name, ssh_con)
+    try:
+        dedup_utils.set_storage_class_compression("STANDARD", "none", ssh_con)
+        dedup_utils.set_storage_class_compression(sc_name, "zlib", ssh_con)
+
+        bucket_std = bucket_factory("s18-std")
+        bucket_lw = bucket_factory("s18-lw")
+
+        keys_std_0, md5_std, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_std, obj_count, obj_size, prefix="copy-0"
+        )
+        keys_lw_0, md5_lw, _ = dedup_utils.upload_identical_objects_with_sc(
+            s3_client, bucket_lw, obj_count, obj_size, sc_name, prefix="copy-0"
+        )
+
+        dedup_utils.assert_all_objects_compression(
+            bucket_std, keys_std_0, expect_compressed=False, tag="PRE-DEDUP SC1 copy-0"
+        )
+        dedup_utils.assert_all_objects_compression(
+            bucket_lw, keys_lw_0, expect_compressed=True, tag="PRE-DEDUP SC2 copy-0"
+        )
+
+        dedup_utils.set_storage_class_compression("STANDARD", "zlib", ssh_con)
+        dedup_utils.set_storage_class_compression(sc_name, "none", ssh_con)
+
+        keys_std_1, md5_std_1, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_std, obj_count, obj_size, prefix="copy-1"
+        )
+        keys_lw_1, md5_lw_1, _ = dedup_utils.upload_identical_objects_with_sc(
+            s3_client, bucket_lw, obj_count, obj_size, sc_name, prefix="copy-1"
+        )
+
+        dedup_utils.assert_all_objects_compression(
+            bucket_std, keys_std_1, expect_compressed=True, tag="PRE-DEDUP SC1 copy-1"
+        )
+        dedup_utils.assert_all_objects_compression(
+            bucket_lw, keys_lw_1, expect_compressed=False, tag="PRE-DEDUP SC2 copy-1"
+        )
+
+        dedup_utils.run_dedup_estimate()
+        estimate_stats = dedup_utils.wait_for_dedup_completion()
+        assert estimate_stats.get("completed") is True, "Estimate did not complete"
+
+        dedup_utils.run_dedup_execute()
+        exec_stats = dedup_utils.wait_for_dedup_completion()
+        assert exec_stats.get("completed") is True, "Exec did not complete"
+
+        parsed = dedup_utils.parse_dedup_stats_full(exec_stats)
+        assert (
+            parsed["deduped_count"] > 0
+        ), f"Expected deduped_count > 0, got {parsed['deduped_count']}"
+        assert (
+            parsed["set_compression_on_tgt"] > 0
+        ), f"Expected set_compression_on_tgt > 0, got {parsed['set_compression_on_tgt']}"
+        assert (
+            parsed["clear_compression_on_tgt"] > 0
+        ), f"Expected clear_compression_on_tgt > 0, got {parsed['clear_compression_on_tgt']}"
+        log.info(
+            f"Per-SC compression cache: deduped={parsed['deduped_count']}, "
+            f"set_compression_on_tgt={parsed['set_compression_on_tgt']}, "
+            f"clear_compression_on_tgt={parsed['clear_compression_on_tgt']}"
+        )
+
+        all_std_keys = keys_std_0 + keys_std_1
+        all_lw_keys = keys_lw_0 + keys_lw_1
+        dedup_utils.assert_all_objects_compression(
+            bucket_std, all_std_keys, expect_compressed=True, tag="POST-DEDUP SC1"
+        )
+        dedup_utils.assert_all_objects_compression(
+            bucket_lw, all_lw_keys, expect_compressed=False, tag="POST-DEDUP SC2"
+        )
+
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_std, all_std_keys)
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket_lw, all_lw_keys)
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_std, all_std_keys, md5_std
+        )
+        dedup_utils.verify_all_objects_integrity(
+            s3_client, bucket_lw, all_lw_keys, md5_lw
+        )
+        dedup_utils.log_dedup_savings(exec_stats, 4 * obj_count * obj_size, "S18")
+    finally:
+        dedup_utils.set_storage_class_compression("STANDARD", "none", ssh_con)
+        dedup_utils.teardown_storage_class(sc_name, pool_name, ssh_con)
+
+
+@pytest.mark.compression
+def test_s19_inc_compressed_shared_manifest(s3_client, bucket_factory, ssh_con):
+    """S19: Incremental dedup — start compressed, switch mode, shared_manifest SRC priority preserved.
+
+    Mirrors upstream _dedup_inc_shared_manifest_test(start_compressed=True).
+    Cycle 1: compressed bucket_a + bucket_b, dedup.
+    Cycle 2: switch to none, add bucket_c (uncompressed), dedup again.
+    Post-dedup: ALL 3 buckets compressed (shared_manifest SRC from cycle 1 wins).
+    """
+    obj_count = 20
+    obj_size = 5 * 1024
+
+    dedup_utils.enable_zone_compression("zlib", ssh_con)
+    try:
+        bucket_a = bucket_factory("s19-a")
+        bucket_b = bucket_factory("s19-b")
+        keys_a, expected_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_a, obj_count, obj_size, prefix="inc-obj"
+        )
+        keys_b, md5_b, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_b, obj_count, obj_size, prefix="inc-obj"
+        )
+        assert expected_md5 == md5_b
+
+        dedup_utils.assert_all_objects_compression(
+            bucket_a, keys_a, expect_compressed=True, tag="PRE-DEDUP-1 bucket_a"
+        )
+        dedup_utils.assert_all_objects_compression(
+            bucket_b, keys_b, expect_compressed=True, tag="PRE-DEDUP-1 bucket_b"
+        )
+
+        dedup_utils.run_dedup_estimate()
+        dedup_utils.wait_for_dedup_completion()
+        dedup_utils.run_dedup_execute()
+        exec_stats_1 = dedup_utils.wait_for_dedup_completion()
+        assert exec_stats_1.get("completed") is True, "Cycle 1 exec did not complete"
+
+        parsed_1 = dedup_utils.parse_dedup_stats_full(exec_stats_1)
+        assert (
+            parsed_1["deduped_count"] > 0
+        ), f"Cycle 1: expected deduped_count > 0, got {parsed_1['deduped_count']}"
+        log.info(f"Cycle 1 complete: deduped={parsed_1['deduped_count']}")
+
+        dedup_utils.disable_zone_compression(ssh_con)
+        bucket_c = bucket_factory("s19-c")
+        keys_c, md5_c, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_c, obj_count, obj_size, prefix="inc-obj"
+        )
+        assert expected_md5 == md5_c
+        dedup_utils.assert_all_objects_compression(
+            bucket_c, keys_c, expect_compressed=False, tag="PRE-DEDUP-2 bucket_c"
+        )
+
+        dedup_utils.run_dedup_estimate()
+        dedup_utils.wait_for_dedup_completion()
+        dedup_utils.run_dedup_execute()
+        exec_stats_2 = dedup_utils.wait_for_dedup_completion()
+        assert exec_stats_2.get("completed") is True, "Cycle 2 exec did not complete"
+
+        parsed_2 = dedup_utils.parse_dedup_stats_full(exec_stats_2)
+        assert (
+            parsed_2["deduped_count"] > 0
+        ), f"Cycle 2: expected deduped_count > 0, got {parsed_2['deduped_count']}"
+        assert (
+            parsed_2["skipped_shared_manifest"] > 0
+        ), f"Cycle 2: expected skipped_shared_manifest > 0, got {parsed_2['skipped_shared_manifest']}"
+        log.info(
+            f"Cycle 2: deduped={parsed_2['deduped_count']}, "
+            f"skipped_shared_manifest={parsed_2['skipped_shared_manifest']}, "
+            f"set_compression_on_tgt={parsed_2.get('set_compression_on_tgt', 0)}"
+        )
+
+        dedup_utils.assert_all_objects_compression(
+            bucket_a, keys_a, expect_compressed=True, tag="POST-DEDUP-2 bucket_a"
+        )
+        dedup_utils.assert_all_objects_compression(
+            bucket_b, keys_b, expect_compressed=True, tag="POST-DEDUP-2 bucket_b"
+        )
+        dedup_utils.assert_all_objects_compression(
+            bucket_c, keys_c, expect_compressed=True, tag="POST-DEDUP-2 bucket_c"
+        )
+
+        for bkt, keys in [(bucket_a, keys_a), (bucket_b, keys_b), (bucket_c, keys_c)]:
+            dedup_utils.verify_all_objects_accessible(s3_client, bkt, keys)
+            dedup_utils.verify_all_objects_integrity(s3_client, bkt, keys, expected_md5)
+        dedup_utils.log_dedup_savings(exec_stats_2, 3 * obj_count * obj_size, "S19")
+    finally:
+        dedup_utils.disable_zone_compression(ssh_con)
+
+
+@pytest.mark.compression
+def test_s20_inc_uncompressed_shared_manifest(s3_client, bucket_factory, ssh_con):
+    """S20: Incremental dedup — start uncompressed, switch mode, shared_manifest SRC priority preserved.
+
+    Mirrors upstream _dedup_inc_shared_manifest_test(start_compressed=False).
+    Cycle 1: uncompressed bucket_a + bucket_b, dedup.
+    Cycle 2: switch to zlib, add bucket_c (compressed), dedup again.
+    Post-dedup: ALL 3 buckets uncompressed (shared_manifest SRC from cycle 1 wins).
+    """
+    obj_count = 20
+    obj_size = 5 * 1024
+
+    dedup_utils.disable_zone_compression(ssh_con)
+    bucket_a = bucket_factory("s20-a")
+    bucket_b = bucket_factory("s20-b")
+    keys_a, expected_md5, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket_a, obj_count, obj_size, prefix="inc-obj"
+    )
+    keys_b, md5_b, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket_b, obj_count, obj_size, prefix="inc-obj"
+    )
+    assert expected_md5 == md5_b
+
+    dedup_utils.assert_all_objects_compression(
+        bucket_a, keys_a, expect_compressed=False, tag="PRE-DEDUP-1 bucket_a"
+    )
+    dedup_utils.assert_all_objects_compression(
+        bucket_b, keys_b, expect_compressed=False, tag="PRE-DEDUP-1 bucket_b"
+    )
+
+    dedup_utils.run_dedup_estimate()
+    dedup_utils.wait_for_dedup_completion()
+    dedup_utils.run_dedup_execute()
+    exec_stats_1 = dedup_utils.wait_for_dedup_completion()
+    assert exec_stats_1.get("completed") is True, "Cycle 1 exec did not complete"
+
+    parsed_1 = dedup_utils.parse_dedup_stats_full(exec_stats_1)
+    assert (
+        parsed_1["deduped_count"] > 0
+    ), f"Cycle 1: expected deduped_count > 0, got {parsed_1['deduped_count']}"
+    log.info(f"Cycle 1 complete: deduped={parsed_1['deduped_count']}")
+
+    dedup_utils.enable_zone_compression("zlib", ssh_con)
+    try:
+        bucket_c = bucket_factory("s20-c")
+        keys_c, md5_c, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket_c, obj_count, obj_size, prefix="inc-obj"
+        )
+        assert expected_md5 == md5_c
+        dedup_utils.assert_all_objects_compression(
+            bucket_c, keys_c, expect_compressed=True, tag="PRE-DEDUP-2 bucket_c"
+        )
+
+        dedup_utils.run_dedup_estimate()
+        dedup_utils.wait_for_dedup_completion()
+        dedup_utils.run_dedup_execute()
+        exec_stats_2 = dedup_utils.wait_for_dedup_completion()
+        assert exec_stats_2.get("completed") is True, "Cycle 2 exec did not complete"
+
+        parsed_2 = dedup_utils.parse_dedup_stats_full(exec_stats_2)
+        assert (
+            parsed_2["deduped_count"] > 0
+        ), f"Cycle 2: expected deduped_count > 0, got {parsed_2['deduped_count']}"
+        assert (
+            parsed_2["skipped_shared_manifest"] > 0
+        ), f"Cycle 2: expected skipped_shared_manifest > 0, got {parsed_2['skipped_shared_manifest']}"
+        log.info(
+            f"Cycle 2: deduped={parsed_2['deduped_count']}, "
+            f"skipped_shared_manifest={parsed_2['skipped_shared_manifest']}, "
+            f"clear_compression_on_tgt={parsed_2.get('clear_compression_on_tgt', 0)}"
+        )
+
+        dedup_utils.assert_all_objects_compression(
+            bucket_a, keys_a, expect_compressed=False, tag="POST-DEDUP-2 bucket_a"
+        )
+        dedup_utils.assert_all_objects_compression(
+            bucket_b, keys_b, expect_compressed=False, tag="POST-DEDUP-2 bucket_b"
+        )
+        dedup_utils.assert_all_objects_compression(
+            bucket_c, keys_c, expect_compressed=False, tag="POST-DEDUP-2 bucket_c"
+        )
+
+        for bkt, keys in [(bucket_a, keys_a), (bucket_b, keys_b), (bucket_c, keys_c)]:
+            dedup_utils.verify_all_objects_accessible(s3_client, bkt, keys)
+            dedup_utils.verify_all_objects_integrity(s3_client, bkt, keys, expected_md5)
+        dedup_utils.log_dedup_savings(exec_stats_2, 3 * obj_count * obj_size, "S20")
+    finally:
+        dedup_utils.disable_zone_compression(ssh_con)
+
+
+# =============================================================================
+# FILTER AND STATS TESTS (S22-S26)
+# =============================================================================
+
+
+@pytest.mark.compression
+def test_s22_filter_bucket_list_parsing(s3_client, bucket):
+    """S22: Filter file parsing — mutual exclusivity, missing file, empty file errors."""
+    obj_size = 5 * 1024
+    dedup_utils.upload_identical_objects(
+        s3_client, bucket, 5, obj_size, prefix="parse-obj"
+    )
+
+    allow_file = dedup_utils.create_filter_list_file([bucket])
+    deny_file = dedup_utils.create_filter_list_file(["other-bucket"])
+    try:
+        out, rc = dedup_utils.run_dedup_cmd_with_rc(
+            f"radosgw-admin dedup estimate "
+            f"--allow-bucket-list {allow_file} --deny-bucket-list {deny_file}"
+        )
+        assert (
+            rc != 0
+        ), f"Mutual exclusivity: allow+deny bucket lists should fail, rc={rc}"
+        log.info(f"Mutual exclusivity rejected as expected (rc={rc})")
+    finally:
+        os.remove(allow_file)
+        os.remove(deny_file)
+
+    out, rc = dedup_utils.run_dedup_cmd_with_rc(
+        "radosgw-admin dedup estimate --allow-bucket-list /tmp/nonexistent-filter-file.txt"
+    )
+    assert rc != 0, f"Non-existent file should fail, rc={rc}"
+    log.info(f"Non-existent file rejected as expected (rc={rc})")
+
+    empty_file = dedup_utils.create_filter_list_file([])
+    try:
+        out, rc = dedup_utils.run_dedup_cmd_with_rc(
+            f"radosgw-admin dedup estimate --allow-bucket-list {empty_file}"
+        )
+        assert rc != 0, f"Empty filter file should fail, rc={rc}"
+        log.info(f"Empty file rejected as expected (rc={rc})")
+    finally:
+        os.remove(empty_file)
+
+
+@pytest.mark.compression
+def test_s23_filter_sc_list_parsing(s3_client, bucket):
+    """S23: SC filter file parsing — mutual exclusivity, missing file, empty file errors."""
+    obj_size = 5 * 1024
+    dedup_utils.upload_identical_objects(
+        s3_client, bucket, 5, obj_size, prefix="parse-obj"
+    )
+
+    allow_file = dedup_utils.create_filter_list_file(["STANDARD"])
+    deny_file = dedup_utils.create_filter_list_file(["LUKEWARM"])
+    try:
+        out, rc = dedup_utils.run_dedup_cmd_with_rc(
+            f"radosgw-admin dedup estimate "
+            f"--allow-storage-class-list {allow_file} "
+            f"--deny-storage-class-list {deny_file}"
+        )
+        assert rc != 0, f"Mutual exclusivity: allow+deny SC lists should fail, rc={rc}"
+        log.info(f"SC mutual exclusivity rejected as expected (rc={rc})")
+    finally:
+        os.remove(allow_file)
+        os.remove(deny_file)
+
+    out, rc = dedup_utils.run_dedup_cmd_with_rc(
+        "radosgw-admin dedup estimate "
+        "--allow-storage-class-list /tmp/nonexistent-sc-filter.txt"
+    )
+    assert rc != 0, f"Non-existent SC file should fail, rc={rc}"
+    log.info(f"Non-existent SC file rejected as expected (rc={rc})")
+
+    empty_file = dedup_utils.create_filter_list_file([])
+    try:
+        out, rc = dedup_utils.run_dedup_cmd_with_rc(
+            f"radosgw-admin dedup estimate " f"--allow-storage-class-list {empty_file}"
+        )
+        assert rc != 0, f"Empty SC filter file should fail, rc={rc}"
+        log.info(f"Empty SC file rejected as expected (rc={rc})")
+    finally:
+        os.remove(empty_file)
+
+
+@pytest.mark.compression
+def test_s24_filter_sc_estimate(s3_client, bucket):
+    """S24: SC filter on estimate — allow STANDARD finds duplicates, deny STANDARD skips all."""
+    obj_count = 20
+    obj_size = 5 * 1024
+    dedup_utils.upload_identical_objects(
+        s3_client, bucket, obj_count, obj_size, prefix="sc-filter-obj"
+    )
+
+    allow_file = dedup_utils.create_filter_list_file(["STANDARD"])
+    try:
+        dedup_utils.run_dedup_estimate(allow_sc_file=allow_file)
+        stats_allow = dedup_utils.wait_for_dedup_completion()
+        assert stats_allow.get("completed") is True, "Allow estimate did not complete"
+        parsed_allow = dedup_utils.parse_dedup_stats_full(stats_allow)
+        assert (
+            parsed_allow["ingress_count"] > 0
+        ), f"Allow STANDARD: expected ingress_count > 0, got {parsed_allow['ingress_count']}"
+        log.info(
+            f"Allow STANDARD estimate: ingress={parsed_allow['ingress_count']}, "
+            f"ingress_skip_filtered_sc={parsed_allow.get('ingress_skip_filtered_sc', 0)}"
+        )
+    finally:
+        os.remove(allow_file)
+
+    deny_file = dedup_utils.create_filter_list_file(["STANDARD"])
+    try:
+        dedup_utils.run_dedup_estimate(deny_sc_file=deny_file)
+        stats_deny = dedup_utils.wait_for_dedup_completion()
+        assert stats_deny.get("completed") is True, "Deny estimate did not complete"
+        parsed_deny = dedup_utils.parse_dedup_stats_full(stats_deny)
+        assert parsed_deny.get("ingress_skip_filtered_sc", 0) > 0, (
+            f"Deny STANDARD: expected ingress_skip_filtered_sc > 0, "
+            f"got {parsed_deny.get('ingress_skip_filtered_sc', 0)}"
+        )
+        log.info(
+            f"Deny STANDARD estimate: ingress_skip_filtered_sc="
+            f"{parsed_deny.get('ingress_skip_filtered_sc', 0)}"
+        )
+    finally:
+        os.remove(deny_file)
+
+
+@pytest.mark.compression
+def test_s25_filter_sc_exec(s3_client, bucket):
+    """S25: SC filter on exec — allow STANDARD dedupes, deny STANDARD dedupes nothing."""
+    obj_count = 20
+    obj_size = 5 * 1024
+    keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket, obj_count, obj_size, prefix="sc-exec-obj"
+    )
+
+    deny_file = dedup_utils.create_filter_list_file(["STANDARD"])
+    try:
+        dedup_utils.run_dedup_estimate(deny_sc_file=deny_file)
+        dedup_utils.wait_for_dedup_completion()
+        dedup_utils.run_dedup_execute(deny_sc_file=deny_file)
+        exec_deny = dedup_utils.wait_for_dedup_completion()
+        assert exec_deny.get("completed") is True, "Deny exec did not complete"
+        parsed_deny = dedup_utils.parse_dedup_stats_full(exec_deny)
+        assert (
+            parsed_deny["deduped_count"] == 0
+        ), f"Deny STANDARD: expected deduped_count == 0, got {parsed_deny['deduped_count']}"
+        log.info(f"Deny STANDARD exec: deduped_count={parsed_deny['deduped_count']}")
+    finally:
+        os.remove(deny_file)
+
+    dedup_utils.verify_all_objects_accessible(s3_client, bucket, keys)
+    dedup_utils.verify_all_objects_integrity(s3_client, bucket, keys, expected_md5)
+
+    allow_file = dedup_utils.create_filter_list_file(["STANDARD"])
+    try:
+        dedup_utils.run_dedup_estimate(allow_sc_file=allow_file)
+        dedup_utils.wait_for_dedup_completion()
+        dedup_utils.run_dedup_execute(allow_sc_file=allow_file)
+        exec_allow = dedup_utils.wait_for_dedup_completion()
+        assert exec_allow.get("completed") is True, "Allow exec did not complete"
+        parsed_allow = dedup_utils.parse_dedup_stats_full(exec_allow)
+        assert (
+            parsed_allow["deduped_count"] > 0
+        ), f"Allow STANDARD: expected deduped_count > 0, got {parsed_allow['deduped_count']}"
+        log.info(f"Allow STANDARD exec: deduped_count={parsed_allow['deduped_count']}")
+    finally:
+        os.remove(allow_file)
+
+    dedup_utils.verify_all_objects_accessible(s3_client, bucket, keys)
+    dedup_utils.verify_all_objects_integrity(s3_client, bucket, keys, expected_md5)
+    dedup_utils.log_dedup_savings(exec_allow, obj_count * obj_size, "S25")
+
+
+@pytest.mark.compression
+def test_s26_compression_stats_counters(s3_client, bucket, ssh_con):
+    """S26: Validate compression stat counters after dedup on compressed objects."""
+    obj_count = 30
+    obj_size = 5 * 1024
+
+    dedup_utils.enable_zone_compression("zlib", ssh_con)
+    try:
+        keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client, bucket, obj_count, obj_size, prefix="compstats-obj"
+        )
+        dedup_utils.assert_all_objects_compression(
+            bucket, keys, expect_compressed=True, tag="PRE-DEDUP"
+        )
+
+        dedup_utils.run_dedup_estimate()
+        dedup_utils.wait_for_dedup_completion()
+        dedup_utils.run_dedup_execute()
+        exec_stats = dedup_utils.wait_for_dedup_completion()
+        assert exec_stats.get("completed") is True, "Exec did not complete"
+
+        parsed = dedup_utils.parse_dedup_stats_full(exec_stats)
+        assert (
+            parsed["deduped_count"] > 0
+        ), f"Expected deduped_count > 0, got {parsed['deduped_count']}"
+        assert (
+            parsed["compressed_objs"] > 0
+        ), f"Expected compressed_objs > 0, got {parsed['compressed_objs']}"
+        assert (
+            parsed["compressed_bytes"] > 0
+        ), f"Expected compressed_bytes > 0, got {parsed['compressed_bytes']}"
+        assert (
+            parsed["deduped_compressed_objects"] > 0
+        ), f"Expected deduped_compressed_objects > 0, got {parsed['deduped_compressed_objects']}"
+        log.info(
+            f"Compression stats: compressed_objs={parsed['compressed_objs']}, "
+            f"compressed_bytes={parsed['compressed_bytes']}, "
+            f"deduped_compressed_objects={parsed['deduped_compressed_objects']}"
+        )
+
+        dedup_utils.assert_all_objects_compression(
+            bucket, keys, expect_compressed=True, tag="POST-DEDUP"
+        )
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket, keys)
+        dedup_utils.verify_all_objects_integrity(s3_client, bucket, keys, expected_md5)
+        dedup_utils.log_dedup_savings(exec_stats, obj_count * obj_size, "S26")
+    finally:
+        dedup_utils.disable_zone_compression(ssh_con)
+
+
+@pytest.mark.compression
+def test_s27_cross_user_compressed_to_uncompressed(s3_clients, test_context, ssh_con):
+    """S27: Cross-user dedup with compression mode switch — compressed to uncompressed.
+
+    user1 uploads to bucket_a with zlib compression enabled.
+    user2 uploads identical content to bucket_b with compression disabled.
+    After dedup, all objects in both buckets should be uncompressed.
+    Verifies dedup works across objects owned by different RGW users.
+    """
+    s3_client1, s3_client2 = s3_clients
+    obj_count = 20
+    obj_size = 5 * 1024
+    bucket_a = f"s27-comp-{random.randint(1, 9999)}"
+    bucket_b = f"s27-uncomp-{random.randint(1, 9999)}"
+
+    dedup_utils.enable_zone_compression("zlib", ssh_con)
+    try:
+        s3_client1.create_bucket(Bucket=bucket_a)
+        test_context["buckets"].append(bucket_a)
+        marker_a = dedup_utils.get_bucket_marker(bucket_a)
+        if marker_a:
+            test_context["bucket_markers"][bucket_a] = marker_a
+
+        keys_a, expected_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client1, bucket_a, obj_count, obj_size, prefix="mode-obj"
+        )
+        dedup_utils.assert_all_objects_compression(
+            bucket_a, keys_a, expect_compressed=True, tag="PRE-DEDUP bucket_a"
+        )
+
+        dedup_utils.disable_zone_compression(ssh_con)
+
+        s3_client2.create_bucket(Bucket=bucket_b)
+        test_context["buckets"].append(bucket_b)
+        marker_b = dedup_utils.get_bucket_marker(bucket_b)
+        if marker_b:
+            test_context["bucket_markers"][bucket_b] = marker_b
+
+        keys_b, md5_b, _ = dedup_utils.upload_identical_objects(
+            s3_client2, bucket_b, obj_count, obj_size, prefix="mode-obj"
+        )
+        assert expected_md5 == md5_b, "MD5 mismatch between buckets"
+        dedup_utils.assert_all_objects_compression(
+            bucket_b, keys_b, expect_compressed=False, tag="PRE-DEDUP bucket_b"
+        )
+
+        dedup_utils.run_dedup_estimate()
+        estimate_stats = dedup_utils.wait_for_dedup_completion()
+        assert estimate_stats.get("completed") is True, "Estimate did not complete"
+
+        dedup_utils.run_dedup_execute()
+        exec_stats = dedup_utils.wait_for_dedup_completion()
+        assert exec_stats.get("completed") is True, "Exec did not complete"
+
+        parsed = dedup_utils.parse_dedup_stats_full(exec_stats)
+        assert (
+            parsed["deduped_count"] > 0
+        ), f"Cross-user dedup should process objects, got deduped_count={parsed['deduped_count']}"
+        assert (
+            parsed["compressed_objs"] > 0
+        ), f"Expected compressed_objs > 0, got {parsed['compressed_objs']}"
+        assert (
+            parsed["clear_compression_on_tgt"] > 0
+        ), f"Expected clear_compression_on_tgt > 0, got {parsed['clear_compression_on_tgt']}"
+        log.info(
+            f"Cross-user dedup (comp->uncomp): deduped={parsed['deduped_count']}, "
+            f"compressed_objs={parsed['compressed_objs']}, "
+            f"clear_compression_on_tgt={parsed['clear_compression_on_tgt']}"
+        )
+
+        dedup_utils.assert_all_objects_compression(
+            bucket_a, keys_a, expect_compressed=False, tag="POST-DEDUP bucket_a"
+        )
+        dedup_utils.assert_all_objects_compression(
+            bucket_b, keys_b, expect_compressed=False, tag="POST-DEDUP bucket_b"
+        )
+
+        dedup_utils.verify_all_objects_accessible(s3_client1, bucket_a, keys_a)
+        dedup_utils.verify_all_objects_accessible(s3_client2, bucket_b, keys_b)
+        dedup_utils.verify_all_objects_integrity(
+            s3_client1, bucket_a, keys_a, expected_md5
+        )
+        dedup_utils.verify_all_objects_integrity(
+            s3_client2, bucket_b, keys_b, expected_md5
+        )
+        dedup_utils.log_dedup_savings(exec_stats, 2 * obj_count * obj_size, "S27")
+    finally:
+        dedup_utils.disable_zone_compression(ssh_con)
+        dedup_utils.cleanup_bucket(s3_client1, bucket_a)
+        dedup_utils.cleanup_bucket(s3_client2, bucket_b)
+
+
+@pytest.mark.compression
+def test_s28_cross_user_uncompressed_to_compressed(s3_clients, test_context, ssh_con):
+    """S28: Cross-user dedup with compression mode switch — uncompressed to compressed.
+
+    user1 uploads to bucket_a with compression disabled.
+    user2 uploads identical content to bucket_b with zlib compression enabled.
+    After dedup, all objects in both buckets should be compressed.
+    Verifies dedup works across objects owned by different RGW users.
+    """
+    s3_client1, s3_client2 = s3_clients
+    obj_count = 20
+    obj_size = 5 * 1024
+    bucket_a = f"s28-uncomp-{random.randint(1, 9999)}"
+    bucket_b = f"s28-comp-{random.randint(1, 9999)}"
+
+    dedup_utils.disable_zone_compression(ssh_con)
+    try:
+        s3_client1.create_bucket(Bucket=bucket_a)
+        test_context["buckets"].append(bucket_a)
+        marker_a = dedup_utils.get_bucket_marker(bucket_a)
+        if marker_a:
+            test_context["bucket_markers"][bucket_a] = marker_a
+
+        keys_a, expected_md5, _ = dedup_utils.upload_identical_objects(
+            s3_client1, bucket_a, obj_count, obj_size, prefix="mode-obj"
+        )
+        dedup_utils.assert_all_objects_compression(
+            bucket_a, keys_a, expect_compressed=False, tag="PRE-DEDUP bucket_a"
+        )
+
+        dedup_utils.enable_zone_compression("zlib", ssh_con)
+
+        s3_client2.create_bucket(Bucket=bucket_b)
+        test_context["buckets"].append(bucket_b)
+        marker_b = dedup_utils.get_bucket_marker(bucket_b)
+        if marker_b:
+            test_context["bucket_markers"][bucket_b] = marker_b
+
+        keys_b, md5_b, _ = dedup_utils.upload_identical_objects(
+            s3_client2, bucket_b, obj_count, obj_size, prefix="mode-obj"
+        )
+        assert expected_md5 == md5_b, "MD5 mismatch between buckets"
+        dedup_utils.assert_all_objects_compression(
+            bucket_b, keys_b, expect_compressed=True, tag="PRE-DEDUP bucket_b"
+        )
+
+        dedup_utils.run_dedup_estimate()
+        estimate_stats = dedup_utils.wait_for_dedup_completion()
+        assert estimate_stats.get("completed") is True, "Estimate did not complete"
+
+        dedup_utils.run_dedup_execute()
+        exec_stats = dedup_utils.wait_for_dedup_completion()
+        assert exec_stats.get("completed") is True, "Exec did not complete"
+
+        parsed = dedup_utils.parse_dedup_stats_full(exec_stats)
+        assert (
+            parsed["deduped_count"] > 0
+        ), f"Cross-user dedup should process objects, got deduped_count={parsed['deduped_count']}"
+        assert (
+            parsed["compressed_objs"] > 0
+        ), f"Expected compressed_objs > 0, got {parsed['compressed_objs']}"
+        assert (
+            parsed["set_compression_on_tgt"] > 0
+        ), f"Expected set_compression_on_tgt > 0, got {parsed['set_compression_on_tgt']}"
+        log.info(
+            f"Cross-user dedup (uncomp->comp): deduped={parsed['deduped_count']}, "
+            f"compressed_objs={parsed['compressed_objs']}, "
+            f"set_compression_on_tgt={parsed['set_compression_on_tgt']}"
+        )
+
+        dedup_utils.assert_all_objects_compression(
+            bucket_a, keys_a, expect_compressed=True, tag="POST-DEDUP bucket_a"
+        )
+        dedup_utils.assert_all_objects_compression(
+            bucket_b, keys_b, expect_compressed=True, tag="POST-DEDUP bucket_b"
+        )
+
+        dedup_utils.verify_all_objects_accessible(s3_client1, bucket_a, keys_a)
+        dedup_utils.verify_all_objects_accessible(s3_client2, bucket_b, keys_b)
+        dedup_utils.verify_all_objects_integrity(
+            s3_client1, bucket_a, keys_a, expected_md5
+        )
+        dedup_utils.verify_all_objects_integrity(
+            s3_client2, bucket_b, keys_b, expected_md5
+        )
+        dedup_utils.log_dedup_savings(exec_stats, 2 * obj_count * obj_size, "S28")
+    finally:
+        dedup_utils.disable_zone_compression(ssh_con)
+        dedup_utils.cleanup_bucket(s3_client1, bucket_a)
+        dedup_utils.cleanup_bucket(s3_client2, bucket_b)
+
+
+# =============================================================================
+# BUG-HUNTING TESTS (B1-B7)
+# =============================================================================
+
+
+@pytest.mark.bug
+def test_b1_overwrite_deduped_object(s3_client, bucket, rgw_config):
+    """B1: Overwrite one deduped target, verify siblings survive."""
+    obj_count = getattr(rgw_config, "objects_count", None) or 10
+    obj_size = 5 * 1024
+
+    keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket, obj_count, obj_size, prefix="ow-obj"
+    )
+
+    dedup_utils.run_dedup_estimate()
+    estimate_stats = dedup_utils.wait_for_dedup_completion()
+    assert estimate_stats.get("completed") is True, "Estimate did not complete"
+
+    dedup_utils.run_dedup_execute()
+    exec_stats = dedup_utils.wait_for_dedup_completion()
+    assert exec_stats.get("completed") is True, "Exec did not complete"
+
+    dedup_utils.validate_estimate_exec_ratio(estimate_stats, exec_stats)
+    dedup_utils.verify_all_objects_integrity(s3_client, bucket, keys, expected_md5)
+    dedup_utils.log_dedup_savings(exec_stats, obj_count * obj_size, "B1")
+
+    overwrite_key = keys[1]
+    new_data = os.urandom(5 * 1024)
+    new_md5 = hashlib.md5(new_data).hexdigest()
+    s3_client.put_object(Bucket=bucket, Key=overwrite_key, Body=new_data)
+
+    resp = s3_client.get_object(Bucket=bucket, Key=overwrite_key)
+    body = resp["Body"].read()
+    assert hashlib.md5(body).hexdigest() == new_md5
+
+    remaining_keys = [k for k in keys if k != overwrite_key]
+    for key in remaining_keys:
+        resp = s3_client.get_object(Bucket=bucket, Key=key)
+        body = resp["Body"].read()
+        assert (
+            hashlib.md5(body).hexdigest() == expected_md5
+        ), f"Object {key} corrupted after overwrite of sibling"
+
+
+@pytest.mark.bug
+def test_b2_delete_dedup_source(s3_client, bucket, rgw_config):
+    """B2: Delete objects one by one, verify remaining survive each time."""
+    obj_count = getattr(rgw_config, "objects_count", None) or 10
+    keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket, obj_count, 5 * 1024, prefix="delsrc-obj"
+    )
+
+    dedup_utils.run_dedup_estimate()
+    estimate_stats = dedup_utils.wait_for_dedup_completion()
+    assert estimate_stats.get("completed") is True, "Estimate did not complete"
+
+    dedup_utils.run_dedup_execute()
+    exec_stats = dedup_utils.wait_for_dedup_completion()
+    assert exec_stats.get("completed") is True, "Exec did not complete"
+
+    dedup_utils.validate_estimate_exec_ratio(estimate_stats, exec_stats)
+    dedup_utils.verify_all_objects_integrity(s3_client, bucket, keys, expected_md5)
+    dedup_utils.log_dedup_savings(exec_stats, obj_count * 5 * 1024, "B2")
+
+    remaining = list(keys)
+    for key_to_delete in keys:
+        s3_client.delete_object(Bucket=bucket, Key=key_to_delete)
+        remaining.remove(key_to_delete)
+        if not remaining:
+            break
+        for key in remaining:
+            resp = s3_client.get_object(Bucket=bucket, Key=key)
+            body = resp["Body"].read()
+            assert (
+                hashlib.md5(body).hexdigest() == expected_md5
+            ), f"Object {key} corrupted after deleting {key_to_delete}"
+
+
+@pytest.mark.bug
+def test_b3_s3_copy_then_delete_deduped(s3_client, bucket_factory):
+    """B3: S3 COPY deduped object (same + cross bucket), delete originals."""
+    bucket_a = bucket_factory("dedup-copysrc")
+    bucket_b = bucket_factory("dedup-copydst")
+
+    obj_size = 5 * 1024
+    keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket_a, 5, obj_size, prefix="cpsrc-obj"
+    )
+
+    dedup_utils.run_dedup_estimate()
+    estimate_stats = dedup_utils.wait_for_dedup_completion()
+    assert estimate_stats.get("completed") is True, "Estimate did not complete"
+
+    dedup_utils.run_dedup_execute()
+    exec_stats = dedup_utils.wait_for_dedup_completion()
+    assert exec_stats.get("completed") is True, "Exec did not complete"
+
+    dedup_utils.validate_estimate_exec_ratio(estimate_stats, exec_stats)
+    dedup_utils.verify_all_objects_integrity(s3_client, bucket_a, keys, expected_md5)
+    dedup_utils.log_dedup_savings(exec_stats, 5 * obj_size, "B3")
+
+    s3_client.copy_object(
+        Bucket=bucket_a,
+        Key="copy-same",
+        CopySource={"Bucket": bucket_a, "Key": keys[0]},
+    )
+    s3_client.copy_object(
+        Bucket=bucket_b,
+        Key="copy-cross",
+        CopySource={"Bucket": bucket_a, "Key": keys[1]},
+    )
+
+    for key in keys:
+        s3_client.delete_object(Bucket=bucket_a, Key=key)
+
+    dedup_utils.verify_object_integrity(s3_client, bucket_a, "copy-same", expected_md5)
+    dedup_utils.verify_object_integrity(s3_client, bucket_b, "copy-cross", expected_md5)
+
+
+@pytest.mark.bug
+def test_b4_cross_bucket_source_delete(s3_client, bucket_factory):
+    """B4: Cross-bucket dedup, delete source bucket, verify target survives."""
+    bucket_a = bucket_factory("dedup-xbkt-a")
+    bucket_b = bucket_factory("dedup-xbkt-b")
+
+    obj_size = 5 * 1024
+    identical_data = dedup_utils.generate_identical_data(obj_size)
+    expected_md5 = hashlib.md5(identical_data).hexdigest()
+
+    s3_client.put_object(Bucket=bucket_a, Key="cross-obj-a", Body=identical_data)
+    s3_client.put_object(Bucket=bucket_b, Key="cross-obj-b", Body=identical_data)
+
+    dedup_utils.run_dedup_estimate()
+    estimate_stats = dedup_utils.wait_for_dedup_completion()
+    assert estimate_stats.get("completed") is True, "Estimate did not complete"
+
+    dedup_utils.run_dedup_execute()
+    exec_stats = dedup_utils.wait_for_dedup_completion()
+    assert exec_stats.get("completed") is True, "Exec did not complete"
+
+    dedup_utils.validate_estimate_exec_ratio(estimate_stats, exec_stats)
+
+    dedup_utils.verify_object_integrity(
+        s3_client, bucket_a, "cross-obj-a", expected_md5
+    )
+    dedup_utils.verify_object_integrity(
+        s3_client, bucket_b, "cross-obj-b", expected_md5
+    )
+    dedup_utils.log_dedup_savings(exec_stats, 2 * obj_size, "B4")
+
+    s3_client.delete_object(Bucket=bucket_a, Key="cross-obj-a")
+    s3_client.delete_bucket(Bucket=bucket_a)
+
+    dedup_utils.verify_object_integrity(
+        s3_client, bucket_b, "cross-obj-b", expected_md5
+    )
+
+
+@pytest.mark.bug
+def test_b5_dedup_idempotency(s3_client, bucket, rgw_config):
+    """B5: Run dedup exec 3 times, verify no corruption or double-counting."""
+    obj_count = getattr(rgw_config, "objects_count", None) or 20
+    keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket, obj_count, 5 * 1024, prefix="idemp-obj"
+    )
+
+    dedup_utils.run_dedup_estimate()
+    estimate_stats = dedup_utils.wait_for_dedup_completion()
+    assert estimate_stats.get("completed") is True, "Estimate did not complete"
+
+    all_run_stats = []
+    all_raw_stats = []
+    for run_num in range(1, 4):
+        dedup_utils.run_dedup_execute()
+        stats = dedup_utils.wait_for_dedup_completion()
+        assert stats.get("completed") is True, f"Exec run {run_num} did not complete"
+        all_raw_stats.append(stats)
+        parsed = dedup_utils.parse_dedup_stats(stats)
+        all_run_stats.append(parsed)
+        dedup_utils.verify_all_objects_accessible(s3_client, bucket, keys)
+
+    assert all_run_stats[0]["deduped_count"] > 0
+    dedup_utils.log_dedup_savings(all_raw_stats[0], obj_count * 5 * 1024, "B5")
+    for parsed in all_run_stats[1:]:
+        assert parsed["deduped_count"] == 0
+        assert parsed["skipped_shared_manifest"] > 0
+
+    dedup_utils.verify_all_objects_integrity(s3_client, bucket, keys, expected_md5)
+
+
+@pytest.mark.bug
+@pytest.mark.slow
+def test_b6_lc_expiration_deduped_large_objects(s3_client, bucket):
+    """B6: LC expiration must succeed on deduped >4MB objects (IBMCEPH-17201).
+
+    Polarion: CEPH-83632923
+
+    Dedup's setxattr modifies object mtime causing drift from bucket-index
+    mtime. LC's remove_expired_obj compares the two and fails with
+    ERR_PRECONDITION_FAILED (-2015) when they diverge. This test verifies
+    the fix allows LC to delete deduped objects normally.
+    """
+    obj_size = 5 * 1024 * 1024  # 5MB — triggers split-head dedup path
+    obj_count = 3
+
+    utils.exec_shell_cmd("ceph config set client.rgw rgw_lc_debug_interval 30")
+    time.sleep(3)
+
+    keys, expected_md5, _ = dedup_utils.upload_identical_multipart_objects(
+        s3_client, bucket, obj_count, obj_size, prefix="b6-lc-large"
+    )
+
+    dedup_utils.run_dedup_estimate()
+    estimate_stats = dedup_utils.wait_for_dedup_completion()
+    assert estimate_stats.get("completed") is True, "Estimate did not complete"
+
+    dedup_utils.run_dedup_execute()
+    exec_stats = dedup_utils.wait_for_dedup_completion()
+    assert exec_stats.get("completed") is True, "Exec did not complete"
+
+    dedup_utils.verify_all_objects_accessible(s3_client, bucket, keys)
+
+    dedup_utils.set_lifecycle_expiration(s3_client, bucket, days=1)
+    log.info("Waiting for LC to process deduped >4MB objects...")
+    time.sleep(120)
+
+    resp = s3_client.list_objects_v2(Bucket=bucket)
+    remaining = resp.get("KeyCount", 0)
+    log.info(f"Objects remaining after LC: {remaining}")
+    assert remaining == 0, (
+        f"LC failed to delete {remaining} deduped objects — "
+        f"possible ERR_PRECONDITION_FAILED (-2015) regression (IBMCEPH-17201)"
+    )
+
+
+@pytest.mark.bug
+def test_b7_s3_delete_deduped_large_objects(s3_client, bucket):
+    """B7: S3 DeleteObject must work on deduped >4MB objects (IBMCEPH-17201 workaround).
+
+    Polarion: CEPH-83632923
+
+    While LC failed on deduped objects due to mtime drift, S3 API DeleteObject
+    always worked. This test confirms the S3 delete path remains functional.
+    """
+    obj_size = 5 * 1024 * 1024
+    obj_count = 3
+
+    keys, expected_md5, _ = dedup_utils.upload_identical_multipart_objects(
+        s3_client, bucket, obj_count, obj_size, prefix="b7-del-large"
+    )
+
+    dedup_utils.run_dedup_estimate()
+    estimate_stats = dedup_utils.wait_for_dedup_completion()
+    assert estimate_stats.get("completed") is True, "Estimate did not complete"
+
+    dedup_utils.run_dedup_execute()
+    exec_stats = dedup_utils.wait_for_dedup_completion()
+    assert exec_stats.get("completed") is True, "Exec did not complete"
+
+    dedup_utils.verify_all_objects_accessible(s3_client, bucket, keys)
+
+    for key in keys:
+        s3_client.delete_object(Bucket=bucket, Key=key)
+        log.info(f"S3 DeleteObject succeeded for deduped large object: {key}")
+
+    resp = s3_client.list_objects_v2(Bucket=bucket)
+    remaining = resp.get("KeyCount", 0)
+    assert remaining == 0, f"S3 DeleteObject failed: {remaining} deduped objects remain"
+
+
+# =============================================================================
+# ENHANCEMENT TESTS (E1-E5) -- 128-limit boundary
+# =============================================================================
+
+
+@pytest.mark.enhancement
+def test_e1_128_limit_boundary(s3_client, bucket):
+    """E1: 200 identical 5KB objects, verify only ~127 deduped, rest skipped."""
+    obj_count = 200
+    obj_size = 5 * 1024
+
+    keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket, obj_count, obj_size, prefix="limit-obj"
+    )
+
+    dedup_utils.run_dedup_estimate()
+    estimate_stats = dedup_utils.wait_for_dedup_completion()
+    assert estimate_stats.get("completed") is True, "Estimate did not complete"
+
+    dedup_utils.run_dedup_execute()
+    exec_stats = dedup_utils.wait_for_dedup_completion()
+    assert exec_stats.get("completed") is True, "Exec did not complete"
+
+    dedup_utils.validate_estimate_exec_ratio(estimate_stats, exec_stats)
+    parsed = dedup_utils.parse_dedup_stats_full(exec_stats)
+
+    log.info(
+        f"Deduped: {parsed['deduped_count']}, "
+        f"Skipped Too Many Copies: {parsed['skipped_too_many_copies']}"
+    )
+
+    assert parsed["deduped_count"] > 0, "Expected some objects deduped"
+    assert (
+        parsed["deduped_count"] <= 128
+    ), f"Expected deduped <= 128 (128 limit), got {parsed['deduped_count']}"
+    assert (
+        parsed["skipped_too_many_copies"] > 0
+    ), f"Expected Skipped Too Many Copies > 0, got {parsed['skipped_too_many_copies']}"
+
+    dedup_utils.verify_all_objects_accessible(s3_client, bucket, keys)
+    dedup_utils.verify_all_objects_integrity(s3_client, bucket, keys, expected_md5)
+    dedup_utils.log_dedup_savings(exec_stats, obj_count * obj_size, "E1")
+
+
+@pytest.mark.enhancement
+def test_e2_versioned_boundary(s3_client, bucket):
+    """E2: 130 versions of same key (past 128 boundary), verify all accessible."""
+    version_count = 130
+    object_key = "versioned-boundary-obj"
+    obj_size = 5 * 1024
+
+    version_ids, expected_md5, _ = dedup_utils.upload_identical_versions(
+        s3_client, bucket, object_key, version_count, obj_size
+    )
+
+    dedup_utils.run_dedup_estimate()
+    estimate_stats = dedup_utils.wait_for_dedup_completion()
+    assert estimate_stats.get("completed") is True, "Estimate did not complete"
+
+    dedup_utils.run_dedup_execute()
+    exec_stats = dedup_utils.wait_for_dedup_completion()
+    assert exec_stats.get("completed") is True, "Exec did not complete"
+
+    dedup_utils.validate_estimate_exec_ratio(estimate_stats, exec_stats)
+    parsed = dedup_utils.parse_dedup_stats_full(exec_stats)
+
+    assert parsed["deduped_count"] > 0
+    assert parsed["unique_count"] >= 1
+
+    for vid in version_ids:
+        resp = s3_client.get_object(Bucket=bucket, Key=object_key, VersionId=vid)
+        body = resp["Body"].read()
+        assert (
+            hashlib.md5(body).hexdigest() == expected_md5
+        ), f"Version {vid} MD5 mismatch"
+
+    versions = dedup_utils.get_all_versions(s3_client, bucket, object_key)
+    assert len(versions) == version_count
+    dedup_utils.log_dedup_savings(exec_stats, version_count * obj_size, "E2")
+
+
+@pytest.mark.enhancement
+def test_e3_multi_cycle_no_progress(s3_client, bucket):
+    """E3: 200 objects, 3 exec cycles. Cycles 2-3 dedup zero -- system is stuck."""
+    obj_count = 200
+    obj_size = 5 * 1024
+
+    keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket, obj_count, obj_size, prefix="cycle-obj"
+    )
+
+    all_cycle_stats = []
+    first_raw_stats = None
+    for cycle in range(1, 4):
+        log.info(f"=== Dedup exec cycle {cycle}/3 ===")
+        dedup_utils.run_dedup_estimate()
+        est = dedup_utils.wait_for_dedup_completion()
+        assert est.get("completed") is True, f"Estimate cycle {cycle} did not complete"
+
+        dedup_utils.run_dedup_execute()
+        stats = dedup_utils.wait_for_dedup_completion()
+        assert stats.get("completed") is True, f"Exec cycle {cycle} did not complete"
+        if cycle == 1:
+            first_raw_stats = stats
+
+        dedup_utils.validate_estimate_exec_ratio(est, stats)
+        parsed = dedup_utils.parse_dedup_stats_full(stats)
+        all_cycle_stats.append(parsed)
+        log.info(
+            f"Cycle {cycle}: deduped={parsed['deduped_count']}, "
+            f"skipped_too_many={parsed['skipped_too_many_copies']}, "
+            f"skipped_shared_manifest={parsed['skipped_shared_manifest']}"
+        )
+
+    assert all_cycle_stats[0]["deduped_count"] > 0, "Cycle 1 should dedup objects"
+    assert all_cycle_stats[1]["deduped_count"] == 0, "Cycle 2 should dedup 0"
+    assert all_cycle_stats[2]["deduped_count"] == 0, "Cycle 3 should dedup 0"
+
+    assert (
+        all_cycle_stats[1]["skipped_too_many_copies"]
+        == all_cycle_stats[2]["skipped_too_many_copies"]
+    ), "Skipped Too Many Copies should be stable across cycles 2-3"
+
+    for parsed in all_cycle_stats[1:]:
+        assert parsed["skipped_shared_manifest"] >= all_cycle_stats[0]["deduped_count"]
+
+    dedup_utils.verify_all_objects_accessible(s3_client, bucket, keys)
+    dedup_utils.verify_all_objects_integrity(s3_client, bucket, keys, expected_md5)
+    dedup_utils.log_dedup_savings(first_raw_stats, obj_count * obj_size, "E3")
+
+
+@pytest.mark.enhancement
+def test_e4_split_head_small_objects(s3_client, bucket):
+    """E4: 50 identical 5KB objects, verify split-head mechanism used."""
+    obj_count = 50
+    obj_size = 5 * 1024
+
+    keys, expected_md5, original_data = dedup_utils.upload_identical_objects(
+        s3_client, bucket, obj_count, obj_size, prefix="splithead-obj"
+    )
+
+    dedup_utils.run_dedup_estimate()
+    estimate_stats = dedup_utils.wait_for_dedup_completion()
+    assert estimate_stats.get("completed") is True, "Estimate did not complete"
+
+    dedup_utils.run_dedup_execute()
+    exec_stats = dedup_utils.wait_for_dedup_completion()
+    assert exec_stats.get("completed") is True, "Exec did not complete"
+
+    dedup_utils.validate_estimate_exec_ratio(estimate_stats, exec_stats)
+    parsed = dedup_utils.parse_dedup_stats_full(exec_stats)
+
+    assert parsed["deduped_count"] > 0
+    assert (
+        parsed["split_head_src"] > 0
+    ), f"Expected Split-Head Src > 0, got {parsed['split_head_src']}"
+    assert (
+        parsed["split_head_tgt"] > 0
+    ), f"Expected Split-Head Tgt > 0, got {parsed['split_head_tgt']}"
+
+    dedup_utils.verify_all_objects_accessible(s3_client, bucket, keys)
+    dedup_utils.verify_all_objects_integrity(s3_client, bucket, keys, expected_md5)
+
+    for key in keys[:5]:
+        dedup_utils.verify_range_get(s3_client, bucket, key, original_data, 0, 1023)
+        dedup_utils.verify_range_get(
+            s3_client, bucket, key, original_data, 2048, obj_size - 1
+        )
+    dedup_utils.log_dedup_savings(exec_stats, obj_count * obj_size, "E4")
+
+
+@pytest.mark.enhancement
+def test_e5_stats_validation(s3_client, bucket):
+    """E5: Validate all expected stats fields present after estimate + exec."""
+    obj_count = 50
+    obj_size = 5 * 1024
+
+    keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket, obj_count, obj_size, prefix="stats-obj"
+    )
+
+    dedup_utils.run_dedup_estimate()
+    estimate_stats = dedup_utils.wait_for_dedup_completion()
+
+    assert isinstance(estimate_stats, dict)
+    assert estimate_stats.get("completed") is True, "Estimate did not complete"
+    est_parsed = dedup_utils.parse_dedup_stats_full(estimate_stats)
+    assert (
+        est_parsed["ingress_count"] > 0
+    ), f"Estimate ingress_count should be > 0, got {est_parsed['ingress_count']}"
+    assert est_parsed["unique_count"] >= 1
+    assert est_parsed["duplicate_count"] > 0
+    assert est_parsed["dedup_ratio_estimate"] > 1.0
+
+    dedup_utils.run_dedup_execute()
+    exec_stats = dedup_utils.wait_for_dedup_completion()
+
+    assert isinstance(exec_stats, dict)
+    assert exec_stats.get("completed") is True, "Exec did not complete"
+    exec_parsed = dedup_utils.parse_dedup_stats_full(exec_stats)
+    assert (
+        exec_parsed["total_processed"] == obj_count
+    ), f"Exec total_processed should be {obj_count}, got {exec_parsed['total_processed']}"
+    assert exec_parsed["deduped_count"] > 0
+    assert exec_parsed["unique_count"] >= 1
+    assert exec_parsed["dedup_ratio_actual"] > 1.0
+
+    dedup_utils.validate_estimate_exec_ratio(estimate_stats, exec_stats)
+
+    md5_skipped = exec_stats.get("md5_stats", {}).get("skipped", {})
+    for field in [
+        "Skipped shared_manifest",
+        "Skipped purged small objs",
+        "Skipped singleton objs",
+        "Skipped source record",
+    ]:
+        assert field in md5_skipped, f"Missing field: {field}"
+    dedup_utils.log_dedup_savings(exec_stats, obj_count * obj_size, "E5")
+
+
+# =============================================================================
+# RESTART SCENARIOS (R1-R5)
+# =============================================================================
+
+
+@pytest.mark.restart
+def test_r1_rgw_restart_mid_exec(s3_client, bucket, ssh_con):
+    """R1: RGW restart mid-exec — verify no data corruption."""
+    obj_count = 100
+    obj_size = 5 * 1024
+    keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket, obj_count, obj_size, prefix="r1"
+    )
+
+    dedup_utils.run_dedup_estimate()
+    dedup_utils.wait_for_dedup_completion()
+
+    dedup_utils.run_dedup_execute_async()
+    time.sleep(5)
+    dedup_utils.restart_rgw_service()
+    time.sleep(30)
+
+    # Re-run dedup exec to complete any interrupted work
+    dedup_utils.run_dedup_execute()
+    stats = dedup_utils.wait_for_dedup_completion()
+    assert stats.get("completed") is True
+
+    dedup_utils.verify_all_objects_accessible(s3_client, bucket, keys)
+    dedup_utils.verify_all_objects_integrity(s3_client, bucket, keys, expected_md5)
+    parsed = dedup_utils.parse_dedup_stats(stats)
+    assert (
+        parsed.get("deduped_count", 0) > 0
+        or parsed.get("skipped_shared_manifest", 0) > 0
+    )
+
+
+@pytest.mark.restart
+def test_r2_rgw_sigkill_mid_exec(s3_client, bucket, ssh_con):
+    """R2: SIGKILL RGW during split-head — verify no orphan tail objects."""
+    obj_count = 50
+    obj_size = 5 * 1024
+    keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket, obj_count, obj_size, prefix="r2"
+    )
+
+    dedup_utils.run_dedup_estimate()
+    dedup_utils.wait_for_dedup_completion()
+
+    dedup_utils.run_dedup_execute_async()
+    time.sleep(3)
+    dedup_utils.kill_rgw_process()
+    time.sleep(30)  # Wait for ceph orch to respawn
+
+    dedup_utils.run_dedup_execute()
+    stats = dedup_utils.wait_for_dedup_completion()
+    assert stats.get("completed") is True
+
+    dedup_utils.verify_all_objects_accessible(s3_client, bucket, keys)
+    orphans = dedup_utils.check_orphan_objects()
+    log.info(f"Orphan split-head objects found: {len(orphans)}")
+
+
+@pytest.mark.restart
+def test_r3_osd_restart_mid_exec(s3_client, bucket, ssh_con):
+    """R3: OSD restart during dedup exec — verify dedup completes."""
+    obj_count = 100
+    obj_size = 5 * 1024
+    keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket, obj_count, obj_size, prefix="r3"
+    )
+
+    dedup_utils.run_dedup_estimate()
+    dedup_utils.wait_for_dedup_completion()
+
+    dedup_utils.run_dedup_execute_async()
+    time.sleep(5)
+
+    osd_id = dedup_utils.get_osd_for_bucket(bucket)
+    dedup_utils.restart_osd(osd_id)
+    dedup_utils.wait_for_health_ok(timeout=120)
+
+    stats = dedup_utils.wait_for_dedup_completion(timeout=900)
+    if not stats.get("completed"):
+        dedup_utils.run_dedup_execute()
+        stats = dedup_utils.wait_for_dedup_completion(timeout=900)
+    assert stats.get("completed") is True
+
+    dedup_utils.verify_all_objects_accessible(s3_client, bucket, keys)
+    dedup_utils.verify_all_objects_integrity(s3_client, bucket, keys, expected_md5)
+
+
+@pytest.mark.restart
+def test_r4_mon_restart_mid_exec(s3_client, bucket, ssh_con):
+    """R4: MON leader restart during dedup — verify dedup completes."""
+    obj_count = 50
+    obj_size = 5 * 1024
+    keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket, obj_count, obj_size, prefix="r4"
+    )
+
+    dedup_utils.run_dedup_estimate()
+    dedup_utils.wait_for_dedup_completion()
+
+    dedup_utils.run_dedup_execute_async()
+    time.sleep(3)
+
+    leader = dedup_utils.get_mon_leader()
+    dedup_utils.restart_mon(leader)
+    time.sleep(15)
+
+    stats = dedup_utils.wait_for_dedup_completion(timeout=900)
+    if not stats.get("completed"):
+        dedup_utils.run_dedup_execute()
+        stats = dedup_utils.wait_for_dedup_completion(timeout=900)
+    assert stats.get("completed") is True
+
+    dedup_utils.verify_all_objects_accessible(s3_client, bucket, keys)
+
+
+@pytest.mark.restart
+def test_r5_rapid_rgw_restarts(s3_client, bucket, ssh_con):
+    """R5: 3 rapid RGW restarts in 30 seconds during exec."""
+    obj_count = 100
+    obj_size = 5 * 1024
+    keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket, obj_count, obj_size, prefix="r5"
+    )
+
+    dedup_utils.run_dedup_estimate()
+    dedup_utils.wait_for_dedup_completion()
+
+    dedup_utils.run_dedup_execute_async()
+    time.sleep(5)
+    dedup_utils.restart_rgw_service()
+    time.sleep(10)
+    dedup_utils.restart_rgw_service()
+    time.sleep(10)
+    dedup_utils.restart_rgw_service()
+    time.sleep(30)
+
+    dedup_utils.run_dedup_execute()
+    stats = dedup_utils.wait_for_dedup_completion()
+    assert stats.get("completed") is True
+
+    dedup_utils.verify_all_objects_accessible(s3_client, bucket, keys)
+    dedup_utils.verify_all_objects_integrity(s3_client, bucket, keys, expected_md5)
+
+
+# =============================================================================
+# CONCURRENT / RACE SCENARIOS (C1-C5)
+# =============================================================================
+
+
+@pytest.mark.concurrent
+def test_c1_exec_during_estimate(s3_client, bucket):
+    """C1: Fire exec while estimate is still running."""
+    obj_count = 200
+    obj_size = 5 * 1024
+    keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket, obj_count, obj_size, prefix="c1"
+    )
+
+    dedup_utils.run_dedup_estimate_async()
+    time.sleep(2)
+
+    # Try exec while estimate is running — should fail or be rejected
+    try:
+        out = dedup_utils.run_dedup_execute()
+        log.info(f"Exec during estimate returned: {out}")
+    except AssertionError:
+        log.info("Exec correctly rejected while estimate is running")
+
+    # Wait for estimate to finish, then run exec properly
+    dedup_utils.wait_for_dedup_completion()
+    dedup_utils.run_dedup_execute()
+    stats = dedup_utils.wait_for_dedup_completion()
+    assert stats.get("completed") is True
+
+    dedup_utils.verify_all_objects_accessible(s3_client, bucket, keys)
+
+
+@pytest.mark.concurrent
+def test_c2_delete_during_exec(s3_client, bucket):
+    """C2: Delete objects during dedup exec."""
+    obj_count = 100
+    obj_size = 5 * 1024
+    keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket, obj_count, obj_size, prefix="c2"
+    )
+
+    dedup_utils.run_dedup_estimate()
+    dedup_utils.wait_for_dedup_completion()
+
+    dedup_utils.run_dedup_execute_async()
+    time.sleep(1)
+
+    # Delete half the objects while exec is running
+    for key in keys[50:]:
+        try:
+            s3_client.delete_object(Bucket=bucket, Key=key)
+        except Exception as e:
+            log.warning(f"Delete {key} during exec: {e}")
+
+    stats = dedup_utils.wait_for_dedup_completion()
+    assert stats.get("completed") is True
+
+    # Surviving objects should be intact
+    surviving_keys = keys[:50]
+    dedup_utils.verify_all_objects_accessible(s3_client, bucket, surviving_keys)
+    dedup_utils.verify_all_objects_integrity(
+        s3_client, bucket, surviving_keys, expected_md5
+    )
+
+
+@pytest.mark.concurrent
+def test_c3_upload_during_exec(s3_client, bucket):
+    """C3: Upload new objects during dedup exec."""
+    obj_count = 50
+    obj_size = 5 * 1024
+    keys_a, md5_a, data_a = dedup_utils.upload_identical_objects(
+        s3_client, bucket, obj_count, obj_size, prefix="c3-a"
+    )
+
+    dedup_utils.run_dedup_estimate()
+    dedup_utils.wait_for_dedup_completion()
+
+    dedup_utils.run_dedup_execute_async()
+    time.sleep(1)
+
+    # Upload new objects with different content while exec runs
+    new_data = os.urandom(obj_size)
+    new_md5 = hashlib.md5(new_data).hexdigest()
+    keys_b = []
+    for i in range(50):
+        key = f"c3-b-{i}"
+        s3_client.put_object(Bucket=bucket, Key=key, Body=new_data)
+        keys_b.append(key)
+
+    stats = dedup_utils.wait_for_dedup_completion()
+    assert stats.get("completed") is True
+
+    # Both sets should be intact
+    dedup_utils.verify_all_objects_accessible(s3_client, bucket, keys_a)
+    dedup_utils.verify_all_objects_integrity(s3_client, bucket, keys_a, md5_a)
+    dedup_utils.verify_all_objects_accessible(s3_client, bucket, keys_b)
+    dedup_utils.verify_all_objects_integrity(s3_client, bucket, keys_b, new_md5)
+
+    # Re-run dedup to catch new objects
+    dedup_utils.run_dedup_execute()
+    stats2 = dedup_utils.wait_for_dedup_completion()
+    assert stats2.get("completed") is True
+    dedup_utils.verify_all_objects_accessible(s3_client, bucket, keys_a + keys_b)
+
+
+@pytest.mark.concurrent
+def test_c4_rapid_pause_resume(s3_client, bucket):
+    """C4: Rapid pause/resume 10 times during exec."""
+    obj_count = 100
+    obj_size = 5 * 1024
+    keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket, obj_count, obj_size, prefix="c4"
+    )
+
+    dedup_utils.run_dedup_estimate()
+    dedup_utils.wait_for_dedup_completion()
+
+    dedup_utils.run_dedup_execute_async()
+    time.sleep(2)
+
+    for i in range(10):
+        try:
+            dedup_utils.run_dedup_pause()
+            time.sleep(1)
+            dedup_utils.run_dedup_resume()
+            time.sleep(1)
+        except AssertionError as e:
+            log.warning(f"Pause/resume cycle {i}: {e}")
+
+    stats = dedup_utils.wait_for_dedup_completion(timeout=900)
+    assert stats.get("completed") is True
+
+    dedup_utils.verify_all_objects_accessible(s3_client, bucket, keys)
+    dedup_utils.verify_all_objects_integrity(s3_client, bucket, keys, expected_md5)
+    parsed = dedup_utils.parse_dedup_stats(stats)
+    assert parsed.get("deduped_count", 0) > 0
+
+
+@pytest.mark.concurrent
+def test_c5_double_abort(s3_client, bucket):
+    """C5: Double abort — second should be no-op, no crash."""
+    obj_count = 100
+    obj_size = 5 * 1024
+    keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket, obj_count, obj_size, prefix="c5"
+    )
+
+    dedup_utils.run_dedup_estimate()
+    dedup_utils.wait_for_dedup_completion()
+
+    dedup_utils.run_dedup_execute_async()
+    time.sleep(2)
+
+    dedup_utils.run_dedup_abort()
+    time.sleep(5)
+    dedup_utils.run_dedup_abort()  # Second abort should be no-op
+
+    # Verify RGW daemons are still running
+    running, total = dedup_utils.verify_rgw_daemons_running()
+    assert running == total, f"Some RGW daemons crashed: {running}/{total}"
+
+    dedup_utils.verify_all_objects_accessible(s3_client, bucket, keys)
+
+    # Fresh exec should work normally (dedup count may be 0 if first exec
+    # already finished before abort — the point is no crash on double abort)
+    dedup_utils.run_dedup_execute()
+    stats = dedup_utils.wait_for_dedup_completion()
+    assert stats.get("completed") is True
+
+
+# =============================================================================
+# DATA EDGE CASES (D1-D5)
+# =============================================================================
+
+
+@pytest.mark.edge_case
+def test_d1_empty_bucket(s3_client, bucket):
+    """D1: Dedup on empty bucket — all-zero counters, no errors."""
+    dedup_utils.run_dedup_estimate()
+    est_stats = dedup_utils.wait_for_dedup_completion()
+    assert est_stats.get("completed") is True
+
+    est_parsed = dedup_utils.parse_dedup_stats_full(est_stats)
+    assert est_parsed.get("ingress_count", 0) == 0
+
+    dedup_utils.run_dedup_execute()
+    exec_stats = dedup_utils.wait_for_dedup_completion()
+    assert exec_stats.get("completed") is True
+
+    exec_parsed = dedup_utils.parse_dedup_stats(exec_stats)
+    assert exec_parsed.get("deduped_count", 0) == 0
+
+
+@pytest.mark.edge_case
+def test_d3_min_size_boundary(s3_client, bucket):
+    """D3: Objects at exactly min_obj_size boundary."""
+    boundary_size = 5120  # Exactly 5KB = 4096 min + margin
+    below_size = 4095  # 1 byte below min_obj_size_for_dedup (4096)
+
+    # Upload objects at the boundary
+    keys_at, md5_at, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket, 20, boundary_size, prefix="d3-at"
+    )
+    # Upload objects below the boundary
+    below_data = os.urandom(below_size)
+    keys_below = []
+    for i in range(20):
+        key = f"d3-below-{i}"
+        s3_client.put_object(Bucket=bucket, Key=key, Body=below_data)
+        keys_below.append(key)
+
+    dedup_utils.run_dedup_estimate()
+    dedup_utils.wait_for_dedup_completion()
+    dedup_utils.run_dedup_execute()
+    exec_stats = dedup_utils.wait_for_dedup_completion()
+    assert exec_stats.get("completed") is True
+
+    # At-boundary objects should be deduped, below should be skipped
+    parsed = dedup_utils.parse_dedup_stats(exec_stats)
+    assert parsed.get("deduped_count", 0) > 0
+    dedup_utils.verify_all_objects_accessible(s3_client, bucket, keys_at + keys_below)
+
+
+@pytest.mark.edge_case
+def test_d4_single_object(s3_client, bucket):
+    """D4: Single object — nothing to dedup with."""
+    obj_size = 5 * 1024
+    keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket, 1, obj_size, prefix="d4"
+    )
+
+    dedup_utils.run_dedup_estimate()
+    est_stats = dedup_utils.wait_for_dedup_completion()
+    assert est_stats.get("completed") is True
+
+    est_parsed = dedup_utils.parse_dedup_stats_full(est_stats)
+    assert est_parsed.get("ingress_count", 0) == 1
+
+    dedup_utils.run_dedup_execute()
+    exec_stats = dedup_utils.wait_for_dedup_completion()
+    assert exec_stats.get("completed") is True
+
+    exec_parsed = dedup_utils.parse_dedup_stats(exec_stats)
+    assert exec_parsed.get("deduped_count", 0) == 0
+
+    dedup_utils.verify_all_objects_integrity(s3_client, bucket, keys, expected_md5)
+
+
+@pytest.mark.edge_case
+@pytest.mark.slow
+def test_d5_max_versions_500(s3_client, bucket):
+    """D5: 500 versions of same key — far past 128 limit."""
+    obj_size = 5 * 1024
+    key = "d5-versioned-key"
+    version_ids, expected_md5, data = dedup_utils.upload_identical_versions(
+        s3_client, bucket, key, 500, obj_size
+    )
+
+    dedup_utils.run_dedup_estimate()
+    dedup_utils.wait_for_dedup_completion()
+    dedup_utils.run_dedup_execute()
+    exec_stats = dedup_utils.wait_for_dedup_completion(timeout=900)
+    assert exec_stats.get("completed") is True
+
+    parsed = dedup_utils.parse_dedup_stats(exec_stats)
+    assert (
+        parsed.get("deduped_count", 0) <= 128
+    ), "Deduped count should not exceed 128 (128 limit)"
+
+    # Verify all 500 versions accessible
+    for vid in version_ids:
+        resp = s3_client.get_object(Bucket=bucket, Key=key, VersionId=vid)
+        body = resp["Body"].read()
+        actual_md5 = hashlib.md5(body).hexdigest()
+        assert actual_md5 == expected_md5, f"Version {vid} MD5 mismatch"
+
+    # Idempotency: second run should dedup 0
+    dedup_utils.run_dedup_execute()
+    stats2 = dedup_utils.wait_for_dedup_completion()
+    parsed2 = dedup_utils.parse_dedup_stats(stats2)
+    assert parsed2.get("deduped_count", 0) == 0, "Second run should dedup nothing"
+
+
+# =============================================================================
+# INFRASTRUCTURE FAILURE SCENARIOS (F1-F5)
+# =============================================================================
+
+
+@pytest.mark.infra
+def test_f1_pool_near_full(s3_client, bucket, ssh_con):
+    """F1: Pool quota to simulate near-full during dedup."""
+    obj_count = 50
+    obj_size = 5 * 1024
+    pool = "default.rgw.buckets.data"
+    keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket, obj_count, obj_size, prefix="f1"
+    )
+
+    # Set a very tight pool quota
+    dedup_utils.set_pool_quota(pool, 1024 * 1024)  # 1MB quota
+
+    try:
+        dedup_utils.run_dedup_estimate()
+        dedup_utils.wait_for_dedup_completion()
+        dedup_utils.run_dedup_execute()
+        stats = dedup_utils.wait_for_dedup_completion()
+        # Dedup may fail or partially succeed under quota
+        log.info(f"Dedup under quota completed={stats.get('completed')}")
+    except AssertionError as e:
+        log.info(f"Dedup under pool quota failed as expected: {e}")
+    finally:
+        dedup_utils.remove_pool_quota(pool)
+
+    # After removing quota, objects should be intact
+    dedup_utils.verify_all_objects_accessible(s3_client, bucket, keys)
+
+    # Re-run dedup without quota
+    dedup_utils.run_dedup_execute()
+    stats = dedup_utils.wait_for_dedup_completion()
+    assert stats.get("completed") is True
+    dedup_utils.verify_all_objects_integrity(s3_client, bucket, keys, expected_md5)
+
+
+@pytest.mark.infra
+def test_f2_reshard_during_exec(s3_client, bucket):
+    """F2: Bucket reshard during dedup exec."""
+    obj_count = 100
+    obj_size = 5 * 1024
+    keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket, obj_count, obj_size, prefix="f2"
+    )
+
+    dedup_utils.run_dedup_estimate()
+    dedup_utils.wait_for_dedup_completion()
+
+    dedup_utils.run_dedup_execute_async()
+    time.sleep(2)
+
+    # Trigger reshard while exec is running
+    try:
+        dedup_utils.trigger_bucket_reshard(bucket, 8)
+    except Exception as e:
+        log.info(f"Reshard during exec: {e}")
+
+    stats = dedup_utils.wait_for_dedup_completion(timeout=900)
+    log.info(f"Dedup after reshard completed={stats.get('completed')}")
+
+    dedup_utils.verify_all_objects_accessible(s3_client, bucket, keys)
+
+    # Re-run after reshard settles
+    if not stats.get("completed"):
+        dedup_utils.run_dedup_execute()
+        stats = dedup_utils.wait_for_dedup_completion()
+    assert stats.get("completed") is True
+    dedup_utils.verify_all_objects_integrity(s3_client, bucket, keys, expected_md5)
+
+
+@pytest.mark.infra
+def test_f3_network_partition(s3_client, bucket, ssh_con):
+    """F3: Block MON traffic on one node during dedup."""
+    obj_count = 100
+    obj_size = 5 * 1024
+    keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket, obj_count, obj_size, prefix="f3"
+    )
+
+    dedup_utils.run_dedup_estimate()
+    dedup_utils.wait_for_dedup_completion()
+
+    dedup_utils.run_dedup_execute_async()
+    time.sleep(3)
+
+    # Block MON traffic briefly (port 6789)
+    utils.exec_shell_cmd("iptables -A INPUT -p tcp --dport 6789 -j DROP")
+    time.sleep(30)
+    utils.exec_shell_cmd("iptables -D INPUT -p tcp --dport 6789 -j DROP")
+
+    stats = dedup_utils.wait_for_dedup_completion(timeout=900)
+    if not stats.get("completed"):
+        dedup_utils.run_dedup_execute()
+        stats = dedup_utils.wait_for_dedup_completion(timeout=900)
+    assert stats.get("completed") is True
+
+    dedup_utils.verify_all_objects_accessible(s3_client, bucket, keys)
+
+
+@pytest.mark.infra
+def test_f4_corrupt_rados_object(s3_client, bucket):
+    """F4: Corrupt a RADOS object, verify dedup detects hash mismatch."""
+    obj_count = 50
+    obj_size = 5 * 1024
+    pool = "default.rgw.buckets.data"
+    keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket, obj_count, obj_size, prefix="f4"
+    )
+
+    marker = dedup_utils.get_bucket_marker(bucket)
+    rados_objects = dedup_utils.get_rados_objects(pool, prefix=marker)
+
+    if rados_objects:
+        # Corrupt one RADOS object
+        target_oid = rados_objects[0]
+        dedup_utils.corrupt_rados_object(pool, target_oid)
+        log.info(f"Corrupted RADOS object: {target_oid}")
+
+    dedup_utils.run_dedup_estimate()
+    dedup_utils.wait_for_dedup_completion()
+    dedup_utils.run_dedup_execute()
+    exec_stats = dedup_utils.wait_for_dedup_completion()
+    assert exec_stats.get("completed") is True
+
+    # Non-corrupted objects should still be accessible
+    accessible_count = 0
+    for key in keys:
+        try:
+            s3_client.head_object(Bucket=bucket, Key=key)
+            accessible_count += 1
+        except Exception:
+            pass
+    log.info(f"Accessible objects after corruption: {accessible_count}/{len(keys)}")
+    assert accessible_count >= len(keys) - 1  # At most 1 corrupted
+
+
+@pytest.mark.infra
+def test_f5_time_jump(s3_client, bucket, ssh_con):
+    """F5: Jump system clock forward during dedup."""
+    obj_count = 50
+    obj_size = 5 * 1024
+    keys, expected_md5, _ = dedup_utils.upload_identical_objects(
+        s3_client, bucket, obj_count, obj_size, prefix="f5"
+    )
+
+    dedup_utils.run_dedup_estimate()
+    dedup_utils.wait_for_dedup_completion()
+
+    dedup_utils.run_dedup_execute_async()
+    time.sleep(2)
+
+    # Jump clock forward 1 hour
+    utils.exec_shell_cmd("date -s '+1 hour'")
+    time.sleep(5)
+
+    stats = dedup_utils.wait_for_dedup_completion(timeout=900)
+
+    # Restore clock — reverse the jump first, then let chrony fine-tune
+    utils.exec_shell_cmd("date -s '-1 hour'")
+    utils.exec_shell_cmd("chronyc makestep")
+    time.sleep(10)
+
+    if not stats.get("completed"):
+        dedup_utils.run_dedup_execute()
+        stats = dedup_utils.wait_for_dedup_completion()
+    assert stats.get("completed") is True
+
+    dedup_utils.verify_all_objects_accessible(s3_client, bucket, keys)
+    dedup_utils.verify_all_objects_integrity(s3_client, bucket, keys, expected_md5)


### PR DESCRIPTION
Complete dedup test automation covering sanity, feature, compression, bug regression, enhancement, restart, concurrent, edge-case, and infrastructure failure scenarios. Includes IBMCEPH-17201 LC regression tests for deduped >4MB objects.

Files added/modified:
  - test_dedup_pytest.py      : 58 pytest tests (main suite)
  - test_dedup_scale_pytest.py: 8 scale/perf tests (separate suite)
  - test_dedup.py             : Non-pytest dedup test module
  - conftest.py               : Pytest fixtures (s3_client, bucket, etc.)
  - reusables/dedup.py        : Shared helpers (upload, dedup, verify)
  - run_dedup_pytest.py       : cephci-to-pytest wrapper
  - pytest.ini                : Marker definitions and logging config
  - upload_dedup_1b_v1.py     : 1B object upload script for scale testing
  - configs/test_dedup_*.yaml : 49 per-test YAML configs
  
all passed logs  http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-AV5T5S