### PR TITLE
[Customer-issue]: Support bucket rm from non master zone

### DIFF
--- a/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_rm_non_master.yaml
+++ b/rgw/v2/tests/s3_swift/multisite_configs/test_bucket_rm_non_master.yaml
@@ -1,0 +1,22 @@
+# script: test_Mbuckets_with_Nobjects.py
+# Force-delete a non-empty bucket from the secondary (non-master) zone.
+# Expectation: radosgw-admin bucket rm --purge-objects succeeds on secondary.
+config:
+  user_count: 1
+  bucket_count: 1
+  objects_count: 10
+  objects_size_range:
+    min: 5
+    max: 15
+  test_ops:
+    create_bucket: true
+    create_object: true
+    download_object: false
+    delete_bucket_object: false
+    force_delete_from_secondary: true
+    sharding:
+      enable: false
+      max_shards: 0
+    compression:
+      enable: false
+      type: zlib

--- a/rgw/v2/tests/s3_swift/reusable.py
+++ b/rgw/v2/tests/s3_swift/reusable.py
@@ -303,6 +303,105 @@ def get_remote_conn_in_multisite():
     return remote_site_ssh_con
 
 
+def exec_on_secondary(cmd):
+    """
+    Run a shell command on the secondary (non-master) zone.
+
+    Returns (returncode, stdout, stderr).
+    """
+    is_primary = utils.is_cluster_primary()
+    if is_primary:
+        secondary_ip = utils.get_rgw_ip(master_zone=False)
+        if not secondary_ip:
+            raise TestExecError("Could not resolve secondary zone RGW IP")
+        log.info(f"Executing on secondary zone ({secondary_ip}): {cmd}")
+        ssh_con = utils.connect_remote(secondary_ip)
+        _, stdout, stderr = ssh_con.exec_command(cmd)
+        out = stdout.read().decode()
+        err = stderr.read().decode()
+        rc = stdout.channel.recv_exit_status()
+        ssh_con.close()
+        return rc, out, err
+
+    log.info(f"Local site is secondary, executing locally: {cmd}")
+    pr = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        shell=True,
+        universal_newlines=True,
+    )
+    out, err = pr.communicate()
+    return pr.returncode, out, err
+
+
+def wait_for_bucket_on_secondary(bucket_name, expected_objects, retries=20, delay=30):
+    """Wait until the bucket exists on secondary with the expected object count."""
+    last_err = ""
+    for attempt in range(1, retries + 1):
+        rc, out, err = exec_on_secondary(
+            f"radosgw-admin bucket stats --bucket {bucket_name}"
+        )
+        last_err = err or out
+        if rc == 0 and out.strip():
+            stats = json.loads(out)
+            num_objects = (
+                stats.get("usage", {}).get("rgw.main", {}).get("num_objects", 0)
+            )
+            log.info(
+                f"Secondary bucket stats for {bucket_name} "
+                f"(attempt {attempt}/{retries}): num_objects={num_objects}"
+            )
+            if num_objects >= expected_objects:
+                return stats
+        else:
+            log.info(
+                f"Bucket {bucket_name} not yet available on secondary "
+                f"(attempt {attempt}/{retries}): rc={rc}, err={err}"
+            )
+        time.sleep(delay)
+    raise TestExecError(
+        f"Bucket {bucket_name} did not sync to secondary with "
+        f"{expected_objects} objects. Last error: {last_err}"
+    )
+
+
+def force_delete_bucket_from_secondary(bucket_name, expected_objects=0):
+    """
+    Force delete a bucket from the secondary zone with --purge-objects.
+    Expectation: the command succeeds and the bucket is gone from secondary.
+    """
+    wait_for_bucket_on_secondary(bucket_name, expected_objects)
+    force_rm_cmd = f"radosgw-admin bucket rm --bucket={bucket_name} --purge-objects"
+    log.info(
+        f"Attempting force delete of bucket {bucket_name} from secondary: {force_rm_cmd}"
+    )
+    rc, out, err = exec_on_secondary(force_rm_cmd)
+    log.info(f"Force delete from secondary: rc={rc} stdout={out} stderr={err}")
+    if rc != 0:
+        raise TestExecError(
+            f"Force delete of bucket {bucket_name} from secondary with "
+            f"--purge-objects failed. stdout={out} stderr={err}"
+        )
+    log.info(
+        f"Force delete of bucket {bucket_name} from secondary "
+        "with --purge-objects succeeded"
+    )
+    stats_rc, stats_out, stats_err = exec_on_secondary(
+        f"radosgw-admin bucket stats --bucket {bucket_name}"
+    )
+    log.info(
+        f"Secondary bucket stats after force delete: rc={stats_rc} "
+        f"stdout={stats_out} stderr={stats_err}"
+    )
+    if stats_rc == 0:
+        raise TestExecError(
+            f"Bucket {bucket_name} still exists on secondary after "
+            "force delete with --purge-objects succeeded"
+        )
+    log.info(f"Bucket {bucket_name} removed from secondary as expected")
+
+
 def create_bucket_readonly(bucket_name, rgw, user_info):
     log.info("creating bucket with name: %s" % bucket_name)
     bucket = s3lib.resource_op(

--- a/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
+++ b/rgw/v2/tests/s3_swift/test_Mbuckets_with_Nobjects.py
@@ -25,6 +25,7 @@ Usage: test_Mbuckets_with_Nobjects.py -c <input_yaml>
     test_Mbuckets_with_Nobjects_get_object_attributes_multipart.yaml
     test_Mbuckets_with_Nobjects_multipart_upload_complete_abort_race.yaml
     test_Mbuckets_with_Nobjects_unicode_bi_list.yaml
+    test_bucket_rm_non_master.yaml
 
 Operation:
         Creates M bucket and N objects
@@ -40,6 +41,7 @@ Operation:
         Verify bi put on incomplete multipart upload
     Verify bucket instance shards are deleted from index pool post bucket delete
     Verify bucket index listing with unicode characters does not cause backwards iteration
+    Force delete a non-empty bucket from secondary zone with --purge-objects
 """
 
 # test basic creation of buckets with objects
@@ -857,6 +859,18 @@ def test_exec(config, ssh_con):
                     if config.test_ops["compression"]["enable"] is True:
                         cmd = "radosgw-admin bucket stats --bucket=%s" % bucket.name
                         out = utils.exec_shell_cmd(cmd)
+                    if config.test_ops.get("force_delete_from_secondary"):
+                        log.info(
+                            "Force delete bucket from secondary zone with --purge-objects"
+                        )
+                        if not utils.is_cluster_multisite():
+                            raise TestExecError(
+                                "force_delete_from_secondary requires a multisite environment"
+                            )
+                        reusable.check_sync_status()
+                        reusable.force_delete_bucket_from_secondary(
+                            bucket.name, expected_objects=config.objects_count
+                        )
                     if config.test_ops["delete_bucket_object"] is True:
                         reusable.delete_objects(bucket)
                         if config.bucket_sync_run_with_disable_sync_thread is False:


### PR DESCRIPTION
[Customer-issue]: Support bucket rm from non master zone

* Adding coverage for force-deleting a non-empty bucket from the secondary (non-master) zone in a multisite setup.
* After bucket create and object upload, wait for sync, then run radosgw-admin bucket rm --bucket=<name> --purge-objects on secondary.
* Expect the command to succeed and the bucket to be gone from secondary.


Pass log: http://magna002.ceph.redhat.com/ceph-qe-logs/Bucket_rm_log/test_bucket_rm_non_master.console.log

Pass logs for existing configs:
http://magna002.ceph.redhat.com/ceph-qe-logs/Bucket_rm_log/test_Mbuckets_with_Nobjects_delete.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/Bucket_rm_log/test_Mbuckets_with_Nobjects_enc.console.log

