### PR TITLE
[TFA] update know issue for zonegroup level policy not being synced in 9.2 and above

### DIFF
--- a/rgw/v2/tests/aws/test_aws_s3_replication.py
+++ b/rgw/v2/tests/aws/test_aws_s3_replication.py
@@ -140,6 +140,10 @@ def test_exec(config, ssh_con):
                     source_zones=zonegroup_source_pipe,
                     dest_zones=zonegroup_dest_pipe,
                 )
+            if not reusable.verify_zonegroup_sync_group(
+                rgw_ssh_con, group_id, user_info, group_status
+            ):
+                return
 
     if config.test_ops.get("create_bucket", False):
         for each_user in user_info:

--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -2652,6 +2652,81 @@ def get_sync_policy(bucket_name=None):
     return sync_policy_resp
 
 
+def verify_zonegroup_sync_group(ssh_con, group_id, users, group_status="enabled"):
+    """
+    Verify zonegroup sync group on both sites. On failure, remove policy and users.
+
+    :param ssh_con: SSH connection to the secondary site
+    :param group_id: sync group id, or list of group ids
+    :param users: user info list to remove on failure
+    :param group_status: status passed to sync group remove
+    :return: True to continue, False if IBMCEPH-17548 on >= 20.2.2 (exit test as pass)
+    """
+    group_ids = group_id if isinstance(group_id, list) else [group_id]
+
+    def _group_id_matches(group_info, gid):
+        if not isinstance(group_info, dict):
+            return False
+        if group_info.get("id") == gid:
+            return True
+        return any(group.get("id") == gid for group in group_info.get("groups", []))
+
+    try:
+        for gid in group_ids:
+            cmd = f"radosgw-admin sync group get --group-id={gid}"
+            log.info(f"Verify sync group get on primary for group {gid}")
+            primary_out = utils.exec_shell_cmd(cmd)
+            if primary_out is False:
+                raise TestExecError(f"sync group get failed on primary for {gid}")
+            try:
+                primary_group = json.loads(primary_out)
+            except Exception:
+                raise TestExecError(
+                    f"invalid json from sync group get on primary for {gid}"
+                )
+            log.info(f"sync group get from primary: {primary_group}")
+            if not _group_id_matches(primary_group, gid):
+                raise TestExecError(f"sync group {gid} not found on primary")
+            log.info(f"sync group {gid} verified on primary")
+
+            log.info(f"Verify sync group get on secondary site for group {gid}")
+            group_found = False
+            other_site_group = None
+            for retry_count in range(21):
+                _, stdout, stderr = ssh_con.exec_command(cmd)
+                sync_group_out = stdout.read().decode()
+                sync_group_error = stderr.read().decode()
+                try:
+                    other_site_group = json.loads(sync_group_out)
+                except Exception:
+                    other_site_group = None
+                if _group_id_matches(other_site_group, gid):
+                    log.info(f"sync group get from secondary: {other_site_group}")
+                    group_found = True
+                    break
+                if retry_count == 20:
+                    break
+                log.info(
+                    f"sync group {gid} not on secondary, retry {retry_count}: {sync_group_error.strip()}"
+                )
+                time.sleep(60)
+            if not group_found:
+                raise TestExecError(f"sync group get failed on secondary for {gid}")
+            log.info(f"sync group {gid} verified on both sites")
+        return True
+    except TestExecError as e:
+        for gid in group_ids:
+            group_operation(gid, "remove", group_status)
+        utils.exec_shell_cmd("radosgw-admin period update --commit")
+        for user in users:
+            remove_user(user)
+        if utils.is_known_issue_version("20.2.2", "IBMCEPH-17548", op=">="):
+            return False
+        raise TestExecError(
+            f"sync group get failed for {group_ids[0]} on both sites: {e}"
+        )
+
+
 def verify_bucket_sync_on_other_site(rgw_ssh_con, bucket):
     log.info(f"verify Bucket {bucket.name} exist on another site")
     _, stdout, _ = rgw_ssh_con.exec_command("radosgw-admin bucket list")

--- a/rgw/v2/tests/s3_swift/test_multisite_bucket_granular_sync_policy.py
+++ b/rgw/v2/tests/s3_swift/test_multisite_bucket_granular_sync_policy.py
@@ -168,6 +168,10 @@ def test_exec(config, ssh_con):
                     source_zones=zonegroup_source_pipe,
                     dest_zones=zonegroup_dest_pipe,
                 )
+            if not reusable.verify_zonegroup_sync_group(
+                rgw_ssh_con, group_id, all_users_info, group_status
+            ):
+                return
 
     if config.test_ops.get("create_bucket", False):
         for each_user in all_users_info:

--- a/rgw/v2/tests/s3_swift/test_multisite_sync_policy.py
+++ b/rgw/v2/tests/s3_swift/test_multisite_sync_policy.py
@@ -123,6 +123,13 @@ def test_exec(config, ssh_con):
                         group_id2 = "new_group"
                         reusable.group_operation(group_id2, "create", group_status)
                         pipe2 = reusable.pipe_operation(group_id2, "create", zone_names)
+                    group_ids = [group_id]
+                    if config.test_ops.get("group_transition", False):
+                        group_ids.append(group_id2)
+                    if not reusable.verify_zonegroup_sync_group(
+                        rgw_ssh_con, group_ids, all_users_info, group_status
+                    ):
+                        return
 
     if config.test_ops.get("create_bucket", False):
         for each_user in all_users_info:

--- a/rgw/v2/tests/s3_swift/test_multisite_syncpolicy_prefix_tag.py
+++ b/rgw/v2/tests/s3_swift/test_multisite_syncpolicy_prefix_tag.py
@@ -64,6 +64,9 @@ def test_exec(config, ssh_con):
             break
     rgw_ssh_con = utils.connect_remote(node_rgw)
 
+    if not reusable.verify_zonegroup_sync_group(rgw_ssh_con, group_id, user_info):
+        return
+
     prefix = "foo"
     tag = "colour=red"
 

--- a/rgw/v2/utils/utils.py
+++ b/rgw/v2/utils/utils.py
@@ -868,6 +868,68 @@ def get_ceph_version():
     return version_id, version_name
 
 
+def _ceph_version_tuple(version_str):
+    """Parse '20.2.2-123.el9cp' or '19.1.3' into (20, 2, 2)."""
+    parts = []
+    for part in str(version_str).split("-")[0].split("."):
+        try:
+            parts.append(int(part))
+        except ValueError:
+            break
+    while len(parts) < 3:
+        parts.append(0)
+    return tuple(parts[:3])
+
+
+def check_ceph_version():
+    """
+    Return running ceph version as (X, Y, Z), ignoring -build suffix.
+
+    Example: '20.2.2-123.el9cp' -> (20, 2, 2)
+    """
+    try:
+        ceph_version_id, _ = get_ceph_version()
+    except Exception:
+        log.info("could not get ceph version")
+        return None
+    log.info(f"ceph version: {ceph_version_id}")
+    if not ceph_version_id:
+        return None
+    current = _ceph_version_tuple(ceph_version_id)
+    log.info(f"parsed ceph version: {current}")
+    return current
+
+
+def is_known_issue_version(expected_version, issue_id=None, op="=="):
+    """
+    Check current ceph version against a known-issue release using op.
+
+    :param expected_version: X.Y.Z to compare against, e.g. "20.2.2" or "19.1.3"
+    :param issue_id: optional tracker id to log when matched
+    :param op: "==", "!=", ">", ">=", "<", "<="
+    :return: True if comparison holds (treat as known issue), else False
+    """
+    current = check_ceph_version()
+    if not current:
+        return False
+    expected = _ceph_version_tuple(expected_version)
+    ops = {
+        "==": current == expected,
+        "!=": current != expected,
+        ">": current > expected,
+        ">=": current >= expected,
+        "<": current < expected,
+        "<=": current <= expected,
+    }
+    if op not in ops:
+        raise TestExecError(f"unsupported version op: {op}")
+    matched = ops[op]
+    log.info(f"version check {current} {op} {expected}: {matched}")
+    if matched and issue_id:
+        log.info(f"Known issue {issue_id}: ceph {op} {expected_version}")
+    return matched
+
+
 def get_ceph_status():
     """
     get the ceph cluster status and health


### PR DESCRIPTION
pass log : https://10.8.128.2/cephci-jenkins/ibm-cos//IBM/9.2/rhel-10/executor/20.2.2-220/rgw/2600/logs/tier_2_rgw_io_ms_spec_to_disable_sync/modify_bucket_granular_sync_policy_which_has_user_mode_set_0.log
https://10.8.128.2/cephci-jenkins/ibm-cos/IBM/9.2/rhel-10/executor/20.2.2-220/rgw/2605/logs/tier_2_rgw_ms_granular_sync_policy/Bucket_Granular_Sync_policy_test_for_prefix_and_tag_0.log
[[BZ#2342570] [Ceph-Dashboard] Export Multi-site Realm Token in non-master zone does not show token details](https://ibm-ceph.atlassian.net/browse/IBMCEPH-10516)